### PR TITLE
fix: swap retired gemini-2.5-flash-preview for GA gemini-2.5-flash

### DIFF
--- a/src/app/costs/page.tsx
+++ b/src/app/costs/page.tsx
@@ -90,8 +90,8 @@ export default function CostsPage() {
         <CardHeader>
           <CardTitle className="text-lg">Google Gemini (PDF Parsing)</CardTitle>
           <p className="text-xs text-muted-foreground">
-            Model: gemini-2.5-flash-preview &middot; Pricing: $0.15/1M input,
-            $0.60/1M output tokens
+            Model: gemini-2.5-flash &middot; Pricing: $0.15/1M input, $0.60/1M
+            output tokens
           </p>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -40,7 +40,7 @@ function getModel() {
   // Cloud mode: Google Gemini
   if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
     return {
-      model: google("gemini-2.5-flash-preview-05-20"),
+      model: google("gemini-2.5-flash"),
       service: "gemini" as const,
     };
   }


### PR DESCRIPTION
## Summary

PDF uploads have been failing with an HTTP 404 from the Gemini API:

```
models/gemini-2.5-flash-preview-05-20 is not found for API version v1beta,
or is not supported for generateContent
```

The preview model was retired once `gemini-2.5-flash` went GA. Swap to the stable model and update the label on `/costs` to match.

## Changes

- `src/lib/parse-pdf.ts` — `google("gemini-2.5-flash-preview-05-20")` → `google("gemini-2.5-flash")`.
- `src/app/costs/page.tsx` — display label updated (no pricing change; `gemini-2.5-flash` is the same \$0.15/\$0.60 per M tokens as the preview).

## Testing

- `npm test` → 59/59 passing.
- Reproduction captured from `flatpare-flatpare-1` container logs (404 on upload).
- Manual verification will happen post-merge by uploading a PDF.

## Checklist

- [x] Tests pass
- [x] No schema, dep, or API changes
- [x] Pricing note on `/costs` still accurate