### PR TITLE
feat: support fully local/self-hosted mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,26 @@
 # Shared app password
 APP_PASSWORD=
 
-# Turso database
+# --- Cloud mode (Vercel deployment) ---
+
+# Turso database (omit for local SQLite)
 TURSO_DATABASE_URL=
 TURSO_AUTH_TOKEN=
 
-# Vercel Blob storage
+# Vercel Blob storage (omit for local filesystem)
 BLOB_READ_WRITE_TOKEN=
 
-# AI provider for PDF parsing (Google Gemini)
+# Google Gemini for PDF parsing (omit to use Ollama or manual entry)
 GOOGLE_GENERATIVE_AI_API_KEY=
 
-# Google Maps Distance Matrix API
+# Google Maps Distance Matrix API (omit to use OpenRouteService or manual entry)
 GOOGLE_MAPS_API_KEY=
+
+# --- Local/self-hosted mode (free alternatives) ---
+
+# Ollama for PDF parsing (omit if using Gemini)
+# OLLAMA_BASE_URL=http://localhost:11434
+# OLLAMA_MODEL=llava
+
+# OpenRouteService for distance calculation (omit if using Google Maps)
+# OPENROUTESERVICE_API_KEY=

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local mode data
+/data/
+/uploads/

--- a/README.md
+++ b/README.md
@@ -4,33 +4,41 @@ Collaborative apartment comparison tool for small groups hunting for rentals tog
 
 ## Features
 
-- **PDF Upload & AI Parsing** — Upload apartment listing PDFs; Gemini extracts structured data (rent, size, rooms, address, etc.)
-- **Auto Distance Calculation** — Bike and transit travel time from Basel SBB via Google Maps
+- **PDF Upload & AI Parsing** — Upload apartment listing PDFs; AI extracts structured data (rent, size, rooms, address, etc.)
+- **Auto Distance Calculation** — Bike and transit travel time from Basel SBB
 - **Star Ratings** — Each user rates apartments on 5 categories (kitchen, balconies, location, floorplan, overall feeling)
 - **Comparison Grid** — All apartments in a horizontally scrollable table with best-value highlighting
 - **Simple Auth** — Shared password gate + display name (no accounts needed)
 - **Mobile-Friendly** — Responsive design with bottom nav on mobile
+- **Cloud or Local** — Deploy to Vercel or run fully self-hosted with free alternatives
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|-----------|
-| Framework | Next.js 16 (App Router) |
-| Database | SQLite via [Turso](https://turso.tech) |
-| ORM | [Drizzle ORM](https://orm.drizzle.team) |
-| Styling | Tailwind CSS + [shadcn/ui](https://ui.shadcn.com) |
-| File Storage | [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) |
-| PDF Parsing | [Vercel AI SDK](https://sdk.vercel.ai) + Google Gemini |
-| Distance API | Google Maps Distance Matrix |
-| Deployment | [Vercel](https://vercel.com) |
+| Layer | Cloud (Vercel) | Local/Self-hosted |
+|-------|---------------|-------------------|
+| Framework | Next.js 16 (App Router) | Same |
+| Database | SQLite via [Turso](https://turso.tech) | Local SQLite file |
+| ORM | [Drizzle ORM](https://orm.drizzle.team) | Same |
+| Styling | Tailwind CSS + [shadcn/ui](https://ui.shadcn.com) | Same |
+| File Storage | [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) | Local filesystem |
+| PDF Parsing | [Vercel AI SDK](https://sdk.vercel.ai) + Google Gemini | Ollama (local LLM) or manual entry |
+| Distance API | Google Maps Distance Matrix | [OpenRouteService](https://openrouteservice.org) (free) or manual entry |
+| Deployment | [Vercel](https://vercel.com) | Any Node.js host |
 
 ## Prerequisites
 
+### Cloud mode (Vercel)
+
 - Node.js 20+
-- npm
 - A [Turso](https://turso.tech) account (free tier)
 - A [Google AI Studio](https://aistudio.google.com) API key
 - (Optional) A [Google Maps Platform](https://console.cloud.google.com) API key
+
+### Local/self-hosted mode
+
+- Node.js 20+
+- (Optional) [Ollama](https://ollama.com) with a vision model (e.g. `llava`) for PDF parsing
+- (Optional) A free [OpenRouteService](https://openrouteservice.org/dev/#/signup) API key for distance calculation
 
 ## Setup
 
@@ -113,6 +121,73 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
+## Local/Self-Hosted Setup (No Cloud Services)
+
+Run Flatpare entirely on your machine with zero cloud dependencies. The only required env var is `APP_PASSWORD`.
+
+### 1. Clone and install
+
+```bash
+git clone <repo-url>
+cd flatpare
+npm install
+```
+
+### 2. Configure environment
+
+```bash
+cp .env.example .env.local
+```
+
+Edit `.env.local` — only `APP_PASSWORD` is required:
+
+```env
+APP_PASSWORD=<choose a shared password>
+```
+
+All cloud variables (`TURSO_DATABASE_URL`, `BLOB_READ_WRITE_TOKEN`, etc.) can be omitted. The app auto-detects local mode when they're absent.
+
+### 3. (Optional) Set up Ollama for AI-powered PDF parsing
+
+Without an AI provider, PDF upload still works but all fields must be filled in manually.
+
+```bash
+# Install Ollama: https://ollama.com/download
+ollama pull llava
+ollama serve  # starts on port 11434
+```
+
+Add to `.env.local`:
+
+```env
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llava
+```
+
+### 4. (Optional) Set up OpenRouteService for distance calculation
+
+Without a distance API, users can enter bike/transit times manually.
+
+1. Sign up at [openrouteservice.org/dev](https://openrouteservice.org/dev/#/signup) (free, no credit card)
+2. Create an API key
+
+Add to `.env.local`:
+
+```env
+OPENROUTESERVICE_API_KEY=<your key>
+```
+
+Note: OpenRouteService supports bike routing but not public transit. Transit times will need to be entered manually.
+
+### 5. Push database schema and run
+
+```bash
+npx drizzle-kit push   # creates ./data/flatpare.db
+npm run dev
+```
+
+Data is stored in `./data/flatpare.db` (SQLite) and uploaded PDFs go to `./uploads/`. Both directories are gitignored.
+
 ## Deploy to Vercel
 
 The app is configured for automatic deployment on push to `main`.
@@ -166,8 +241,9 @@ src/
     db/schema.ts                # Drizzle database schema
     db/index.ts                 # Database client
     auth.ts                     # Cookie/session helpers
-    parse-pdf.ts                # AI extraction logic
-    distance.ts                 # Google Maps API wrapper
+    parse-pdf.ts                # AI extraction logic (Gemini / Ollama)
+    distance.ts                 # Distance calculation (Google Maps / OpenRouteService)
+    storage.ts                  # File storage (Vercel Blob / local filesystem)
   proxy.ts                      # Auth proxy (Next.js 16)
 ```
 

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,17 @@
 import type { Config } from "drizzle-kit";
 
+const isCloud = !!process.env.TURSO_DATABASE_URL;
+
 export default {
   schema: "./src/lib/db/schema.ts",
   out: "./drizzle",
-  dialect: "turso",
-  dbCredentials: {
-    url: process.env.TURSO_DATABASE_URL!,
-    authToken: process.env.TURSO_AUTH_TOKEN,
-  },
+  dialect: isCloud ? "turso" : "sqlite",
+  dbCredentials: isCloud
+    ? {
+        url: process.env.TURSO_DATABASE_URL!,
+        authToken: process.env.TURSO_AUTH_TOKEN,
+      }
+    : {
+        url: "file:./data/flatpare.db",
+      },
 } satisfies Config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/google": "^3.0.64",
+        "@ai-sdk/openai": "^3.0.53",
         "@base-ui/react": "^1.4.0",
         "@libsql/client": "^0.17.2",
         "@vercel/blob": "^2.3.3",
@@ -58,6 +59,22 @@
       "version": "3.0.64",
       "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
       "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/openai": {
+      "version": "3.0.53",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
+      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.64",
+    "@ai-sdk/openai": "^3.0.53",
     "@base-ui/react": "^1.4.0",
     "@libsql/client": "^0.17.2",
     "@vercel/blob": "^2.3.3",

--- a/src/app/api/parse-pdf/route.ts
+++ b/src/app/api/parse-pdf/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { put } from "@vercel/blob";
+import { uploadFile } from "@/lib/storage";
 import { extractApartmentData } from "@/lib/parse-pdf";
 
 export async function POST(request: Request) {
@@ -13,21 +13,40 @@ export async function POST(request: Request) {
     );
   }
 
-  // Upload PDF to Vercel Blob
-  const blob = await put(`apartments/${Date.now()}-${file.name}`, file, {
-    access: "public",
-  });
+  const filename = `${Date.now()}-${file.name}`;
 
-  // Convert PDF to base64 for AI processing
-  // For now, send the entire PDF as a single document URL
-  // Gemini can handle PDF files directly via URL
+  // Upload PDF (Vercel Blob in cloud, local filesystem otherwise)
+  const pdfUrl = await uploadFile(filename, file);
+
+  // Try AI extraction — if no AI provider is configured, return empty extraction
+  const hasAI =
+    !!process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
+    !!process.env.OLLAMA_BASE_URL;
+
+  if (!hasAI) {
+    return NextResponse.json({
+      pdfUrl,
+      extracted: {
+        name: file.name.replace(/\.pdf$/i, ""),
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        rentChf: null,
+      },
+      aiAvailable: false,
+    });
+  }
+
   const arrayBuffer = await file.arrayBuffer();
   const base64 = Buffer.from(arrayBuffer).toString("base64");
 
   const extracted = await extractApartmentData([base64]);
 
   return NextResponse.json({
-    pdfUrl: blob.url,
+    pdfUrl,
     extracted,
+    aiAvailable: true,
   });
 }

--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+import { readFile } from "fs/promises";
+import path from "path";
+
+const UPLOADS_DIR = path.join(process.cwd(), "uploads");
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  const { path: segments } = await params;
+  const filename = segments.join("/");
+
+  // Prevent path traversal
+  const filePath = path.resolve(UPLOADS_DIR, filename);
+  if (!filePath.startsWith(UPLOADS_DIR)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+
+  try {
+    const buffer = await readFile(filePath);
+    return new NextResponse(buffer, {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `inline; filename="${path.basename(filePath)}"`,
+      },
+    });
+  } catch {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+}

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -2,9 +2,17 @@ import { drizzle } from "drizzle-orm/libsql";
 import { createClient } from "@libsql/client";
 import * as schema from "./schema";
 
-const client = createClient({
-  url: process.env.TURSO_DATABASE_URL!,
-  authToken: process.env.TURSO_AUTH_TOKEN,
-});
+const isCloud = !!process.env.TURSO_DATABASE_URL;
+
+const client = createClient(
+  isCloud
+    ? {
+        url: process.env.TURSO_DATABASE_URL!,
+        authToken: process.env.TURSO_AUTH_TOKEN,
+      }
+    : {
+        url: "file:./data/flatpare.db",
+      }
+);
 
 export const db = drizzle(client, { schema });

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -2,6 +2,7 @@ import { db } from "@/lib/db";
 import { apiUsage } from "@/lib/db/schema";
 
 const BASEL_SBB = "Basel SBB, Switzerland";
+const BASEL_SBB_COORDS = { lat: 47.5476, lng: 7.5897 };
 
 interface DistanceResult {
   bikeMinutes: number | null;
@@ -11,23 +12,35 @@ interface DistanceResult {
 export async function calculateDistance(
   address: string
 ): Promise<DistanceResult> {
-  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
-  if (!apiKey) {
-    return { bikeMinutes: null, transitMinutes: null };
+  // Try Google Maps first
+  if (process.env.GOOGLE_MAPS_API_KEY) {
+    return calculateWithGoogleMaps(address);
   }
 
+  // Fall back to OpenRouteService
+  if (process.env.OPENROUTESERVICE_API_KEY) {
+    return calculateWithOpenRouteService(address);
+  }
+
+  // No provider — return nulls for manual entry
+  return { bikeMinutes: null, transitMinutes: null };
+}
+
+async function calculateWithGoogleMaps(
+  address: string
+): Promise<DistanceResult> {
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY!;
   const results: DistanceResult = { bikeMinutes: null, transitMinutes: null };
 
   try {
     const [bikeRes, transitRes] = await Promise.all([
-      fetchDistance(address, "bicycling", apiKey),
-      fetchDistance(address, "transit", apiKey),
+      fetchGoogleDistance(address, "bicycling", apiKey),
+      fetchGoogleDistance(address, "transit", apiKey),
     ]);
 
     results.bikeMinutes = bikeRes;
     results.transitMinutes = transitRes;
 
-    // Log usage (2 API calls: bike + transit)
     try {
       await db.insert(apiUsage).values({
         service: "google_maps",
@@ -37,13 +50,13 @@ export async function calculateDistance(
       // Don't fail distance calc if logging fails
     }
   } catch {
-    // Return nulls on failure — user can fill in manually
+    // Return nulls on failure
   }
 
   return results;
 }
 
-async function fetchDistance(
+async function fetchGoogleDistance(
   destination: string,
   mode: string,
   apiKey: string
@@ -63,4 +76,87 @@ async function fetchDistance(
   if (element?.status !== "OK") return null;
 
   return Math.round(element.duration.value / 60);
+}
+
+async function calculateWithOpenRouteService(
+  address: string
+): Promise<DistanceResult> {
+  const apiKey = process.env.OPENROUTESERVICE_API_KEY!;
+  const results: DistanceResult = { bikeMinutes: null, transitMinutes: null };
+
+  try {
+    // First geocode the address
+    const coords = await geocodeWithORS(address, apiKey);
+    if (!coords) return results;
+
+    // ORS supports cycling-regular; no public transit support
+    const bikeRes = await fetchORSRoute(
+      BASEL_SBB_COORDS,
+      coords,
+      "cycling-regular",
+      apiKey
+    );
+    results.bikeMinutes = bikeRes;
+    // ORS doesn't support public transit — leave transitMinutes as null
+
+    try {
+      await db.insert(apiUsage).values({
+        service: "openrouteservice",
+        operation: "calculate_distance",
+      });
+    } catch {
+      // Don't fail if logging fails
+    }
+  } catch {
+    // Return nulls on failure
+  }
+
+  return results;
+}
+
+async function geocodeWithORS(
+  address: string,
+  apiKey: string
+): Promise<{ lat: number; lng: number } | null> {
+  const url = new URL("https://api.openrouteservice.org/geocode/search");
+  url.searchParams.set("api_key", apiKey);
+  url.searchParams.set("text", address);
+  url.searchParams.set("size", "1");
+
+  const res = await fetch(url.toString());
+  const data = await res.json();
+
+  const coords = data.features?.[0]?.geometry?.coordinates;
+  if (!coords) return null;
+
+  return { lng: coords[0], lat: coords[1] };
+}
+
+async function fetchORSRoute(
+  origin: { lat: number; lng: number },
+  destination: { lat: number; lng: number },
+  profile: string,
+  apiKey: string
+): Promise<number | null> {
+  const url = `https://api.openrouteservice.org/v2/directions/${profile}`;
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      Authorization: apiKey,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      coordinates: [
+        [origin.lng, origin.lat],
+        [destination.lng, destination.lat],
+      ],
+    }),
+  });
+
+  const data = await res.json();
+  const duration = data.routes?.[0]?.summary?.duration;
+  if (duration == null) return null;
+
+  return Math.round(duration / 60);
 }

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -1,5 +1,6 @@
 import { generateText, Output } from "ai";
 import { google } from "@ai-sdk/google";
+import { createOpenAI } from "@ai-sdk/openai";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { apiUsage } from "@/lib/db/schema";
@@ -31,11 +32,38 @@ export const apartmentExtractionSchema = z.object({
 
 export type ApartmentExtraction = z.infer<typeof apartmentExtractionSchema>;
 
+function getModel() {
+  // Cloud mode: Google Gemini
+  if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+    return {
+      model: google("gemini-2.5-flash-preview-05-20"),
+      service: "gemini" as const,
+    };
+  }
+
+  // Local mode: Ollama via OpenAI-compatible API
+  if (process.env.OLLAMA_BASE_URL) {
+    const ollama = createOpenAI({
+      baseURL: `${process.env.OLLAMA_BASE_URL}/v1`,
+      apiKey: "ollama", // Ollama doesn't need a real key
+    });
+    const modelName = process.env.OLLAMA_MODEL || "llava";
+    return {
+      model: ollama(modelName),
+      service: "ollama" as const,
+    };
+  }
+
+  throw new Error("No AI provider configured");
+}
+
 export async function extractApartmentData(
   pdfBase64Pages: string[]
 ): Promise<ApartmentExtraction> {
+  const { model, service } = getModel();
+
   const result = await generateText({
-    model: google("gemini-2.5-flash-preview-05-20"),
+    model,
     output: Output.object({
       schema: apartmentExtractionSchema,
     }),
@@ -66,7 +94,7 @@ Return null for any field you cannot determine from the document.`,
   // Log token usage
   try {
     await db.insert(apiUsage).values({
-      service: "gemini",
+      service,
       operation: "parse_pdf",
       inputTokens: result.usage?.inputTokens ?? null,
       outputTokens: result.usage?.outputTokens ?? null,

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,26 @@
+import { put } from "@vercel/blob";
+import { writeFile, mkdir } from "fs/promises";
+import path from "path";
+
+const UPLOADS_DIR = path.join(process.cwd(), "uploads");
+
+const isCloud = !!process.env.BLOB_READ_WRITE_TOKEN;
+
+export async function uploadFile(
+  filename: string,
+  file: File
+): Promise<string> {
+  if (isCloud) {
+    const blob = await put(`apartments/${filename}`, file, {
+      access: "public",
+    });
+    return blob.url;
+  }
+
+  // Local mode: write to ./uploads/
+  await mkdir(UPLOADS_DIR, { recursive: true });
+  const buffer = Buffer.from(await file.arrayBuffer());
+  const filePath = path.join(UPLOADS_DIR, filename);
+  await writeFile(filePath, buffer);
+  return `/api/uploads/${filename}`;
+}


### PR DESCRIPTION
## Summary
- All cloud dependencies (Turso, Vercel Blob, Gemini, Google Maps) are now optional
- App auto-detects local vs cloud mode based on which env vars are set
- Only `APP_PASSWORD` is required to run locally

## Changes
- **Database** (`src/lib/db/index.ts`, `drizzle.config.ts`): Falls back to local SQLite file (`./data/flatpare.db`) when `TURSO_DATABASE_URL` is not set
- **Storage** (`src/lib/storage.ts`, `src/app/api/uploads/`): New storage adapter — uses local filesystem when `BLOB_READ_WRITE_TOKEN` is not set, with a catch-all API route to serve uploaded files
- **PDF parsing** (`src/lib/parse-pdf.ts`, `src/app/api/parse-pdf/route.ts`): Falls back to Ollama via OpenAI-compatible API (`@ai-sdk/openai`), or returns empty extraction for manual entry when no AI provider is configured
- **Distance** (`src/lib/distance.ts`): Falls back to OpenRouteService (free, bike only — no transit), or returns nulls for manual entry
- **Config**: Updated `.env.example` with local-mode variables, `.gitignore` for `data/` and `uploads/`, README with full local setup guide

## Test plan
- [ ] Verify cloud mode still works (all env vars set)
- [ ] Run locally with only `APP_PASSWORD` set — upload PDF, verify manual entry works
- [ ] Run with Ollama — verify AI extraction works
- [ ] Run with OpenRouteService key — verify bike distance calculation
- [ ] `npx drizzle-kit push` creates local SQLite DB without Turso vars

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)