### PR TITLE
fix: wrap users dropdown label in Menu.Group to stop render crash (#28)

### DIFF
--- a/src/components/__tests__/nav-bar.test.tsx
+++ b/src/components/__tests__/nav-bar.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, act, waitFor } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => "/apartments",
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { NavBar } from "../nav-bar";
+
+beforeEach(() => {
+  vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.endsWith("/api/auth/users")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(["Alice", "Bob"]),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  }) as typeof fetch);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("NavBar users dropdown", () => {
+  it("opens the users dropdown without throwing when a label is present", async () => {
+    await act(async () => {
+      render(<NavBar userName="Alice" />);
+    });
+
+    const trigger = screen.getByRole("button", { name: /Alice/i });
+
+    // Opening the menu would previously crash because DropdownMenuLabel
+    // (base-ui Menu.GroupLabel) requires a Menu.Group ancestor.
+    await act(async () => {
+      trigger.click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Switch user")).toBeInTheDocument();
+    });
+
+    // Other users (from mocked fetch, minus current) should render.
+    expect(screen.getByText("Bob")).toBeInTheDocument();
+  });
+
+  it("tolerates a non-array response from /api/auth/users without crashing", async () => {
+    vi.spyOn(global, "fetch").mockImplementation((() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ error: "unexpected" }),
+      } as Response)) as typeof fetch);
+
+    await act(async () => {
+      render(<NavBar userName="Alice" />);
+    });
+
+    const trigger = screen.getByRole("button", { name: /Alice/i });
+
+    await act(async () => {
+      trigger.click();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Switch user")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("No other users")).toBeInTheDocument();
+  });
+});

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuLabel,
+  DropdownMenuGroup,
 } from "@/components/ui/dropdown-menu";
 
 const navItems = [
@@ -32,7 +33,7 @@ export function NavBar({ userName }: { userName: string }) {
   useEffect(() => {
     fetch("/api/auth/users")
       .then((res) => res.json())
-      .then((data: string[]) => setUsers(data))
+      .then((data) => setUsers(Array.isArray(data) ? data : []))
       .catch(() => {});
   }, []);
 
@@ -85,17 +86,24 @@ export function NavBar({ userName }: { userName: string }) {
               <ChevronDown className="h-3 w-3" />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
-              <DropdownMenuLabel>Switch user</DropdownMenuLabel>
-              {otherUsers.map((name) => (
-                <DropdownMenuItem key={name} onClick={() => switchUser(name)}>
-                  {name}
-                </DropdownMenuItem>
-              ))}
-              {otherUsers.length === 0 && (
-                <DropdownMenuItem disabled>
-                  <span className="text-muted-foreground">No other users</span>
-                </DropdownMenuItem>
-              )}
+              <DropdownMenuGroup>
+                <DropdownMenuLabel>Switch user</DropdownMenuLabel>
+                {otherUsers.map((name) => (
+                  <DropdownMenuItem
+                    key={name}
+                    onClick={() => switchUser(name)}
+                  >
+                    {name}
+                  </DropdownMenuItem>
+                ))}
+                {otherUsers.length === 0 && (
+                  <DropdownMenuItem disabled>
+                    <span className="text-muted-foreground">
+                      No other users
+                    </span>
+                  </DropdownMenuItem>
+                )}
+              </DropdownMenuGroup>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => router.push("/")}>
                 <Plus className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary

Fixes #28 — clicking the users dropdown in the navbar showed the generic "This page couldn't load" overlay.

## Root cause

`DropdownMenuLabel` is backed by `@base-ui/react`'s `Menu.GroupLabel`, which throws at render time when it has no `Menu.Group` ancestor:

```
Base UI: MenuGroupRootContext is missing. Menu group parts must be used within <Menu.Group>.
```

`src/components/nav-bar.tsx:88` rendered the label directly inside `DropdownMenuContent`, so the menu crashed the moment its portal mounted. The error bubbled to the nearest boundary and rendered as the Next.js route-error screen.

## Fix

1. **Wrap label + user items in `DropdownMenuGroup`** — correct base-ui usage; restores the intended `aria-labelledby` association.
2. **Harden `/api/auth/users` fetch** — coerce non-array responses with `Array.isArray` so a future bad response can't crash `users.filter`.
3. **Render test** (`src/components/__tests__/nav-bar.test.tsx`) — opens the dropdown and asserts it mounts. Verified to fail on the pre-fix code before committing (confirmed via a temporary revert).

## Scope check

Grepped for other `DropdownMenuLabel` usages — only the one in `nav-bar.tsx`. No further call sites need updating.

## Tests

- `npm test` → **62/62** passing (60 existing + 2 new).
- `npm run build` succeeds.

Closes #28