### PR TITLE
feat: extract and display listing URL from PDF

### DIFF
--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -33,6 +33,7 @@ interface ApartmentDetail {
   distanceBikeMin: number | null;
   distanceTransitMin: number | null;
   pdfUrl: string | null;
+  listingUrl: string | null;
   ratings: Rating[];
 }
 
@@ -125,16 +126,32 @@ export default function ApartmentDetailPage() {
             <p className="text-muted-foreground">{apartment.address}</p>
           )}
         </div>
-        {apartment.pdfUrl && (
-          <a
-            href={apartment.pdfUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className={buttonVariants({ variant: "outline", size: "sm" })}
-          >
-            View PDF
-          </a>
-        )}
+        <div className="flex items-center gap-2">
+          {apartment.pdfUrl && (
+            <a
+              href={apartment.pdfUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              View PDF
+            </a>
+          )}
+          {apartment.listingUrl ? (
+            <a
+              href={apartment.listingUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonVariants({ variant: "outline", size: "sm" })}
+            >
+              Original Listing
+            </a>
+          ) : (
+            <Badge variant="secondary" className="text-muted-foreground">
+              URL missing
+            </Badge>
+          )}
+        </div>
       </div>
 
       {/* Apartment metrics */}

--- a/src/app/apartments/new/page.tsx
+++ b/src/app/apartments/new/page.tsx
@@ -20,6 +20,7 @@ type ApartmentForm = {
   distanceBikeMin: string;
   distanceTransitMin: string;
   pdfUrl: string;
+  listingUrl: string;
   rawExtractedData: Record<string, unknown> | null;
 };
 
@@ -34,6 +35,7 @@ const emptyForm: ApartmentForm = {
   distanceBikeMin: "",
   distanceTransitMin: "",
   pdfUrl: "",
+  listingUrl: "",
   rawExtractedData: null,
 };
 
@@ -65,6 +67,7 @@ function formFromExtracted(
     distanceBikeMin: "",
     distanceTransitMin: "",
     pdfUrl,
+    listingUrl: (extracted.listingUrl as string) || "",
     rawExtractedData: extracted,
   };
 }
@@ -85,6 +88,7 @@ function formToPayload(form: ApartmentForm) {
       ? parseInt(form.distanceTransitMin)
       : null,
     pdfUrl: form.pdfUrl || null,
+    listingUrl: form.listingUrl || null,
     rawExtractedData: form.rawExtractedData,
   };
 }
@@ -649,6 +653,14 @@ function ApartmentFormFields({
             onChange={(e) => onChange("numBalconies", e.target.value)}
           />
         </div>
+      </div>
+      <div className="space-y-2">
+        <Label>Listing URL</Label>
+        <Input
+          value={form.listingUrl}
+          onChange={(e) => onChange("listingUrl", e.target.value)}
+          placeholder="https://..."
+        />
       </div>
       <div className="grid grid-cols-2 gap-4">
         <div className="space-y-2">

--- a/src/app/api/apartments/[id]/route.ts
+++ b/src/app/api/apartments/[id]/route.ts
@@ -51,6 +51,7 @@ export async function PATCH(
       rentChf: body.rentChf,
       distanceBikeMin: body.distanceBikeMin,
       distanceTransitMin: body.distanceTransitMin,
+      listingUrl: body.listingUrl,
     })
     .where(eq(apartments.id, apartmentId))
     .returning();

--- a/src/app/api/apartments/route.ts
+++ b/src/app/api/apartments/route.ts
@@ -17,6 +17,7 @@ export async function GET() {
       distanceBikeMin: apartments.distanceBikeMin,
       distanceTransitMin: apartments.distanceTransitMin,
       pdfUrl: apartments.pdfUrl,
+      listingUrl: apartments.listingUrl,
       createdAt: apartments.createdAt,
       avgKitchen: avg(ratings.kitchen),
       avgBalconies: avg(ratings.balconies),
@@ -48,6 +49,7 @@ export async function POST(request: Request) {
       distanceBikeMin: body.distanceBikeMin,
       distanceTransitMin: body.distanceTransitMin,
       pdfUrl: body.pdfUrl,
+      listingUrl: body.listingUrl || null,
       rawExtractedData: body.rawExtractedData
         ? JSON.stringify(body.rawExtractedData)
         : null,

--- a/src/app/api/parse-pdf/route.ts
+++ b/src/app/api/parse-pdf/route.ts
@@ -34,6 +34,7 @@ export async function POST(request: Request) {
         numBathrooms: null,
         numBalconies: null,
         rentChf: null,
+        listingUrl: null,
       },
       aiAvailable: false,
     });

--- a/src/lib/__tests__/parse-pdf.test.ts
+++ b/src/lib/__tests__/parse-pdf.test.ts
@@ -53,6 +53,7 @@ describe("apartmentExtractionSchema", () => {
       numBathrooms: 1,
       numBalconies: 1,
       rentChf: 1800,
+      listingUrl: "https://www.immobilienscout24.ch/listing/123",
     };
     const result = apartmentExtractionSchema.parse(data);
     expect(result).toEqual(data);
@@ -67,6 +68,7 @@ describe("apartmentExtractionSchema", () => {
       numBathrooms: null,
       numBalconies: null,
       rentChf: null,
+      listingUrl: null,
     };
     const result = apartmentExtractionSchema.parse(data);
     expect(result).toEqual(data);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -13,6 +13,7 @@ export const apartments = sqliteTable("apartments", {
   distanceBikeMin: integer("distance_bike_min"),
   distanceTransitMin: integer("distance_transit_min"),
   pdfUrl: text("pdf_url"),
+  listingUrl: text("listing_url"),
   rawExtractedData: text("raw_extracted_data"),
   createdAt: integer("created_at", { mode: "timestamp" }).default(
     sql`(unixepoch())`

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -28,6 +28,10 @@ export const apartmentExtractionSchema = z.object({
     .number()
     .nullable()
     .describe("Monthly rent in CHF (gross/brutto if available)"),
+  listingUrl: z
+    .string()
+    .nullable()
+    .describe("Original listing URL from the document (e.g. immobilienscout24, wg-gesucht, homegate, etc.)"),
 });
 
 export type ApartmentExtraction = z.infer<typeof apartmentExtractionSchema>;


### PR DESCRIPTION
## Summary
- AI extraction now pulls the original listing URL from uploaded PDFs
- Detail page shows "Original Listing" link when URL exists, or "URL missing" badge when absent
- Listing URL is editable in the upload/create form and PATCH endpoint

## Changes
- `src/lib/db/schema.ts` — Added `listingUrl` column to apartments table
- `src/lib/parse-pdf.ts` — Added `listingUrl` to AI extraction schema
- `src/app/api/apartments/route.ts` — Include `listingUrl` in GET list and POST
- `src/app/api/apartments/[id]/route.ts` — Include `listingUrl` in PATCH
- `src/app/api/parse-pdf/route.ts` — Include `listingUrl: null` in no-AI fallback
- `src/app/apartments/new/page.tsx` — Added listing URL form field, pass through to API
- `src/app/apartments/[id]/page.tsx` — Display listing URL link or "URL missing" badge
- `src/lib/__tests__/parse-pdf.test.ts` — Updated schema validation tests

## Test plan
- [x] Build succeeds
- [x] All 56 tests pass
- [x] AI extraction includes listingUrl field
- [x] Detail page shows clickable link when URL exists
- [x] Detail page shows "URL missing" badge when no URL
- [x] URL is editable in upload form

**Note:** Run `npx drizzle-kit push` after merge to apply the schema migration.

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)