### PR TITLE
feat: add multi-user management and switching

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -12,8 +12,22 @@ export default function LoginPage() {
   const [step, setStep] = useState<"password" | "name">("password");
   const [password, setPassword] = useState("");
   const [displayName, setDisplayName] = useState("");
+  const [existingUsers, setExistingUsers] = useState<string[]>([]);
+  const [showNewUserInput, setShowNewUserInput] = useState(false);
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (step === "name") {
+      fetch("/api/auth/users")
+        .then((res) => res.json())
+        .then((users: string[]) => {
+          setExistingUsers(users);
+          if (users.length === 0) setShowNewUserInput(true);
+        })
+        .catch(() => setShowNewUserInput(true));
+    }
+  }, [step]);
 
   async function handlePassword(e: React.FormEvent) {
     e.preventDefault();
@@ -36,24 +50,28 @@ export default function LoginPage() {
     setStep("name");
   }
 
-  async function handleName(e: React.FormEvent) {
-    e.preventDefault();
+  async function selectUser(name: string) {
     setError("");
     setLoading(true);
 
     const res = await fetch("/api/auth/name", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ displayName }),
+      body: JSON.stringify({ displayName: name }),
     });
 
     if (!res.ok) {
-      setError("Please enter a name");
+      setError("Failed to set name");
       setLoading(false);
       return;
     }
 
     router.push("/apartments");
+  }
+
+  async function handleNewName(e: React.FormEvent) {
+    e.preventDefault();
+    await selectUser(displayName.trim());
   }
 
   return (
@@ -64,7 +82,7 @@ export default function LoginPage() {
           <p className="text-center text-sm text-muted-foreground">
             {step === "password"
               ? "Enter the password to continue"
-              : "What's your name?"}
+              : "Who are you?"}
           </p>
         </CardHeader>
         <CardContent>
@@ -89,25 +107,80 @@ export default function LoginPage() {
               </Button>
             </form>
           ) : (
-            <form onSubmit={handleName} className="space-y-4">
-              <div className="space-y-2">
-                <Label htmlFor="name">Display name</Label>
-                <Input
-                  id="name"
-                  type="text"
-                  value={displayName}
-                  onChange={(e) => setDisplayName(e.target.value)}
-                  placeholder="e.g. Lara"
-                  autoFocus
-                />
-              </div>
-              {error && (
-                <p className="text-sm text-destructive">{error}</p>
+            <div className="space-y-3">
+              {existingUsers.length > 0 && !showNewUserInput && (
+                <>
+                  <div className="space-y-2">
+                    {existingUsers.map((name) => (
+                      <Button
+                        key={name}
+                        variant="outline"
+                        className="w-full justify-start"
+                        disabled={loading}
+                        onClick={() => selectUser(name)}
+                      >
+                        {name}
+                      </Button>
+                    ))}
+                  </div>
+                  <div className="relative my-3">
+                    <div className="absolute inset-0 flex items-center">
+                      <span className="w-full border-t" />
+                    </div>
+                    <div className="relative flex justify-center text-xs uppercase">
+                      <span className="bg-card px-2 text-muted-foreground">or</span>
+                    </div>
+                  </div>
+                  <Button
+                    variant="secondary"
+                    className="w-full"
+                    onClick={() => setShowNewUserInput(true)}
+                  >
+                    Add new user
+                  </Button>
+                </>
               )}
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? "Saving..." : "Enter"}
-              </Button>
-            </form>
+              {showNewUserInput && (
+                <form onSubmit={handleNewName} className="space-y-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="name">Display name</Label>
+                    <Input
+                      id="name"
+                      type="text"
+                      value={displayName}
+                      onChange={(e) => setDisplayName(e.target.value)}
+                      placeholder="e.g. Lara"
+                      autoFocus
+                    />
+                  </div>
+                  {error && (
+                    <p className="text-sm text-destructive">{error}</p>
+                  )}
+                  <div className="flex gap-2">
+                    {existingUsers.length > 0 && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="flex-1"
+                        onClick={() => {
+                          setShowNewUserInput(false);
+                          setDisplayName("");
+                        }}
+                      >
+                        Back
+                      </Button>
+                    )}
+                    <Button
+                      type="submit"
+                      className="flex-1"
+                      disabled={loading || !displayName.trim()}
+                    >
+                      {loading ? "Saving..." : "Enter"}
+                    </Button>
+                  </div>
+                </form>
+              )}
+            </div>
           )}
         </CardContent>
       </Card>

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -1,9 +1,19 @@
 "use client";
 
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { ThemeToggle } from "@/components/theme-toggle";
+import { ChevronDown, Plus, User } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+} from "@/components/ui/dropdown-menu";
 
 const navItems = [
   { href: "/apartments", label: "Apartments" },
@@ -15,6 +25,26 @@ const navItems = [
 
 export function NavBar({ userName }: { userName: string }) {
   const pathname = usePathname();
+  const router = useRouter();
+  const [users, setUsers] = useState<string[]>([]);
+
+  useEffect(() => {
+    fetch("/api/auth/users")
+      .then((res) => res.json())
+      .then((data: string[]) => setUsers(data))
+      .catch(() => {});
+  }, []);
+
+  async function switchUser(name: string) {
+    await fetch("/api/auth/name", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ displayName: name }),
+    });
+    router.refresh();
+  }
+
+  const otherUsers = users.filter((u) => u !== userName);
 
   return (
     <header className="border-b bg-background">
@@ -40,7 +70,31 @@ export function NavBar({ userName }: { userName: string }) {
         </nav>
         <div className="flex items-center gap-3">
           <ThemeToggle />
-          <span className="text-sm text-muted-foreground">{userName}</span>
+          <DropdownMenu>
+            <DropdownMenuTrigger className="flex items-center gap-1 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground">
+              <User className="h-3.5 w-3.5" />
+              <span>{userName}</span>
+              <ChevronDown className="h-3 w-3" />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
+              <DropdownMenuLabel>Switch user</DropdownMenuLabel>
+              {otherUsers.map((name) => (
+                <DropdownMenuItem key={name} onSelect={() => switchUser(name)}>
+                  {name}
+                </DropdownMenuItem>
+              ))}
+              {otherUsers.length === 0 && (
+                <DropdownMenuItem disabled>
+                  <span className="text-muted-foreground">No other users</span>
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onSelect={() => router.push("/")}>
+                <Plus className="h-3.5 w-3.5" />
+                Add new user
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
       </div>
       {/* Mobile bottom nav */}


### PR DESCRIPTION
## Summary
- Login page shows existing users to pick from after password verification
- "Add new user" option for creating new display names
- Navbar user switcher dropdown to switch between users without re-authentication
- "Add new user" option in the dropdown navigates back to login

## Changes
- `src/app/page.tsx` — Reworked the name step to fetch and display existing users, with a fallback to manual name entry
- `src/components/nav-bar.tsx` — Added dropdown menu with user list, switch action, and "Add new user" link

## Test plan
- [x] Build succeeds
- [x] All 56 existing tests pass
- [x] Login flow: password → user picker (existing users) or new name input
- [x] Login flow: no existing users → shows name input directly
- [x] Navbar dropdown: lists other users, switching updates cookie and refreshes
- [x] Navbar dropdown: "Add new user" redirects to login page
- [x] Ratings are attributed to the currently selected user

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)