### PR TITLE
feat: surface error details via collapsible panel (#27)

### DIFF
--- a/src/app/add-user/add-user-form.tsx
+++ b/src/app/add-user/add-user-form.tsx
@@ -7,32 +7,55 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  type ErrorDetails,
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+} from "@/lib/fetch-error";
+
+interface ErrorState {
+  headline: string;
+  details?: ErrorDetails;
+}
 
 export function AddUserForm() {
   const router = useRouter();
   const [displayName, setDisplayName] = useState("");
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
+  const [error, setError] = useState<ErrorState | null>(null);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    setError("");
+    setError(null);
     setLoading(true);
 
-    const res = await fetch("/api/auth/name", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ displayName: displayName.trim() }),
-    });
+    const url = "/api/auth/name";
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: displayName.trim() }),
+      });
 
-    if (!res.ok) {
-      setError("Failed to set name");
+      if (!res.ok) {
+        setError({
+          headline: "Failed to set name",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setLoading(false);
+        return;
+      }
+
+      router.push("/apartments");
+      router.refresh();
+    } catch (err) {
+      setError({
+        headline: "Couldn't reach the server",
+        details: fetchErrorFromException(err, url),
+      });
       setLoading(false);
-      return;
     }
-
-    router.push("/apartments");
-    router.refresh();
   }
 
   return (
@@ -64,7 +87,9 @@ export function AddUserForm() {
                 autoFocus
               />
             </div>
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && (
+              <ErrorDisplay headline={error.headline} details={error.details} />
+            )}
             <div className="flex gap-2">
               <Button
                 type="button"

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -9,6 +9,17 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { StarRating } from "@/components/star-rating";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  type ErrorDetails,
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+} from "@/lib/fetch-error";
+
+interface ErrorState {
+  headline: string;
+  details?: ErrorDetails;
+}
 
 interface Rating {
   id: number;
@@ -66,30 +77,49 @@ export default function ApartmentDetailPage() {
   });
   const [saving, setSaving] = useState(false);
   const [userName, setUserName] = useState("");
+  const [error, setError] = useState<ErrorState | null>(null);
 
   const loadApartment = useCallback(async () => {
-    const res = await fetch(`/api/apartments/${params.id}`);
-    const data = await res.json();
-    setApartment(data);
+    const url = `/api/apartments/${params.id}`;
+    try {
+      const res = await fetch(url);
+      if (!res.ok) {
+        setError({
+          headline: "Couldn't load apartment",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setLoading(false);
+        return;
+      }
+      const data = await res.json();
+      setApartment(data);
+      setError(null);
 
-    const name = getCookieValue("flatpare-name") ?? "";
-    setUserName(name);
+      const name = getCookieValue("flatpare-name") ?? "";
+      setUserName(name);
 
-    const existing = data.ratings?.find(
-      (r: Rating) => r.userName === name
-    );
-    if (existing) {
-      setMyRating({
-        kitchen: existing.kitchen,
-        balconies: existing.balconies,
-        location: existing.location,
-        floorplan: existing.floorplan,
-        overallFeeling: existing.overallFeeling,
-        comment: existing.comment || "",
+      const existing = data.ratings?.find(
+        (r: Rating) => r.userName === name
+      );
+      if (existing) {
+        setMyRating({
+          kitchen: existing.kitchen,
+          balconies: existing.balconies,
+          location: existing.location,
+          floorplan: existing.floorplan,
+          overallFeeling: existing.overallFeeling,
+          comment: existing.comment || "",
+        });
+      }
+
+      setLoading(false);
+    } catch (err) {
+      setError({
+        headline: "Couldn't load apartment",
+        details: fetchErrorFromException(err, url),
       });
+      setLoading(false);
     }
-
-    setLoading(false);
   }, [params.id]);
 
   useEffect(() => {
@@ -99,27 +129,73 @@ export default function ApartmentDetailPage() {
   async function handleDelete() {
     if (!confirm("Delete this apartment? This cannot be undone.")) return;
     setDeleting(true);
-    await fetch(`/api/apartments/${params.id}`, { method: "DELETE" });
-    router.push("/apartments");
+    const url = `/api/apartments/${params.id}`;
+    try {
+      const res = await fetch(url, { method: "DELETE" });
+      if (!res.ok) {
+        setError({
+          headline: "Couldn't delete apartment",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setDeleting(false);
+        return;
+      }
+      router.push("/apartments");
+    } catch (err) {
+      setError({
+        headline: "Couldn't delete apartment",
+        details: fetchErrorFromException(err, url),
+      });
+      setDeleting(false);
+    }
   }
 
   async function handleSaveRating() {
     setSaving(true);
-    await fetch(`/api/apartments/${params.id}/ratings`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(myRating),
-    });
-    await loadApartment();
-    setSaving(false);
+    const url = `/api/apartments/${params.id}/ratings`;
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(myRating),
+      });
+      if (!res.ok) {
+        setError({
+          headline: "Couldn't save rating",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setSaving(false);
+        return;
+      }
+      await loadApartment();
+      setSaving(false);
+    } catch (err) {
+      setError({
+        headline: "Couldn't save rating",
+        details: fetchErrorFromException(err, url),
+      });
+      setSaving(false);
+    }
   }
 
-  if (loading || !apartment) {
+  if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
         <p className="text-muted-foreground">Loading...</p>
       </div>
     );
+  }
+
+  if (error && !apartment) {
+    return (
+      <div className="py-8">
+        <ErrorDisplay headline={error.headline} details={error.details} />
+      </div>
+    );
+  }
+
+  if (!apartment) {
+    return null;
   }
 
   const otherRatings = apartment.ratings.filter(
@@ -170,6 +246,10 @@ export default function ApartmentDetailPage() {
           </Button>
         </div>
       </div>
+
+      {error && (
+        <ErrorDisplay headline={error.headline} details={error.details} />
+      )}
 
       {/* Apartment metrics */}
       <div className="flex flex-wrap gap-2">

--- a/src/app/apartments/new/page.tsx
+++ b/src/app/apartments/new/page.tsx
@@ -8,6 +8,17 @@ import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  type ErrorDetails,
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+} from "@/lib/fetch-error";
+
+interface ErrorState {
+  headline: string;
+  details?: ErrorDetails;
+}
 
 type ApartmentForm = {
   name: string;
@@ -102,7 +113,7 @@ export default function UploadPage() {
   const [items, setItems] = useState<UploadItem[]>([]);
   const [singleForm, setSingleForm] = useState<ApartmentForm>(emptyForm);
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
+  const [error, setError] = useState<ErrorState | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const processingRef = useRef(false);
 
@@ -125,7 +136,7 @@ export default function UploadPage() {
   const processFiles = useCallback(async (files: File[]) => {
     const pdfFiles = files.filter((f) => f.type === "application/pdf");
     if (pdfFiles.length === 0) {
-      setError("No PDF files selected");
+      setError({ headline: "No PDF files selected" });
       return;
     }
 
@@ -141,7 +152,7 @@ export default function UploadPage() {
 
     setItems(newItems);
     setStep("processing");
-    setError("");
+    setError(null);
     processingRef.current = true;
 
     // Process sequentially to avoid overwhelming the API
@@ -263,12 +274,12 @@ export default function UploadPage() {
     );
 
     if (toSave.length === 0) {
-      setError("No apartments to save");
+      setError({ headline: "No apartments to save" });
       return;
     }
 
     setSaving(true);
-    setError("");
+    setError(null);
 
     for (const item of toSave) {
       try {
@@ -308,27 +319,39 @@ export default function UploadPage() {
   async function handleSaveSingle(e: React.FormEvent) {
     e.preventDefault();
     if (!singleForm.name.trim()) {
-      setError("Name is required");
+      setError({ headline: "Name is required" });
       return;
     }
 
     setSaving(true);
-    setError("");
+    setError(null);
 
-    const res = await fetch("/api/apartments", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(formToPayload(singleForm)),
-    });
+    const url = "/api/apartments";
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formToPayload(singleForm)),
+      });
 
-    if (!res.ok) {
-      setError("Failed to save apartment");
+      if (!res.ok) {
+        setError({
+          headline: "Failed to save apartment",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setSaving(false);
+        return;
+      }
+
+      const apartment = await res.json();
+      router.push(`/apartments/${apartment.id}`);
+    } catch (err) {
+      setError({
+        headline: "Failed to save apartment",
+        details: fetchErrorFromException(err, url),
+      });
       setSaving(false);
-      return;
     }
-
-    const apartment = await res.json();
-    router.push(`/apartments/${apartment.id}`);
   }
 
   // --- Upload step ---
@@ -375,7 +398,9 @@ export default function UploadPage() {
           </Button>
         </div>
 
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && (
+          <ErrorDisplay headline={error.headline} details={error.details} />
+        )}
 
         <div className="text-center">
           <Button
@@ -457,7 +482,9 @@ export default function UploadPage() {
           </p>
         )}
 
-        {error && <p className="text-sm text-destructive">{error}</p>}
+        {error && (
+          <ErrorDisplay headline={error.headline} details={error.details} />
+        )}
 
         <div className="space-y-3">
           {items.map((item) => {
@@ -558,7 +585,9 @@ export default function UploadPage() {
               }
             />
 
-            {error && <p className="text-sm text-destructive">{error}</p>}
+            {error && (
+          <ErrorDisplay headline={error.headline} details={error.details} />
+        )}
 
             <div className="flex gap-2">
               <Button type="submit" className="flex-1" disabled={saving}>

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -7,6 +7,17 @@ import { buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StarRating } from "@/components/star-rating";
 import { Building2 } from "lucide-react";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  type ErrorDetails,
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+} from "@/lib/fetch-error";
+
+interface ErrorState {
+  headline: string;
+  details?: ErrorDetails;
+}
 
 interface ApartmentSummary {
   id: number;
@@ -22,20 +33,46 @@ interface ApartmentSummary {
 export default function ApartmentsPage() {
   const [apartments, setApartments] = useState<ApartmentSummary[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ErrorState | null>(null);
 
   useEffect(() => {
-    fetch("/api/apartments")
-      .then((res) => res.json())
-      .then((data) => {
+    const url = "/api/apartments";
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          setError({
+            headline: "Couldn't load apartments",
+            details: await fetchErrorFromResponse(res, url),
+          });
+          setLoading(false);
+          return;
+        }
+        const data = (await res.json()) as ApartmentSummary[];
         setApartments(data);
         setLoading(false);
-      });
+      } catch (err) {
+        setError({
+          headline: "Couldn't load apartments",
+          details: fetchErrorFromException(err, url),
+        });
+        setLoading(false);
+      }
+    })();
   }, []);
 
   if (loading) {
     return (
       <div className="flex items-center justify-center py-20">
         <p className="text-muted-foreground">Loading apartments...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-8">
+        <ErrorDisplay headline={error.headline} details={error.details} />
       </div>
     );
   }

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -6,6 +6,17 @@ import { Button, buttonVariants } from "@/components/ui/button";
 import { StarRating } from "@/components/star-rating";
 import { cn } from "@/lib/utils";
 import { BarChart3 } from "lucide-react";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  type ErrorDetails,
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+} from "@/lib/fetch-error";
+
+interface ErrorState {
+  headline: string;
+  details?: ErrorDetails;
+}
 
 interface ApartmentWithRatings {
   id: number;
@@ -52,22 +63,47 @@ export default function ComparePage() {
   const [apartments, setApartments] = useState<ApartmentWithRatings[]>([]);
   const [hiddenIds, setHiddenIds] = useState<Set<number>>(new Set());
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ErrorState | null>(null);
 
   useEffect(() => {
     async function load() {
-      const res = await fetch("/api/apartments");
-      const list = await res.json();
+      const listUrl = "/api/apartments";
+      try {
+        const res = await fetch(listUrl);
+        if (!res.ok) {
+          setError({
+            headline: "Couldn't load comparison data",
+            details: await fetchErrorFromResponse(res, listUrl),
+          });
+          setLoading(false);
+          return;
+        }
+        const list = (await res.json()) as { id: number }[];
 
-      // Fetch full details for each apartment
-      const details = await Promise.all(
-        list.map(async (apt: { id: number }) => {
-          const r = await fetch(`/api/apartments/${apt.id}`);
-          return r.json();
-        })
-      );
+        const details: ApartmentWithRatings[] = [];
+        for (const apt of list) {
+          const detailUrl = `/api/apartments/${apt.id}`;
+          const r = await fetch(detailUrl);
+          if (!r.ok) {
+            setError({
+              headline: "Couldn't load comparison data",
+              details: await fetchErrorFromResponse(r, detailUrl),
+            });
+            setLoading(false);
+            return;
+          }
+          details.push(await r.json());
+        }
 
-      setApartments(details);
-      setLoading(false);
+        setApartments(details);
+        setLoading(false);
+      } catch (err) {
+        setError({
+          headline: "Couldn't load comparison data",
+          details: fetchErrorFromException(err, listUrl),
+        });
+        setLoading(false);
+      }
     }
     load();
   }, []);
@@ -76,6 +112,14 @@ export default function ComparePage() {
     return (
       <div className="flex items-center justify-center py-20">
         <p className="text-muted-foreground">Loading comparison...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="py-8">
+        <ErrorDisplay headline={error.headline} details={error.details} />
       </div>
     );
   }

--- a/src/app/costs/page.tsx
+++ b/src/app/costs/page.tsx
@@ -3,6 +3,17 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  type ErrorDetails,
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+} from "@/lib/fetch-error";
+
+interface ErrorState {
+  headline: string;
+  details?: ErrorDetails;
+}
 
 interface CostsData {
   gemini: {
@@ -35,14 +46,32 @@ function formatUsd(n: number): string {
 export default function CostsPage() {
   const [data, setData] = useState<CostsData | null>(null);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ErrorState | null>(null);
 
   useEffect(() => {
-    fetch("/api/costs")
-      .then((r) => r.json())
-      .then((d) => {
+    const url = "/api/costs";
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (!res.ok) {
+          setError({
+            headline: "Couldn't load cost data",
+            details: await fetchErrorFromResponse(res, url),
+          });
+          setLoading(false);
+          return;
+        }
+        const d = (await res.json()) as CostsData;
         setData(d);
         setLoading(false);
-      });
+      } catch (err) {
+        setError({
+          headline: "Couldn't load cost data",
+          details: fetchErrorFromException(err, url),
+        });
+        setLoading(false);
+      }
+    })();
   }, []);
 
   if (loading) {
@@ -53,10 +82,13 @@ export default function CostsPage() {
     );
   }
 
-  if (!data) {
+  if (error || !data) {
     return (
-      <div className="flex items-center justify-center py-20">
-        <p className="text-muted-foreground">Failed to load cost data</p>
+      <div className="py-8">
+        <ErrorDisplay
+          headline={error?.headline ?? "Couldn't load cost data"}
+          details={error?.details}
+        />
       </div>
     );
   }

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { ErrorDisplay } from "@/components/error-display";
+
+interface ErrorBoundaryProps {
+  error: Error & { digest?: string };
+  unstable_retry: () => void;
+}
+
+export default function ErrorBoundary({ error, unstable_retry }: ErrorBoundaryProps) {
+  useEffect(() => {
+    console.error("[error.tsx]", error);
+  }, [error]);
+
+  return (
+    <div className="flex-1 flex items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <h1 className="text-lg font-semibold">Something went wrong</h1>
+          <p className="text-sm text-muted-foreground">
+            The page couldn&apos;t load. You can retry, or expand the details below
+            to see what happened.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <ErrorDisplay
+            headline={error.message || "Unexpected error"}
+            details={{
+              message: error.message,
+              stack: error.stack,
+              url: error.digest ? `digest: ${error.digest}` : undefined,
+              timestamp: new Date().toISOString(),
+            }}
+          />
+          <Button onClick={() => unstable_retry()} className="w-full">
+            Try again
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,17 @@ import { Card, CardContent, CardHeader } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  type ErrorDetails,
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+} from "@/lib/fetch-error";
+
+interface ErrorState {
+  headline: string;
+  details?: ErrorDetails;
+}
 
 export default function LoginPage() {
   const router = useRouter();
@@ -15,7 +26,7 @@ export default function LoginPage() {
   const [displayName, setDisplayName] = useState("");
   const [existingUsers, setExistingUsers] = useState<string[]>([]);
   const [showNewUserInput, setShowNewUserInput] = useState(false);
-  const [error, setError] = useState("");
+  const [error, setError] = useState<ErrorState | null>(null);
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
@@ -32,42 +43,66 @@ export default function LoginPage() {
 
   async function handlePassword(e: React.FormEvent) {
     e.preventDefault();
-    setError("");
+    setError(null);
     setLoading(true);
 
-    const res = await fetch("/api/auth", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ password }),
-    });
+    const url = "/api/auth";
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ password }),
+      });
 
-    if (!res.ok) {
-      setError("Wrong password");
+      if (!res.ok) {
+        setError({
+          headline: "Wrong password",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setLoading(false);
+        return;
+      }
+
       setLoading(false);
-      return;
+      setStep("name");
+    } catch (err) {
+      setError({
+        headline: "Couldn't reach the server",
+        details: fetchErrorFromException(err, url),
+      });
+      setLoading(false);
     }
-
-    setLoading(false);
-    setStep("name");
   }
 
   async function selectUser(name: string) {
-    setError("");
+    setError(null);
     setLoading(true);
 
-    const res = await fetch("/api/auth/name", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ displayName: name }),
-    });
+    const url = "/api/auth/name";
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ displayName: name }),
+      });
 
-    if (!res.ok) {
-      setError("Failed to set name");
+      if (!res.ok) {
+        setError({
+          headline: "Failed to set name",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setLoading(false);
+        return;
+      }
+
+      router.push("/apartments");
+    } catch (err) {
+      setError({
+        headline: "Couldn't reach the server",
+        details: fetchErrorFromException(err, url),
+      });
       setLoading(false);
-      return;
     }
-
-    router.push("/apartments");
   }
 
   async function handleNewName(e: React.FormEvent) {
@@ -111,7 +146,7 @@ export default function LoginPage() {
                 />
               </div>
               {error && (
-                <p className="text-sm text-destructive">{error}</p>
+                <ErrorDisplay headline={error.headline} details={error.details} />
               )}
               <Button type="submit" className="w-full" disabled={loading}>
                 {loading ? "Checking..." : "Continue"}
@@ -165,7 +200,7 @@ export default function LoginPage() {
                     />
                   </div>
                   {error && (
-                    <p className="text-sm text-destructive">{error}</p>
+                    <ErrorDisplay headline={error.headline} details={error.details} />
                   )}
                   <div className="flex gap-2">
                     {existingUsers.length > 0 && (

--- a/src/components/__tests__/error-display.test.tsx
+++ b/src/components/__tests__/error-display.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { ErrorDisplay } from "@/components/error-display";
+
+afterEach(cleanup);
+
+describe("<ErrorDisplay />", () => {
+  it("renders the headline", () => {
+    render(<ErrorDisplay headline="Something went wrong" />);
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+  });
+
+  it("does not show a details section when details prop is absent", () => {
+    render(<ErrorDisplay headline="Just a headline" />);
+    expect(screen.queryByText("Show details")).not.toBeInTheDocument();
+  });
+
+  it("renders a collapsible details section when details are provided", () => {
+    render(
+      <ErrorDisplay
+        headline="Couldn't load apartments"
+        details={{
+          status: 500,
+          url: "/api/apartments",
+          message: "database down",
+          timestamp: "2026-04-22T10:00:00.000Z",
+        }}
+      />
+    );
+    expect(screen.getByText("Show details")).toBeInTheDocument();
+    expect(screen.getByText("500")).toBeInTheDocument();
+    expect(screen.getByText("/api/apartments")).toBeInTheDocument();
+    expect(screen.getByText("database down")).toBeInTheDocument();
+  });
+
+  it("includes the stack when provided", () => {
+    render(
+      <ErrorDisplay
+        headline="Boom"
+        details={{
+          message: "boom",
+          stack: "Error: boom\n  at foo.ts:1",
+          timestamp: "2026-04-22T10:00:00.000Z",
+        }}
+      />
+    );
+    expect(screen.getByText(/at foo\.ts:1/)).toBeInTheDocument();
+  });
+
+  describe("copy button", () => {
+    beforeEach(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: vi.fn().mockResolvedValue(undefined) },
+        configurable: true,
+      });
+    });
+
+    it("copies a serialized block to the clipboard", async () => {
+      const writeText = navigator.clipboard.writeText as ReturnType<typeof vi.fn>;
+      render(
+        <ErrorDisplay
+          headline="Couldn't load"
+          details={{
+            status: 500,
+            url: "/api/x",
+            message: "nope",
+            timestamp: "2026-04-22T10:00:00.000Z",
+          }}
+        />
+      );
+      const btn = screen.getByRole("button", { name: /copy details/i });
+      fireEvent.click(btn);
+      expect(writeText).toHaveBeenCalledTimes(1);
+      const payload = writeText.mock.calls[0][0] as string;
+      expect(payload).toContain("Couldn't load");
+      expect(payload).toContain("Status: 500");
+      expect(payload).toContain("URL: /api/x");
+    });
+
+    it("does not throw when clipboard API is unavailable", () => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: {
+          writeText: vi.fn().mockRejectedValue(new Error("denied")),
+        },
+        configurable: true,
+      });
+      render(
+        <ErrorDisplay
+          headline="Boom"
+          details={{ timestamp: "2026-04-22T10:00:00.000Z" }}
+        />
+      );
+      const btn = screen.getByRole("button", { name: /copy details/i });
+      expect(() => fireEvent.click(btn)).not.toThrow();
+    });
+  });
+});

--- a/src/components/error-display.tsx
+++ b/src/components/error-display.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useState } from "react";
+import { Copy, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  type ErrorDetails,
+  serializeErrorDetails,
+} from "@/lib/fetch-error";
+
+interface ErrorDisplayProps {
+  headline: string;
+  details?: ErrorDetails;
+  className?: string;
+}
+
+export function ErrorDisplay({ headline, details, className }: ErrorDisplayProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    if (!details) return;
+    const text = serializeErrorDetails(headline, details);
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard API unavailable (non-HTTPS, older browsers) — silently no-op.
+    }
+  }
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm",
+        className
+      )}
+    >
+      <p className="text-destructive">{headline}</p>
+      {details && (
+        <details className="mt-2 text-xs">
+          <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+            Show details
+          </summary>
+          <div className="mt-2 space-y-1 font-mono text-muted-foreground">
+            {details.status !== undefined && (
+              <div>
+                <span className="text-foreground/80">Status:</span> {details.status}
+              </div>
+            )}
+            {details.url && (
+              <div className="break-all">
+                <span className="text-foreground/80">URL:</span> {details.url}
+              </div>
+            )}
+            {details.message && (
+              <div className="break-words">
+                <span className="text-foreground/80">Message:</span>{" "}
+                {details.message}
+              </div>
+            )}
+            <div>
+              <span className="text-foreground/80">Time:</span>{" "}
+              {details.timestamp}
+            </div>
+            {details.stack && (
+              <pre className="mt-2 max-h-48 overflow-auto whitespace-pre-wrap rounded bg-muted p-2 text-[11px] leading-tight">
+                {details.stack}
+              </pre>
+            )}
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="mt-2 inline-flex items-center gap-1 rounded border border-border px-2 py-1 text-xs text-foreground/80 hover:bg-accent"
+            >
+              {copied ? (
+                <>
+                  <Check className="h-3 w-3" />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy className="h-3 w-3" />
+                  Copy details
+                </>
+              )}
+            </button>
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/src/lib/__tests__/fetch-error.test.ts
+++ b/src/lib/__tests__/fetch-error.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  fetchErrorFromResponse,
+  fetchErrorFromException,
+  serializeErrorDetails,
+} from "@/lib/fetch-error";
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function textResponse(status: number, body: string): Response {
+  return new Response(body, {
+    status,
+    headers: { "content-type": "text/plain" },
+  });
+}
+
+describe("fetchErrorFromResponse", () => {
+  it("extracts the `error` field from a JSON body", async () => {
+    const res = jsonResponse(500, { error: "database connection failed" });
+    const details = await fetchErrorFromResponse(res, "/api/apartments");
+    expect(details.status).toBe(500);
+    expect(details.url).toBe("/api/apartments");
+    expect(details.message).toBe("database connection failed");
+    expect(details.timestamp).toMatch(/^\d{4}-/);
+  });
+
+  it("falls back to text body when response is not JSON", async () => {
+    const res = textResponse(502, "Bad Gateway from upstream");
+    const details = await fetchErrorFromResponse(res, "/api/foo");
+    expect(details.status).toBe(502);
+    expect(details.message).toBe("Bad Gateway from upstream");
+  });
+
+  it("falls back to statusText when there's no body", async () => {
+    const res = new Response(null, { status: 404, statusText: "Not Found" });
+    const details = await fetchErrorFromResponse(res, "/api/missing");
+    expect(details.status).toBe(404);
+    expect(details.message).toBe("Not Found");
+  });
+
+  it("ignores non-string `error` fields", async () => {
+    const res = jsonResponse(500, { error: { nested: "object" } });
+    const details = await fetchErrorFromResponse(res, "/api/x");
+    expect(details.message).not.toBe("[object Object]");
+  });
+
+  it("truncates very long text bodies", async () => {
+    const longBody = "x".repeat(2000);
+    const res = textResponse(500, longBody);
+    const details = await fetchErrorFromResponse(res, "/api/x");
+    expect(details.message?.length).toBeLessThanOrEqual(500);
+  });
+});
+
+describe("fetchErrorFromException", () => {
+  it("captures message and stack from an Error", () => {
+    const err = new Error("network offline");
+    const details = fetchErrorFromException(err, "/api/foo");
+    expect(details.url).toBe("/api/foo");
+    expect(details.message).toBe("network offline");
+    expect(details.stack).toContain("network offline");
+  });
+
+  it("handles non-Error throws", () => {
+    const details = fetchErrorFromException("boom", "/api/foo");
+    expect(details.message).toBe("boom");
+    expect(details.stack).toBeUndefined();
+  });
+});
+
+describe("serializeErrorDetails", () => {
+  it("builds a readable multi-line block", () => {
+    const text = serializeErrorDetails("Couldn't load", {
+      status: 500,
+      url: "/api/x",
+      message: "nope",
+      timestamp: "2026-04-22T10:00:00.000Z",
+    });
+    expect(text).toContain("Couldn't load");
+    expect(text).toContain("Status: 500");
+    expect(text).toContain("URL: /api/x");
+    expect(text).toContain("Message: nope");
+    expect(text).toContain("Time: 2026-04-22T10:00:00.000Z");
+  });
+
+  it("omits missing fields", () => {
+    const text = serializeErrorDetails("Boom", {
+      timestamp: "2026-04-22T10:00:00.000Z",
+    });
+    expect(text).not.toContain("Status:");
+    expect(text).not.toContain("URL:");
+    expect(text).toContain("Time:");
+  });
+
+  it("includes stack when present", () => {
+    const text = serializeErrorDetails("Boom", {
+      timestamp: "2026-04-22T10:00:00.000Z",
+      stack: "Error: boom\n  at foo.ts:1",
+    });
+    expect(text).toContain("Stack:");
+    expect(text).toContain("at foo.ts:1");
+  });
+});

--- a/src/lib/fetch-error.ts
+++ b/src/lib/fetch-error.ts
@@ -1,0 +1,67 @@
+export interface ErrorDetails {
+  status?: number;
+  url?: string;
+  message?: string;
+  stack?: string;
+  timestamp: string;
+}
+
+export async function fetchErrorFromResponse(
+  res: Response,
+  url: string
+): Promise<ErrorDetails> {
+  let message: string | undefined;
+  try {
+    const cloned = res.clone();
+    const data = (await cloned.json()) as { error?: unknown };
+    if (typeof data?.error === "string") {
+      message = data.error;
+    }
+  } catch {
+    try {
+      const text = await res.clone().text();
+      if (text) message = text.slice(0, 500);
+    } catch {
+      // give up — status alone is the signal
+    }
+  }
+
+  return {
+    status: res.status,
+    url,
+    message: message ?? res.statusText ?? undefined,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function fetchErrorFromException(
+  err: unknown,
+  url: string
+): ErrorDetails {
+  if (err instanceof Error) {
+    return {
+      url,
+      message: err.message,
+      stack: err.stack,
+      timestamp: new Date().toISOString(),
+    };
+  }
+  return {
+    url,
+    message: String(err),
+    timestamp: new Date().toISOString(),
+  };
+}
+
+export function serializeErrorDetails(
+  headline: string,
+  details: ErrorDetails
+): string {
+  const lines = [headline];
+  if (details.status !== undefined) lines.push(`Status: ${details.status}`);
+  if (details.url) lines.push(`URL: ${details.url}`);
+  if (details.message) lines.push(`Message: ${details.message}`);
+  if (details.timestamp) lines.push(`Time: ${details.timestamp}`);
+  if (details.stack) lines.push("", "Stack:", details.stack);
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary

Replaces bare error strings (`"This page couldn't load"`, `"Failed to set name"`, etc.) with a reusable `ErrorDisplay` component that shows a human-friendly headline plus a collapsible "Show details" section with technical context — status, URL, message, stack (when available), timestamp, and a **Copy details** button.

Also adds `src/app/error.tsx`, the Next.js route-level error boundary that was missing. That's the direct source of the "This page couldn't load" screen that issue #28 surfaced.

## Changes

### New

- `src/lib/fetch-error.ts` — normalized `ErrorDetails` shape plus three helpers:
  - `fetchErrorFromResponse(res, url)` pulls the `error` field from API JSON bodies (our routes already return `{ error: string }`), falls back to body text, then `statusText`.
  - `fetchErrorFromException(err, url)` handles caught exceptions (Error or other).
  - `serializeErrorDetails(headline, details)` for the copy-to-clipboard payload.
- `src/components/error-display.tsx` — destructive-styled alert with a native `<details>`. Closed by default. Copy button uses `navigator.clipboard` with a silent no-op fallback for non-HTTPS contexts.
- `src/app/error.tsx` — Client Component error boundary using Next.js 16's `unstable_retry` prop (new in v16.2.0). Passes `error.message`, `error.digest`, and `error.stack` into `ErrorDisplay`.
- Tests: `src/lib/__tests__/fetch-error.test.ts` (10 cases), `src/components/__tests__/error-display.test.tsx` (6 cases).

### Wired into existing call sites

Every fetch call site now captures a normalized error object and renders it via `ErrorDisplay`:

- `src/app/page.tsx` — login + name selection.
- `src/app/add-user/add-user-form.tsx`.
- `src/app/apartments/page.tsx` — list.
- `src/app/apartments/[id]/page.tsx` — load, save rating, delete.
- `src/app/apartments/new/page.tsx` — page-level errors (PDF validation, save). Per-item `StatusBadge` errors in the batch upload flow are unchanged.
- `src/app/compare/page.tsx`.
- `src/app/costs/page.tsx`.

## Testing

- `npm test` — **82 tests / 17 files passing**, up from 66/15 on main. Added 16 new tests, no existing tests touched.
- `npm run build` — TypeScript type-check passes. (Build's page-data collection fails locally because the worktree has no SQLite DB; compilation itself succeeds.)
- `npm run lint` — no new errors or warnings introduced. Pre-existing issues (tracked in #36) are unchanged.

## Design notes

- **Native `<details>`** instead of adding a shadcn `Collapsible`. Semantic, accessible for free, zero new deps.
- **Kept headlines human** (e.g. "Couldn't load apartments") — the technical noise is tucked behind the toggle.
- **`unstable_retry`** is the Next.js 16.2 way to recover; used it instead of the older `reset`.
- **Clipboard API** may be unavailable on non-HTTPS origins; the copy button silently no-ops in that case rather than throwing.

## Out of scope

- Fixing the pre-existing lint errors (tracked in #36).
- Per-item `StatusBadge` error UI in the batch upload flow — it uses a compact badge with tooltip and doesn't warrant the full panel treatment.

## Checklist

- [x] Tests pass (82 / 17)
- [x] TypeScript type-check passes
- [x] No new lint errors
- [x] Follows Next.js 16 `error.tsx` convention (Client Component + `unstable_retry`)

Closes #27