### PR TITLE
feat: add infrastructure cost dashboard (#5)

### DIFF
--- a/src/app/api/costs/route.ts
+++ b/src/app/api/costs/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { apiUsage } from "@/lib/db/schema";
+import { sql, eq, sum, count } from "drizzle-orm";
+
+// Pricing estimates (per token, USD)
+const GEMINI_FLASH_INPUT_PER_TOKEN = 0.00000015; // $0.15 per 1M input tokens
+const GEMINI_FLASH_OUTPUT_PER_TOKEN = 0.0000006; // $0.60 per 1M output tokens
+// Google Maps Distance Matrix: $5 per 1000 elements, 2 elements per call (bike + transit)
+const MAPS_COST_PER_CALL = (5 / 1000) * 2;
+
+export async function GET() {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  // All-time stats
+  const [geminiAllTime] = await db
+    .select({
+      totalCalls: count(),
+      totalInputTokens: sum(apiUsage.inputTokens),
+      totalOutputTokens: sum(apiUsage.outputTokens),
+    })
+    .from(apiUsage)
+    .where(eq(apiUsage.service, "gemini"));
+
+  const [mapsAllTime] = await db
+    .select({ totalCalls: count() })
+    .from(apiUsage)
+    .where(eq(apiUsage.service, "google_maps"));
+
+  // Last 30 days stats
+  const [gemini30d] = await db
+    .select({
+      totalCalls: count(),
+      totalInputTokens: sum(apiUsage.inputTokens),
+      totalOutputTokens: sum(apiUsage.outputTokens),
+    })
+    .from(apiUsage)
+    .where(
+      sql`${apiUsage.service} = 'gemini' AND ${apiUsage.createdAt} >= ${Math.floor(thirtyDaysAgo.getTime() / 1000)}`
+    );
+
+  const [maps30d] = await db
+    .select({ totalCalls: count() })
+    .from(apiUsage)
+    .where(
+      sql`${apiUsage.service} = 'google_maps' AND ${apiUsage.createdAt} >= ${Math.floor(thirtyDaysAgo.getTime() / 1000)}`
+    );
+
+  // Calculate estimated costs
+  const geminiInputTokens30d = Number(gemini30d.totalInputTokens) || 0;
+  const geminiOutputTokens30d = Number(gemini30d.totalOutputTokens) || 0;
+  const geminiCost30d =
+    geminiInputTokens30d * GEMINI_FLASH_INPUT_PER_TOKEN +
+    geminiOutputTokens30d * GEMINI_FLASH_OUTPUT_PER_TOKEN;
+
+  const mapsCalls30d = maps30d.totalCalls || 0;
+  const mapsCost30d = mapsCalls30d * MAPS_COST_PER_CALL;
+
+  return NextResponse.json({
+    gemini: {
+      allTime: {
+        calls: geminiAllTime.totalCalls || 0,
+        inputTokens: Number(geminiAllTime.totalInputTokens) || 0,
+        outputTokens: Number(geminiAllTime.totalOutputTokens) || 0,
+      },
+      last30Days: {
+        calls: gemini30d.totalCalls || 0,
+        inputTokens: geminiInputTokens30d,
+        outputTokens: geminiOutputTokens30d,
+        estimatedCostUsd: Math.round(geminiCost30d * 10000) / 10000,
+      },
+    },
+    googleMaps: {
+      allTime: {
+        calls: mapsAllTime.totalCalls || 0,
+      },
+      last30Days: {
+        calls: mapsCalls30d,
+        estimatedCostUsd: Math.round(mapsCost30d * 10000) / 10000,
+      },
+    },
+    totalEstimatedCost30d:
+      Math.round((geminiCost30d + mapsCost30d) * 10000) / 10000,
+  });
+}

--- a/src/app/costs/layout.tsx
+++ b/src/app/costs/layout.tsx
@@ -1,0 +1,20 @@
+import { cookies } from "next/headers";
+import { NavBar } from "@/components/nav-bar";
+
+export default async function CostsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const cookieStore = await cookies();
+  const userName = cookieStore.get("flatpare-name")?.value ?? "Unknown";
+
+  return (
+    <>
+      <NavBar userName={userName} />
+      <main className="mx-auto w-full max-w-3xl flex-1 px-4 py-6 pb-20 sm:pb-6">
+        {children}
+      </main>
+    </>
+  );
+}

--- a/src/app/costs/page.tsx
+++ b/src/app/costs/page.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
+
+interface CostsData {
+  gemini: {
+    allTime: { calls: number; inputTokens: number; outputTokens: number };
+    last30Days: {
+      calls: number;
+      inputTokens: number;
+      outputTokens: number;
+      estimatedCostUsd: number;
+    };
+  };
+  googleMaps: {
+    allTime: { calls: number };
+    last30Days: { calls: number; estimatedCostUsd: number };
+  };
+  totalEstimatedCost30d: number;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return String(n);
+}
+
+function formatUsd(n: number): string {
+  if (n < 0.01 && n > 0) return "< $0.01";
+  return `$${n.toFixed(2)}`;
+}
+
+export default function CostsPage() {
+  const [data, setData] = useState<CostsData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/costs")
+      .then((r) => r.json())
+      .then((d) => {
+        setData(d);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Loading cost data...</p>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <p className="text-muted-foreground">Failed to load cost data</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold">Infrastructure Costs</h1>
+        <p className="text-sm text-muted-foreground">
+          Estimated costs based on tracked API usage
+        </p>
+      </div>
+
+      {/* Total summary */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Last 30 Days Total</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-3xl font-semibold">
+            {formatUsd(data.totalEstimatedCost30d)}
+          </p>
+          <p className="text-sm text-muted-foreground">
+            estimated across tracked API services
+          </p>
+        </CardContent>
+      </Card>
+
+      {/* Gemini */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">Google Gemini (PDF Parsing)</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Model: gemini-2.5-flash-preview &middot; Pricing: $0.15/1M input,
+            $0.60/1M output tokens
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">
+              Last 30 days
+            </h4>
+            <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+              <Stat
+                label="API calls"
+                value={String(data.gemini.last30Days.calls)}
+              />
+              <Stat
+                label="Input tokens"
+                value={formatTokens(data.gemini.last30Days.inputTokens)}
+              />
+              <Stat
+                label="Output tokens"
+                value={formatTokens(data.gemini.last30Days.outputTokens)}
+              />
+              <Stat
+                label="Est. cost"
+                value={formatUsd(data.gemini.last30Days.estimatedCostUsd)}
+              />
+            </div>
+          </div>
+          <Separator />
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">
+              All time
+            </h4>
+            <div className="grid grid-cols-3 gap-4">
+              <Stat
+                label="API calls"
+                value={String(data.gemini.allTime.calls)}
+              />
+              <Stat
+                label="Input tokens"
+                value={formatTokens(data.gemini.allTime.inputTokens)}
+              />
+              <Stat
+                label="Output tokens"
+                value={formatTokens(data.gemini.allTime.outputTokens)}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Google Maps */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">
+            Google Maps (Distance Calculation)
+          </CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Distance Matrix API &middot; $5/1,000 elements &middot; 2 elements
+            per call (bike + transit)
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">
+              Last 30 days
+            </h4>
+            <div className="grid grid-cols-2 gap-4">
+              <Stat
+                label="API calls"
+                value={String(data.googleMaps.last30Days.calls)}
+              />
+              <Stat
+                label="Est. cost"
+                value={formatUsd(data.googleMaps.last30Days.estimatedCostUsd)}
+              />
+            </div>
+          </div>
+          <Separator />
+          <div>
+            <h4 className="text-sm font-medium text-muted-foreground mb-2">
+              All time
+            </h4>
+            <div className="grid grid-cols-2 gap-4">
+              <Stat
+                label="API calls"
+                value={String(data.googleMaps.allTime.calls)}
+              />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* External dashboards */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">External Dashboards</CardTitle>
+          <p className="text-xs text-muted-foreground">
+            Usage for Vercel and Turso is tracked in their own dashboards
+          </p>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-3">
+            <DashboardLink
+              name="Vercel"
+              description="Function invocations, bandwidth, build minutes, Blob storage"
+              url="https://vercel.com/dashboard"
+              freeNote="Hobby plan: 100K function invocations, 100 GB bandwidth/mo"
+            />
+            <Separator />
+            <DashboardLink
+              name="Turso"
+              description="Database size, row reads/writes"
+              url="https://turso.tech/app"
+              freeNote="Free plan: 9 GB storage, 1B row reads/mo"
+            />
+            <Separator />
+            <DashboardLink
+              name="Google Cloud Console"
+              description="Gemini API and Maps API billing"
+              url="https://console.cloud.google.com/billing"
+              freeNote="Maps: $200/mo free credit"
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-2xl font-semibold">{value}</p>
+      <p className="text-xs text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function DashboardLink({
+  name,
+  description,
+  url,
+  freeNote,
+}: {
+  name: string;
+  description: string;
+  url: string;
+  freeNote: string;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div>
+        <p className="font-medium">{name}</p>
+        <p className="text-sm text-muted-foreground">{description}</p>
+        <p className="text-xs text-muted-foreground italic">{freeNote}</p>
+      </div>
+      <a
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="shrink-0 text-sm text-primary underline-offset-4 hover:underline"
+      >
+        Open dashboard
+      </a>
+    </div>
+  );
+}

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -8,6 +8,7 @@ const navItems = [
   { href: "/apartments", label: "Apartments" },
   { href: "/apartments/new", label: "Upload" },
   { href: "/compare", label: "Compare" },
+  { href: "/costs", label: "Costs" },
 ];
 
 export function NavBar({ userName }: { userName: string }) {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -51,7 +51,19 @@ export const ratings = sqliteTable(
   ]
 );
 
+export const apiUsage = sqliteTable("api_usage", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  service: text("service").notNull(), // "gemini" | "google_maps"
+  operation: text("operation").notNull(), // "parse_pdf" | "calculate_distance"
+  inputTokens: integer("input_tokens"),
+  outputTokens: integer("output_tokens"),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(
+    sql`(unixepoch())`
+  ),
+});
+
 export type Apartment = typeof apartments.$inferSelect;
 export type NewApartment = typeof apartments.$inferInsert;
 export type Rating = typeof ratings.$inferSelect;
 export type NewRating = typeof ratings.$inferInsert;
+export type ApiUsage = typeof apiUsage.$inferSelect;

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -1,3 +1,6 @@
+import { db } from "@/lib/db";
+import { apiUsage } from "@/lib/db/schema";
+
 const BASEL_SBB = "Basel SBB, Switzerland";
 
 interface DistanceResult {
@@ -23,6 +26,16 @@ export async function calculateDistance(
 
     results.bikeMinutes = bikeRes;
     results.transitMinutes = transitRes;
+
+    // Log usage (2 API calls: bike + transit)
+    try {
+      await db.insert(apiUsage).values({
+        service: "google_maps",
+        operation: "calculate_distance",
+      });
+    } catch {
+      // Don't fail distance calc if logging fails
+    }
   } catch {
     // Return nulls on failure — user can fill in manually
   }

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -1,6 +1,8 @@
 import { generateText, Output } from "ai";
 import { google } from "@ai-sdk/google";
 import { z } from "zod";
+import { db } from "@/lib/db";
+import { apiUsage } from "@/lib/db/schema";
 
 export const apartmentExtractionSchema = z.object({
   name: z.string().describe("Listing title or apartment name"),
@@ -32,7 +34,7 @@ export type ApartmentExtraction = z.infer<typeof apartmentExtractionSchema>;
 export async function extractApartmentData(
   pdfBase64Pages: string[]
 ): Promise<ApartmentExtraction> {
-  const { output } = await generateText({
+  const result = await generateText({
     model: google("gemini-2.5-flash-preview-05-20"),
     output: Output.object({
       schema: apartmentExtractionSchema,
@@ -61,9 +63,21 @@ Return null for any field you cannot determine from the document.`,
     ],
   });
 
-  if (!output) {
+  // Log token usage
+  try {
+    await db.insert(apiUsage).values({
+      service: "gemini",
+      operation: "parse_pdf",
+      inputTokens: result.usage?.inputTokens ?? null,
+      outputTokens: result.usage?.outputTokens ?? null,
+    });
+  } catch {
+    // Don't fail the parse if logging fails
+  }
+
+  if (!result.output) {
     throw new Error("Failed to extract apartment data from PDF");
   }
 
-  return output;
+  return result.output;
 }


### PR DESCRIPTION
## Summary

Adds a `/costs` page that tracks and displays estimated infrastructure costs across API services the app uses.

## Changes

- **New `api_usage` DB table** — logs every Gemini and Google Maps API call with token counts
- **Instrumented `parse-pdf.ts`** — records input/output token counts after each PDF extraction
- **Instrumented `distance.ts`** — records each Maps Distance Matrix API call
- **New `GET /api/costs` route** — aggregates usage data and calculates estimated costs using published pricing
- **New `/costs` page** — shows per-service usage (all-time + last 30 days), estimated costs, and links to external dashboards (Vercel, Turso, Google Cloud)
- **Nav bar** — added "Costs" link

## Testing

- Upload a PDF and verify `api_usage` table gets a Gemini entry with token counts
- Verify distance calculation logs a `google_maps` entry
- Visit `/costs` and confirm stats display correctly
- Verify the 30-day cost estimate math is correct

Closes #5