### PR TITLE
feat: add dark/light/system theme toggle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "drizzle-orm": "^0.45.2",
         "lucide-react": "^1.8.0",
         "next": "16.2.4",
+        "next-themes": "^0.4.6",
         "react": "19.2.4",
         "react-dom": "19.2.4",
         "remark": "^15.0.1",
@@ -10524,6 +10525,16 @@
         "sass": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/next/node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.8.0",
     "next": "16.2.4",
+    "next-themes": "^0.4.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "remark": "^15.0.1",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { ThemeProvider } from "@/components/theme-provider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -26,8 +27,11 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col">{children}</body>
+      <body className="min-h-full flex flex-col">
+        <ThemeProvider>{children}</ThemeProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 const navItems = [
   { href: "/apartments", label: "Apartments" },
@@ -37,7 +38,10 @@ export function NavBar({ userName }: { userName: string }) {
             </Link>
           ))}
         </nav>
-        <span className="text-sm text-muted-foreground">{userName}</span>
+        <div className="flex items-center gap-3">
+          <ThemeToggle />
+          <span className="text-sm text-muted-foreground">{userName}</span>
+        </div>
       </div>
       {/* Mobile bottom nav */}
       <nav className="fixed bottom-0 left-0 right-0 z-50 flex border-t bg-background sm:hidden">

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useTheme } from "next-themes";
+import { useEffect, useState } from "react";
+import { Sun, Moon, Monitor } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const themes = [
+  { value: "light", icon: Sun, label: "Light" },
+  { value: "dark", icon: Moon, label: "Dark" },
+  { value: "system", icon: Monitor, label: "System" },
+] as const;
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  if (!mounted) {
+    return <div className="h-8 w-20" />;
+  }
+
+  return (
+    <div className="flex items-center rounded-md border bg-muted p-0.5">
+      {themes.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          type="button"
+          onClick={() => setTheme(value)}
+          aria-label={`Switch to ${label} theme`}
+          className={cn(
+            "rounded-sm p-1 transition-colors",
+            theme === value
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground"
+          )}
+        >
+          <Icon className="h-3.5 w-3.5" />
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Added theme toggle (light/dark/system) to the navbar using `next-themes`
- Uses Tailwind `class` strategy — the existing `.dark` CSS variables already handle all styling
- Preference persists in localStorage, no flash of wrong theme on load
- Three-way toggle with sun/moon/monitor icons

## Changes
- `src/components/theme-provider.tsx` — wraps app with `next-themes` provider
- `src/components/theme-toggle.tsx` — segmented toggle button component
- `src/app/layout.tsx` — wrapped children with ThemeProvider, added `suppressHydrationWarning`
- `src/components/nav-bar.tsx` — added ThemeToggle next to username

## Test plan
- [x] Build succeeds
- [x] All 56 existing tests pass
- [x] Light mode renders correctly (existing baseline)
- [x] Dark mode applies `.dark` class variables
- [x] System mode follows OS preference
- [x] Preference persists across page reloads

Closes #15
Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)