### PR TITLE
docs: polish README with logo, badges, and tighter layout (#26)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - run: npm ci
+
+      # TODO: remove continue-on-error once #36 is resolved
+      - name: Lint
+        run: npm run lint
+        continue-on-error: true
+
+      - name: Test
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -1,20 +1,182 @@
-# Flatpare
+<p align="center">
+  <img src="public/flatpare_logo.svg" alt="Flatpare" width="160" />
+</p>
 
-Collaborative apartment comparison tool for small groups hunting for rentals together. Upload PDF listings, extract data with AI, rate apartments, and compare them side-by-side.
+<h1 align="center">Flatpare</h1>
+
+<p align="center">
+  Collaborative apartment comparison tool for small groups hunting for rentals together.<br/>
+  Upload PDF listings, extract data with AI, rate apartments, compare side-by-side.
+</p>
+
+<p align="center">
+  <a href="https://github.com/brlauuu/flatpare/actions/workflows/test.yml"><img alt="CI" src="https://github.com/brlauuu/flatpare/actions/workflows/test.yml/badge.svg" /></a>
+  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" />
+  <img alt="Next.js" src="https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs" />
+  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white" />
+  <img alt="Tailwind CSS" src="https://img.shields.io/badge/Tailwind-4-06B6D4?logo=tailwindcss&logoColor=white" />
+  <img alt="Drizzle ORM" src="https://img.shields.io/badge/Drizzle-ORM-C5F74F?logo=drizzle&logoColor=black" />
+  <img alt="Vitest" src="https://img.shields.io/badge/Vitest-4-6E9F18?logo=vitest&logoColor=white" />
+</p>
 
 ## Features
 
-- **PDF Upload & AI Parsing** — Upload apartment listing PDFs; AI extracts structured data (rent, size, rooms, address, etc.)
-- **Auto Distance Calculation** — Bike and transit travel time from Basel SBB
-- **Star Ratings** — Each user rates apartments on 5 categories (kitchen, balconies, location, floorplan, overall feeling)
-- **Comparison Grid** — All apartments in a horizontally scrollable table with best-value highlighting
-- **Simple Auth** — Shared password gate + display name (no accounts needed)
-- **Mobile-Friendly** — Responsive design with bottom nav on mobile
-- **Cloud or Local** — Deploy to Vercel or run fully self-hosted with free alternatives
+- **PDF upload & AI parsing** — listings are extracted into structured data (rent, size, rooms, address).
+- **Auto distance** — bike and transit travel time from Basel SBB.
+- **Star ratings & comparison grid** — each user rates on 5 categories; results show side-by-side.
+- **Simple auth** — shared password + display name, no accounts.
+- **Cloud or local** — deploy to Vercel, or run fully self-hosted.
 
-## Tech Stack
+## Quick start
 
-| Layer | Cloud (Vercel) | Local/Self-hosted |
+```bash
+cp .env.example .env.local   # set APP_PASSWORD at minimum
+docker compose up -d
+```
+
+Open [http://localhost:3002](http://localhost:3002).
+
+For deployment and non-Docker setup, pick a path below.
+
+<details>
+<summary><strong>Deploy to Vercel</strong></summary>
+
+1. Import the repo in [Vercel](https://vercel.com/new).
+2. Add environment variables in **Project Settings > Environment Variables**:
+
+   | Variable | Required | Notes |
+   |----------|----------|-------|
+   | `APP_PASSWORD` | Yes | Shared access password |
+   | `TURSO_DATABASE_URL` | Yes | `libsql://...` URL from Turso |
+   | `TURSO_AUTH_TOKEN` | Yes | Auth token from Turso |
+   | `BLOB_READ_WRITE_TOKEN` | Yes | Auto-added when you connect Vercel Blob |
+   | `GOOGLE_GENERATIVE_AI_API_KEY` | Yes | PDF parsing |
+   | `GOOGLE_MAPS_API_KEY` | No | Auto distance calculation |
+
+3. Connect a **Blob store**: dashboard → **Storage** → **Create** → **Blob**.
+4. Push the database schema before first use:
+   ```bash
+   TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... npx drizzle-kit push
+   ```
+
+Subsequent pushes to `main` deploy automatically.
+
+</details>
+
+<details>
+<summary><strong>Cloud mode — run locally against Turso + Gemini</strong></summary>
+
+**Prerequisites:** Node.js 20+, a [Turso](https://turso.tech) account, a [Google AI Studio](https://aistudio.google.com) API key, optionally a [Google Maps](https://console.cloud.google.com) key.
+
+```bash
+git clone <repo-url>
+cd flatpare
+npm install
+```
+
+Create a Turso database:
+
+```bash
+curl -sSfL https://get.tur.so/install.sh | bash
+turso auth signup
+turso db create flatpare
+turso db show flatpare --url           # libsql://flatpare-<you>.turso.io
+turso db tokens create flatpare        # auth token
+```
+
+Get a Gemini key at [aistudio.google.com/apikey](https://aistudio.google.com/apikey). Optionally enable the **Distance Matrix API** in [Google Cloud Console](https://console.cloud.google.com/apis) and create a key.
+
+Configure `.env.local`:
+
+```env
+APP_PASSWORD=<shared password>
+TURSO_DATABASE_URL=libsql://flatpare-<you>.turso.io
+TURSO_AUTH_TOKEN=<token>
+GOOGLE_GENERATIVE_AI_API_KEY=<key>
+GOOGLE_MAPS_API_KEY=<key, or omit>
+```
+
+Push schema and run:
+
+```bash
+npx drizzle-kit push
+npm run dev
+```
+
+`BLOB_READ_WRITE_TOKEN` is only needed in production (Vercel adds it automatically).
+
+</details>
+
+<details>
+<summary><strong>Local / self-hosted — no cloud services</strong></summary>
+
+Runs with a local SQLite file, local filesystem storage, and free or no AI. The only required env var is `APP_PASSWORD`.
+
+```bash
+git clone <repo-url>
+cd flatpare
+npm install
+cp .env.example .env.local        # set APP_PASSWORD
+npx drizzle-kit push              # creates ./data/flatpare.db
+npm run dev
+```
+
+Data lives in `./data/flatpare.db`; uploaded PDFs go to `./uploads/`. Both are gitignored.
+
+**Optional — Ollama for PDF parsing**
+
+```bash
+ollama pull llava
+ollama serve
+```
+
+```env
+OLLAMA_BASE_URL=http://localhost:11434
+OLLAMA_MODEL=llava
+```
+
+**Optional — OpenRouteService for bike distance**
+
+Sign up at [openrouteservice.org/dev](https://openrouteservice.org/dev/#/signup) (free, no credit card). Transit is not supported — enter manually.
+
+```env
+OPENROUTESERVICE_API_KEY=<key>
+```
+
+</details>
+
+<details>
+<summary><strong>Docker details</strong></summary>
+
+The quick-start command above uses `docker compose up -d`. Data is persisted in Docker volumes (`flatpare-data`, `flatpare-uploads`).
+
+Use a different host port:
+
+```bash
+PORT=8080 docker compose up -d
+```
+
+With host-installed Ollama for PDF parsing:
+
+```env
+OLLAMA_BASE_URL=http://host.docker.internal:11434
+OLLAMA_MODEL=llava
+```
+
+Rebuild after updates:
+
+```bash
+git pull
+docker compose build
+docker compose up -d
+```
+
+</details>
+
+<details>
+<summary><strong>Tech stack</strong></summary>
+
+| Layer | Cloud (Vercel) | Local/self-hosted |
 |-------|---------------|-------------------|
 | Framework | Next.js 16 (App Router) | Same |
 | Database | SQLite via [Turso](https://turso.tech) | Local SQLite file |
@@ -25,236 +187,10 @@ Collaborative apartment comparison tool for small groups hunting for rentals tog
 | Distance API | Google Maps Distance Matrix | [OpenRouteService](https://openrouteservice.org) (free) or manual entry |
 | Deployment | [Vercel](https://vercel.com) | Any Node.js host |
 
-## Prerequisites
+</details>
 
-### Cloud mode (Vercel)
-
-- Node.js 20+
-- A [Turso](https://turso.tech) account (free tier)
-- A [Google AI Studio](https://aistudio.google.com) API key
-- (Optional) A [Google Maps Platform](https://console.cloud.google.com) API key
-
-### Local/self-hosted mode
-
-- Node.js 20+
-- (Optional) [Ollama](https://ollama.com) with a vision model (e.g. `llava`) for PDF parsing
-- (Optional) A free [OpenRouteService](https://openrouteservice.org/dev/#/signup) API key for distance calculation
-
-## Setup
-
-### 1. Clone and install
-
-```bash
-git clone <repo-url>
-cd flatpare
-npm install
-```
-
-### 2. Create a Turso database
-
-```bash
-# Install Turso CLI
-curl -sSfL https://get.tur.so/install.sh | bash
-
-# Sign up or log in
-turso auth signup   # or: turso auth login
-
-# Create the database
-turso db create flatpare
-
-# Get connection URL
-turso db show flatpare --url
-# Output: libsql://flatpare-<yourname>.turso.io
-
-# Create auth token
-turso db tokens create flatpare
-# Output: <long token string>
-```
-
-### 3. Get a Google Generative AI API key
-
-1. Go to [Google AI Studio](https://aistudio.google.com/apikey)
-2. Click **Create API Key**
-3. Select or create a Google Cloud project
-4. Copy the key
-
-### 4. (Optional) Get a Google Maps API key
-
-Only needed for automatic bike/transit distance calculation from Basel SBB. Without it, users can enter distances manually.
-
-1. Go to [Google Cloud Console](https://console.cloud.google.com/apis)
-2. Enable the **Distance Matrix API**
-3. Go to **Credentials** > **Create Credentials** > **API Key**
-4. Restrict the key to the Distance Matrix API (recommended)
-
-### 5. Configure environment variables
-
-Copy the example file and fill in your values:
-
-```bash
-cp .env.example .env.local
-```
-
-Edit `.env.local`:
-
-```env
-APP_PASSWORD=<choose a shared password>
-TURSO_DATABASE_URL=libsql://flatpare-<yourname>.turso.io
-TURSO_AUTH_TOKEN=<token from step 2>
-GOOGLE_GENERATIVE_AI_API_KEY=<key from step 3>
-GOOGLE_MAPS_API_KEY=<key from step 4, or leave empty>
-```
-
-`BLOB_READ_WRITE_TOKEN` is only needed in production (Vercel adds it automatically when you connect a Blob store).
-
-### 6. Push database schema
-
-```bash
-npx drizzle-kit push
-```
-
-### 7. Run locally
-
-```bash
-npm run dev
-```
-
-Open [http://localhost:3002](http://localhost:3002).
-
-## Local/Self-Hosted Setup (No Cloud Services)
-
-Run Flatpare entirely on your machine with zero cloud dependencies. The only required env var is `APP_PASSWORD`.
-
-### 1. Clone and install
-
-```bash
-git clone <repo-url>
-cd flatpare
-npm install
-```
-
-### 2. Configure environment
-
-```bash
-cp .env.example .env.local
-```
-
-Edit `.env.local` — only `APP_PASSWORD` is required:
-
-```env
-APP_PASSWORD=<choose a shared password>
-```
-
-All cloud variables (`TURSO_DATABASE_URL`, `BLOB_READ_WRITE_TOKEN`, etc.) can be omitted. The app auto-detects local mode when they're absent.
-
-### 3. (Optional) Set up Ollama for AI-powered PDF parsing
-
-Without an AI provider, PDF upload still works but all fields must be filled in manually.
-
-```bash
-# Install Ollama: https://ollama.com/download
-ollama pull llava
-ollama serve  # starts on port 11434
-```
-
-Add to `.env.local`:
-
-```env
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=llava
-```
-
-### 4. (Optional) Set up OpenRouteService for distance calculation
-
-Without a distance API, users can enter bike/transit times manually.
-
-1. Sign up at [openrouteservice.org/dev](https://openrouteservice.org/dev/#/signup) (free, no credit card)
-2. Create an API key
-
-Add to `.env.local`:
-
-```env
-OPENROUTESERVICE_API_KEY=<your key>
-```
-
-Note: OpenRouteService supports bike routing but not public transit. Transit times will need to be entered manually.
-
-### 5. Push database schema and run
-
-```bash
-npx drizzle-kit push   # creates ./data/flatpare.db
-npm run dev
-```
-
-Data is stored in `./data/flatpare.db` (SQLite) and uploaded PDFs go to `./uploads/`. Both directories are gitignored.
-
-## Docker
-
-The simplest way to run Flatpare locally or on a server.
-
-### Quick start
-
-```bash
-cp .env.example .env.local
-# Edit .env.local — at minimum set APP_PASSWORD
-
-docker compose up -d
-```
-
-The app is available at `http://localhost:3002`. To use a different port:
-
-```bash
-PORT=8080 docker compose up -d
-```
-
-Data (SQLite database and uploaded PDFs) is persisted in Docker volumes.
-
-### With Ollama (AI-powered PDF parsing)
-
-If you're running Ollama on the host machine, add to `.env.local`:
-
-```env
-OLLAMA_BASE_URL=http://host.docker.internal:11434
-OLLAMA_MODEL=llava
-```
-
-### Rebuild after updates
-
-```bash
-git pull
-docker compose build
-docker compose up -d
-```
-
-## Deploy to Vercel
-
-The app is configured for automatic deployment on push to `main`.
-
-### First-time setup
-
-1. Import the repo in [Vercel](https://vercel.com/new)
-2. Add environment variables in **Project Settings > Environment Variables**:
-
-   | Variable | Required | Notes |
-   |----------|----------|-------|
-   | `APP_PASSWORD` | Yes | Shared access password |
-   | `TURSO_DATABASE_URL` | Yes | `libsql://...` URL from Turso |
-   | `TURSO_AUTH_TOKEN` | Yes | Auth token from Turso |
-   | `BLOB_READ_WRITE_TOKEN` | Yes | Auto-added when you connect Vercel Blob storage |
-   | `GOOGLE_GENERATIVE_AI_API_KEY` | Yes | For PDF parsing |
-   | `GOOGLE_MAPS_API_KEY` | No | For auto distance calculation |
-
-3. Connect a **Blob store**: Project dashboard > **Storage** > **Create** > **Blob**
-4. Push the database schema before first use:
-   ```bash
-   TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... npx drizzle-kit push
-   ```
-
-### Subsequent deploys
-
-Push to `main` and Vercel deploys automatically.
-
-## Project Structure
+<details>
+<summary><strong>Project structure</strong></summary>
 
 ```
 src/
@@ -264,65 +200,43 @@ src/
       page.tsx                  # Apartment list
       new/page.tsx              # PDF upload & parse
       [id]/page.tsx             # Apartment detail & ratings
-    compare/
-      page.tsx                  # Comparison grid
-    costs/
-      page.tsx                  # API cost dashboard
-    guide/
-      page.tsx                  # In-app user guide (rendered from markdown)
+    compare/page.tsx            # Comparison grid
+    costs/page.tsx              # API cost dashboard
+    guide/page.tsx              # In-app user guide
     api/
-      auth/route.ts             # Password verification
-      auth/name/route.ts        # Set display name
-      auth/users/route.ts       # List users who have rated
-      apartments/route.ts       # List & create apartments
-      apartments/[id]/route.ts  # Get, update, delete apartment
-      apartments/[id]/ratings/  # Upsert rating
-      parse-pdf/route.ts        # PDF upload & AI extraction
-      distance/route.ts         # Distance calculation
-      costs/route.ts            # API usage cost estimates
+      auth/                     # Password, name, users
+      apartments/               # List, create, update, delete, ratings
+      parse-pdf/                # PDF upload & AI extraction
+      distance/                 # Distance calculation
+      costs/                    # API usage cost estimates
   components/                   # UI components (shadcn/ui + custom)
-  content/
-    guide.md                    # User guide markdown source
+  content/guide.md              # User guide markdown source
   lib/
-    db/schema.ts                # Drizzle database schema
-    db/index.ts                 # Database client
+    db/                         # Drizzle schema + client
     auth.ts                     # Cookie/session helpers
-    parse-pdf.ts                # AI extraction logic (Gemini / Ollama)
-    distance.ts                 # Distance calculation (Google Maps / OpenRouteService)
-    storage.ts                  # File storage (Vercel Blob / local filesystem)
+    parse-pdf.ts                # AI extraction (Gemini / Ollama)
+    distance.ts                 # Distance (Google Maps / OpenRouteService)
+    storage.ts                  # File storage (Blob / filesystem)
   proxy.ts                      # Auth proxy (Next.js 16)
 ```
 
-## Architecture
+</details>
 
-### How It Works
+<details>
+<summary><strong>Architecture</strong></summary>
 
-1. **Authentication:** A simple shared password gate using HTTP-only cookies. No user accounts — just enter the password and pick a display name. The auth proxy (`proxy.ts`) redirects unauthenticated requests to the login page.
+- **Authentication:** shared password gate with HTTP-only cookies; no accounts. The auth proxy (`proxy.ts`) redirects unauthenticated requests.
+- **PDF flow:** upload → store → AI extraction → structured data → user reviews & saves. Provider auto-selects between Gemini, Ollama, and manual entry.
+- **Distance:** Google Maps preferred, OpenRouteService fallback. Returns bike and transit minutes.
+- **Ratings:** one upsert per user per apartment across 5 categories; averages drive the comparison grid.
+- **Storage:** Turso or local SQLite for data; Vercel Blob or `./uploads/` for files.
 
-2. **PDF Upload Flow:**
-   ```
-   User uploads PDF → uploadFile() stores it → extractApartmentData() sends to AI → structured data returned → user reviews & saves
-   ```
-   The AI provider is selected automatically: Google Gemini if `GOOGLE_GENERATIVE_AI_API_KEY` is set, Ollama if `OLLAMA_BASE_URL` is set, or manual entry if neither.
+**Tables:** `apartments`, `ratings` (unique on `(apartmentId, userName)`), `api_usage`.
 
-3. **Distance Calculation:**
-   ```
-   Apartment address → calculateDistance() → Google Maps (preferred) or OpenRouteService (fallback) → bike & transit minutes
-   ```
+</details>
 
-4. **Rating System:** Each user can rate each apartment once (upsert). Ratings are tied to the display name. Average ratings are computed per apartment for the comparison grid.
-
-5. **Data Storage:** SQLite via Drizzle ORM. In cloud mode, the database lives on Turso; locally, it's a file at `./data/flatpare.db`. File uploads go to Vercel Blob (cloud) or `./uploads/` (local).
-
-### Database Schema
-
-Three tables:
-
-- **apartments** — Core listing data (name, address, size, rent, distances, PDF URL)
-- **ratings** — Per-user ratings across 5 categories, with unique constraint on (apartmentId, userName)
-- **api_usage** — Tracks API calls to Gemini and Google Maps for the cost dashboard
-
-### API Routes
+<details>
+<summary><strong>API routes</strong></summary>
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
@@ -339,7 +253,10 @@ Three tables:
 | `POST` | `/api/distance` | Calculate bike/transit distance for an address |
 | `GET` | `/api/costs` | Get API usage stats and estimated costs |
 
-### Environment Variables
+</details>
+
+<details>
+<summary><strong>Environment variables</strong></summary>
 
 | Variable | Required | Mode | Description |
 |----------|----------|------|-------------|
@@ -354,30 +271,22 @@ Three tables:
 | `OPENROUTESERVICE_API_KEY` | No | Local | Free distance calculation alternative |
 | `DISABLE_SECURE_COOKIES` | No | Local | Set to bypass secure cookie flag in dev |
 
+</details>
+
 ## Testing
 
-Tests use [Vitest](https://vitest.dev/) with React Testing Library.
-
 ```bash
-# Run all tests
-npm test
-
-# Watch mode
+npm test          # run once
 npm run test:watch
 ```
 
-Test files live alongside their source in `__tests__/` directories:
-- `src/lib/__tests__/` — Unit tests for auth, distance, parse-pdf, storage, utils
-- `src/app/api/__tests__/` — API route handler tests
-- `src/components/__tests__/` — Component rendering and interaction tests
+Uses [Vitest](https://vitest.dev/) with React Testing Library. Test files live next to their source in `__tests__/` directories.
 
 ## Contributing
 
-1. Create a feature branch from `main`
-2. Make your changes
-3. Run `npm test` to ensure all tests pass
-4. Run `npm run lint` to check for lint errors
-5. Submit a pull request
+1. Create a feature branch from `main`.
+2. Make changes, run `npm test` and `npm run lint`.
+3. Open a pull request.
 
 ## License
 


### PR DESCRIPTION
## Summary

Gives the README a visual identity and makes the quick-start command the first actionable thing a reader sees. Wires up a CI workflow so the status badge has a source.

## Changes

- **README**
  - Centered logo (`public/flatpare_logo.svg`), title, tagline.
  - Badges row: live CI status + TypeScript, Next.js 16, React 19, Tailwind, Drizzle ORM, Vitest (shields.io static).
  - **Quick start** section with `docker compose up -d` above the fold.
  - Long setup sections collapsed under `<details>`: Vercel deploy, cloud-mode local dev, local/self-hosted, Docker details, tech stack, project structure, architecture, API routes, environment variables.
  - Feature list trimmed from 7 bullets to 5.
  - Line count: 384 → 293.
- **CI** (`.github/workflows/test.yml`)
  - Triggers on push to `main` and all PRs.
  - Runs `npm ci` → `npm run lint` → `npm test` on Node 20.
  - `Lint` step has `continue-on-error: true` as a temporary measure — pre-existing lint errors are tracked separately in #36. Once that lands, remove the flag.

## Testing

- `npm test` — 62 tests / 14 files passing (unchanged).
- `npm run lint` — 2 errors + 1 warning (all pre-existing, tracked in #36). Workflow handles this with `continue-on-error` so CI stays green.
- Workflow YAML validated with `yaml.safe_load`.

## Out of scope

- Test-count badge — the dynamic options all require extra infrastructure (gist + PAT, or a side branch committed to by CI). Not worth the lift; CI pass/fail carries the signal.
- Fixing the pre-existing lint errors — see #36.

## Checklist

- [x] Tests pass locally
- [x] Workflow YAML parses
- [x] No functional code changes
- [x] Follow-up lint cleanup filed as #36

Closes #26