### PR TITLE
fix: send PDFs to Gemini as file parts, not image parts

### DIFF
--- a/src/app/api/parse-pdf/route.ts
+++ b/src/app/api/parse-pdf/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
     const arrayBuffer = await file.arrayBuffer();
     const base64 = Buffer.from(arrayBuffer).toString("base64");
 
-    const extracted = await extractApartmentData([base64]);
+    const extracted = await extractApartmentData(base64);
 
     return NextResponse.json({
       pdfUrl,

--- a/src/lib/__tests__/parse-pdf.test.ts
+++ b/src/lib/__tests__/parse-pdf.test.ts
@@ -100,9 +100,40 @@ describe("extractApartmentData", () => {
       usage: { inputTokens: 100, outputTokens: 50 },
     } as never);
 
-    const result = await extractApartmentData(["base64pdf"]);
+    const result = await extractApartmentData("base64pdf");
     expect(result).toEqual(mockOutput);
     expect(mockedGenerateText).toHaveBeenCalledOnce();
+  });
+
+  it("sends the PDF as a file part with application/pdf mediaType", async () => {
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-key";
+
+    mockedGenerateText.mockResolvedValue({
+      output: {
+        name: "x",
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        rentChf: null,
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never);
+
+    await extractApartmentData("base64pdf");
+
+    const call = mockedGenerateText.mock.calls[0][0] as {
+      messages: Array<{ content: Array<Record<string, unknown>> }>;
+    };
+    const filePart = call.messages[0].content.find(
+      (p) => p.type === "file"
+    );
+    expect(filePart).toEqual({
+      type: "file",
+      data: "base64pdf",
+      mediaType: "application/pdf",
+    });
   });
 
   it("uses Ollama when OLLAMA_BASE_URL is set", async () => {
@@ -121,12 +152,12 @@ describe("extractApartmentData", () => {
       usage: { inputTokens: 50, outputTokens: 25 },
     } as never);
 
-    const result = await extractApartmentData(["base64pdf"]);
+    const result = await extractApartmentData("base64pdf");
     expect(result.name).toBe("Ollama Apt");
   });
 
   it("throws when no AI provider is configured", async () => {
-    await expect(extractApartmentData(["base64pdf"])).rejects.toThrow(
+    await expect(extractApartmentData("base64pdf")).rejects.toThrow(
       "No AI provider configured"
     );
   });
@@ -139,7 +170,7 @@ describe("extractApartmentData", () => {
       usage: { inputTokens: 100, outputTokens: 0 },
     } as never);
 
-    await expect(extractApartmentData(["base64pdf"])).rejects.toThrow(
+    await expect(extractApartmentData("base64pdf")).rejects.toThrow(
       "Failed to extract apartment data from PDF"
     );
   });

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -62,7 +62,7 @@ function getModel() {
 }
 
 export async function extractApartmentData(
-  pdfBase64Pages: string[]
+  pdfBase64: string
 ): Promise<ApartmentExtraction> {
   const { model, service } = getModel();
 
@@ -83,13 +83,11 @@ For rent, prefer the gross/brutto rent (Bruttomiete) if both net and gross are s
 For rooms, use the Swiss convention (e.g. 3.5 Zimmer = 3.5 rooms).
 Return null for any field you cannot determine from the document.`,
           },
-          ...pdfBase64Pages.map(
-            (page) =>
-              ({
-                type: "image" as const,
-                image: page,
-              })
-          ),
+          {
+            type: "file",
+            data: pdfBase64,
+            mediaType: "application/pdf",
+          },
         ],
       },
     ],


### PR DESCRIPTION
## Summary

Follow-up to #32 — the model string was fixed, but the upload still fails because the code sends raw PDF bytes as a \`type: \"image\"\` content block. The retired preview model accepted this; GA \`gemini-2.5-flash\` returns:

\`\`\`
400 INVALID_ARGUMENT: Unable to process input image
\`\`\`

## Fix

AI SDK v6 (\`@ai-sdk/provider-utils\` \`FilePart\`) supports native PDF input. Swap to a single \`file\` part with the correct media type. Gemini handles multi-page PDFs natively from one file part.

## Changes

- \`src/lib/parse-pdf.ts\` — \`{ type: \"image\", image: ... }\` → \`{ type: \"file\", data: pdfBase64, mediaType: \"application/pdf\" }\`. Signature: \`pdfBase64Pages: string[]\` → \`pdfBase64: string\` (the old array only ever had one element).
- \`src/app/api/parse-pdf/route.ts\` — \`extractApartmentData([base64])\` → \`extractApartmentData(base64)\`.
- \`src/lib/__tests__/parse-pdf.test.ts\` — updated existing tests for the new signature, added one regression test that asserts the content block is \`{ type: \"file\", data, mediaType: \"application/pdf\" }\`.

## Testing

- \`npm test\` → 60/60 passing (59 existing + 1 new).
- Manual smoke test post-merge: upload a PDF in \`flatpare-flatpare-1\`.