### PR TITLE
fix: wire up drizzle migrations to repair stale schemas (#25)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,10 +33,8 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
 
-# Copy drizzle config and schema for schema push on startup
-COPY --from=builder /app/drizzle.config.ts ./
-COPY --from=builder /app/src/lib/db/schema.ts ./src/lib/db/schema.ts
-COPY --from=builder /app/node_modules ./node_modules
+# Migrations are applied at startup via src/instrumentation.ts
+COPY --from=builder /app/drizzle ./drizzle
 COPY --from=builder /app/docker-entrypoint.sh ./
 
 # Create data and uploads directories for local mode

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,10 +1,4 @@
 #!/bin/sh
 set -e
 
-# Push database schema if using local SQLite
-if [ -z "$TURSO_DATABASE_URL" ]; then
-  echo "Local mode: pushing database schema..."
-  npx drizzle-kit push --force
-fi
-
 exec node server.js

--- a/drizzle/0000_initial_schema.sql
+++ b/drizzle/0000_initial_schema.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS `apartments` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`address` text,
+	`size_m2` real,
+	`num_rooms` real,
+	`num_bathrooms` integer,
+	`num_balconies` integer,
+	`rent_chf` real,
+	`distance_bike_min` integer,
+	`distance_transit_min` integer,
+	`pdf_url` text,
+	`listing_url` text,
+	`raw_extracted_data` text,
+	`created_at` integer DEFAULT (unixepoch()),
+	`updated_at` integer DEFAULT (unixepoch())
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `api_usage` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`service` text NOT NULL,
+	`operation` text NOT NULL,
+	`input_tokens` integer,
+	`output_tokens` integer,
+	`created_at` integer DEFAULT (unixepoch())
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS `ratings` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`apartment_id` integer NOT NULL,
+	`user_name` text NOT NULL,
+	`kitchen` integer DEFAULT 0,
+	`balconies` integer DEFAULT 0,
+	`location` integer DEFAULT 0,
+	`floorplan` integer DEFAULT 0,
+	`overall_feeling` integer DEFAULT 0,
+	`comment` text DEFAULT '',
+	`created_at` integer DEFAULT (unixepoch()),
+	`updated_at` integer DEFAULT (unixepoch()),
+	FOREIGN KEY (`apartment_id`) REFERENCES `apartments`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS `ratings_apartment_user_idx` ON `ratings` (`apartment_id`,`user_name`);

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,306 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1a6848e0-731a-4f91-9395-2275713a1699",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "apartments": {
+      "name": "apartments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_m2": {
+          "name": "size_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_rooms": {
+          "name": "num_rooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_bathrooms": {
+          "name": "num_bathrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_balconies": {
+          "name": "num_balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rent_chf": {
+          "name": "rent_chf",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_bike_min": {
+          "name": "distance_bike_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_transit_min": {
+          "name": "distance_transit_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_url": {
+          "name": "listing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_extracted_data": {
+          "name": "raw_extracted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_usage": {
+      "name": "api_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ratings": {
+      "name": "ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kitchen": {
+          "name": "kitchen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "balconies": {
+          "name": "balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "location": {
+          "name": "location",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "floorplan": {
+          "name": "floorplan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "overall_feeling": {
+          "name": "overall_feeling",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "ratings_apartment_user_idx": {
+          "name": "ratings_apartment_user_idx",
+          "columns": [
+            "apartment_id",
+            "user_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ratings_apartment_id_apartments_id_fk": {
+          "name": "ratings_apartment_id_apartments_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1776832975059,
+      "tag": "0000_initial_schema",
+      "breakpoints": true
+    }
+  ]
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  // Bundle the drizzle/ migration SQL files with every serverless trace so
+  // src/instrumentation.ts can apply them on Vercel cold starts.
+  outputFileTracingIncludes: {
+    "/*": ["./drizzle/**/*"],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "db:generate": "drizzle-kit generate",
+    "db:push": "drizzle-kit push",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.64",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,6 @@
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  const { runMigrations } = await import("@/lib/db/migrate");
+  await runMigrations();
+}

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -1,0 +1,67 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect } from "vitest";
+import { createClient } from "@libsql/client";
+import { applyMigrations } from "../migrate";
+
+async function columnNames(
+  client: ReturnType<typeof createClient>,
+  table: string
+): Promise<string[]> {
+  const res = await client.execute({
+    sql: `PRAGMA table_info(${table})`,
+    args: [],
+  });
+  return res.rows.map((r) => String(r.name));
+}
+
+describe("applyMigrations", () => {
+  it("creates full schema on a fresh database", async () => {
+    const client = createClient({ url: ":memory:" });
+
+    await applyMigrations(client);
+
+    expect(await columnNames(client, "apartments")).toContain("listing_url");
+    expect(await columnNames(client, "ratings")).toContain("user_name");
+    expect(await columnNames(client, "api_usage")).toContain("service");
+
+    const migrations = await client.execute({
+      sql: "SELECT hash FROM __drizzle_migrations",
+      args: [],
+    });
+    expect(migrations.rows).toHaveLength(1);
+  });
+
+  it("adds listing_url to a legacy database missing the column", async () => {
+    const client = createClient({ url: ":memory:" });
+
+    // Simulate a pre-PR #23 database: apartments without listing_url.
+    await client.execute({
+      sql: `CREATE TABLE apartments (
+        id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        name text NOT NULL
+      )`,
+      args: [],
+    });
+
+    expect(await columnNames(client, "apartments")).not.toContain("listing_url");
+
+    await applyMigrations(client);
+
+    expect(await columnNames(client, "apartments")).toContain("listing_url");
+  });
+
+  it("is idempotent when run twice on the same database", async () => {
+    const client = createClient({ url: ":memory:" });
+
+    await applyMigrations(client);
+    await applyMigrations(client);
+
+    const migrations = await client.execute({
+      sql: "SELECT hash FROM __drizzle_migrations",
+      args: [],
+    });
+    expect(migrations.rows).toHaveLength(1);
+  });
+});

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -1,0 +1,67 @@
+import path from "node:path";
+import { createClient, type Client } from "@libsql/client";
+import { drizzle } from "drizzle-orm/libsql";
+import { migrate } from "drizzle-orm/libsql/migrator";
+import * as schema from "./schema";
+
+const MIGRATIONS_FOLDER = path.join(process.cwd(), "drizzle");
+
+let cachedPromise: Promise<void> | null = null;
+
+async function ensureListingUrlColumn(client: Client): Promise<void> {
+  // Repair legacy databases (pre-PR #23) where `apartments` predates
+  // `listing_url`. Our baseline migration uses CREATE TABLE IF NOT EXISTS,
+  // which is a no-op on existing tables and therefore can't add the column.
+  const tables = await client.execute({
+    sql: "SELECT name FROM sqlite_master WHERE type='table' AND name='apartments'",
+    args: [],
+  });
+  if (tables.rows.length === 0) return;
+
+  const cols = await client.execute({
+    sql: "PRAGMA table_info(apartments)",
+    args: [],
+  });
+  const hasListingUrl = cols.rows.some((row) => row.name === "listing_url");
+  if (hasListingUrl) return;
+
+  await client.execute({
+    sql: "ALTER TABLE apartments ADD COLUMN listing_url text",
+    args: [],
+  });
+}
+
+export async function applyMigrations(client: Client): Promise<void> {
+  await ensureListingUrlColumn(client);
+  const db = drizzle(client, { schema });
+  await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+}
+
+function createDefaultClient(): Client {
+  return createClient(
+    process.env.TURSO_DATABASE_URL
+      ? {
+          url: process.env.TURSO_DATABASE_URL,
+          authToken: process.env.TURSO_AUTH_TOKEN,
+        }
+      : {
+          url: "file:./data/flatpare.db",
+        }
+  );
+}
+
+export async function runMigrations(): Promise<void> {
+  if (cachedPromise) return cachedPromise;
+
+  const client = createDefaultClient();
+  cachedPromise = applyMigrations(client)
+    .catch((err) => {
+      cachedPromise = null;
+      throw err;
+    })
+    .finally(() => {
+      client.close();
+    });
+
+  return cachedPromise;
+}


### PR DESCRIPTION
## Summary

Fixes #25, where `GET /api/apartments` crashes with `SQLite input error: no such column: apartments.listing_url`. The `listing_url` column was added to `schema.ts` in PR #23 but never reached any deployed DB — the previous \"migration system\" was a single `drizzle-kit push --force` call in `docker-entrypoint.sh` that only runs for local-SQLite Docker boots.

This replaces it with a proper Drizzle migration pipeline that runs on every environment, and self-repairs existing legacy DBs (including Turso) without manual intervention.

## Changes

- **`drizzle/0000_initial_schema.sql`** — baseline migration generated from the current schema, hand-edited to `CREATE TABLE IF NOT EXISTS` (+ `CREATE UNIQUE INDEX IF NOT EXISTS`) so it's idempotent on existing DBs.
- **`src/lib/db/migrate.ts`** — programmatic runner:
  - Column-patch step: if `apartments` exists without `listing_url`, runs `ALTER TABLE apartments ADD COLUMN listing_url text`. Repairs legacy Turso/local DBs where the baseline `CREATE TABLE IF NOT EXISTS` can't add columns.
  - Then calls `drizzle-orm/libsql/migrator` against `drizzle/` (tracks applied migrations in `__drizzle_migrations`).
  - Cached-promise guard so concurrent calls in one process don't race.
- **`src/instrumentation.ts`** — Next.js `register()` hook, gated on `NEXT_RUNTIME === 'nodejs'`. Runs migrations once per server instance before requests are served.
- **`next.config.ts`** — `outputFileTracingIncludes` bundles `drizzle/**/*` into the serverless trace so Vercel has the SQL files at runtime.
- **`docker-entrypoint.sh`** — drops the old `drizzle-kit push --force`; instrumentation handles it.
- **`Dockerfile`** — copies `drizzle/` into the runtime image; no longer ships `drizzle.config.ts`, `schema.ts`, or full `node_modules`.
- **`package.json`** — adds `db:generate` / `db:push` / `db:studio` for future schema work.

## Testing

Verified locally with `node .next/standalone/server.js` against three DB states:

1. **Fresh DB** — instrumentation creates all tables, `GET /api/apartments` returns `200 []`.
2. **Realistic legacy DB** (pre-PR #23, has every column except `listing_url`, plus a data row) — instrumentation adds `listing_url`, API returns `200` with `listingUrl: null` on the legacy row.
3. **Already-migrated DB** — instrumentation no-ops (migrator sees existing row in `__drizzle_migrations`).

Vitest suite: **59/59 passing** including 3 new tests in `src/lib/db/__tests__/migrate.test.ts` covering the three scenarios above against in-memory libsql.

`npm run build` succeeds; the standalone bundle contains `drizzle/` at the root.

## Deploy note

Full Vercel redeploy required — the first cold start after deploy will run the column-patch on the live Turso DB.

## Checklist

- [x] Tests pass (59/59)
- [x] Production build succeeds
- [x] Drizzle migrations bundled into standalone trace (`.next/standalone/drizzle/` verified)
- [x] End-to-end verified against a simulated legacy DB
- [x] No schema changes beyond making an existing column reachable

Closes #25