### PR TITLE
feat: explicit users table + inline user management in navbar

### DIFF
--- a/drizzle/0001_users_table.sql
+++ b/drizzle/0001_users_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS `users` (
+	`name` text PRIMARY KEY NOT NULL,
+	`created_at` integer DEFAULT (unixepoch())
+);
+--> statement-breakpoint
+INSERT OR IGNORE INTO `users` (`name`)
+  SELECT DISTINCT `user_name` FROM `ratings`;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,331 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "b2d95bb9-97c3-471c-a5a6-58c800f95f39",
+  "prevId": "1a6848e0-731a-4f91-9395-2275713a1699",
+  "tables": {
+    "apartments": {
+      "name": "apartments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_m2": {
+          "name": "size_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_rooms": {
+          "name": "num_rooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_bathrooms": {
+          "name": "num_bathrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_balconies": {
+          "name": "num_balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rent_chf": {
+          "name": "rent_chf",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_bike_min": {
+          "name": "distance_bike_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_transit_min": {
+          "name": "distance_transit_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_url": {
+          "name": "listing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_extracted_data": {
+          "name": "raw_extracted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_usage": {
+      "name": "api_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ratings": {
+      "name": "ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kitchen": {
+          "name": "kitchen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "balconies": {
+          "name": "balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "location": {
+          "name": "location",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "floorplan": {
+          "name": "floorplan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "overall_feeling": {
+          "name": "overall_feeling",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "ratings_apartment_user_idx": {
+          "name": "ratings_apartment_user_idx",
+          "columns": [
+            "apartment_id",
+            "user_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ratings_apartment_id_apartments_id_fk": {
+          "name": "ratings_apartment_id_apartments_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1776832975059,
       "tag": "0000_initial_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1776840392526,
+      "tag": "0001_users_table",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/__tests__/auth.test.ts
+++ b/src/app/api/__tests__/auth.test.ts
@@ -7,20 +7,37 @@ vi.mock("@/lib/auth", () => ({
   setDisplayName: vi.fn(async () => {}),
 }));
 
-// Mock db for users route
+// Mock db
+const usersSelectRows: { name: string }[] = [];
+let lastInsertValues: Record<string, unknown> | null = null;
+
 vi.mock("@/lib/db", () => ({
   db: {
-    selectDistinct: vi.fn(() => ({
-      from: vi.fn().mockResolvedValue([
-        { userName: "Alice" },
-        { userName: "Bob" },
-      ]),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        orderBy: vi.fn().mockResolvedValue(usersSelectRows),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((v: Record<string, unknown>) => {
+        lastInsertValues = v;
+        return { onConflictDoNothing: vi.fn().mockResolvedValue(undefined) };
+      }),
     })),
   },
 }));
 
 vi.mock("@/lib/db/schema", () => ({
+  users: { name: "name", createdAt: "created_at" },
   ratings: { userName: "user_name" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  asc: vi.fn((c) => c),
+  desc: vi.fn((c) => c),
+  eq: vi.fn(),
+  ne: vi.fn(),
+  avg: vi.fn(),
 }));
 
 import { POST as authPost } from "../../api/auth/route";
@@ -32,6 +49,8 @@ const mockedVerifyPassword = vi.mocked(verifyPassword);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  usersSelectRows.length = 0;
+  lastInsertValues = null;
 });
 
 afterEach(() => {
@@ -69,7 +88,7 @@ describe("POST /api/auth", () => {
 });
 
 describe("POST /api/auth/name", () => {
-  it("returns success for valid display name", async () => {
+  it("returns success and upserts the user", async () => {
     const req = new Request("http://localhost/api/auth/name", {
       method: "POST",
       body: JSON.stringify({ displayName: "Alice" }),
@@ -79,6 +98,18 @@ describe("POST /api/auth/name", () => {
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(data.success).toBe(true);
+    expect(lastInsertValues).toEqual({ name: "Alice" });
+  });
+
+  it("trims whitespace before inserting", async () => {
+    const req = new Request("http://localhost/api/auth/name", {
+      method: "POST",
+      body: JSON.stringify({ displayName: "  Bob  " }),
+    });
+
+    const res = await namePost(req);
+    expect(res.status).toBe(200);
+    expect(lastInsertValues).toEqual({ name: "Bob" });
   });
 
   it("returns 400 for empty display name", async () => {
@@ -103,7 +134,8 @@ describe("POST /api/auth/name", () => {
 });
 
 describe("GET /api/auth/users", () => {
-  it("returns sorted list of users", async () => {
+  it("returns list of users from the users table", async () => {
+    usersSelectRows.push({ name: "Alice" }, { name: "Bob" });
     const res = await usersGet();
     const data = await res.json();
     expect(data).toEqual(["Alice", "Bob"]);

--- a/src/app/api/auth/name/route.ts
+++ b/src/app/api/auth/name/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from "next/server";
 import { setDisplayName } from "@/lib/auth";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
 
 export async function POST(request: Request) {
   const { displayName } = await request.json();
@@ -8,6 +10,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Name is required" }, { status: 400 });
   }
 
-  await setDisplayName(displayName.trim());
+  const name = displayName.trim();
+
+  await db.insert(users).values({ name }).onConflictDoNothing();
+  await setDisplayName(name);
+
   return NextResponse.json({ success: true });
 }

--- a/src/app/api/auth/users/[name]/route.ts
+++ b/src/app/api/auth/users/[name]/route.ts
@@ -1,0 +1,50 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { db } from "@/lib/db";
+import { ratings, users } from "@/lib/db/schema";
+import { eq, ne, asc } from "drizzle-orm";
+import { setDisplayName } from "@/lib/auth";
+
+const NAME_COOKIE = "flatpare-name";
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ name: string }> }
+) {
+  try {
+    const { name: raw } = await params;
+    const name = decodeURIComponent(raw);
+
+    await db.delete(ratings).where(eq(ratings.userName, name));
+    await db.delete(users).where(eq(users.name, name));
+
+    const cookieStore = await cookies();
+    const currentName = cookieStore.get(NAME_COOKIE)?.value;
+    const isSelf = currentName === name;
+
+    if (!isSelf) {
+      return NextResponse.json({ switchedTo: undefined });
+    }
+
+    const [next] = await db
+      .select({ name: users.name })
+      .from(users)
+      .where(ne(users.name, name))
+      .orderBy(asc(users.createdAt))
+      .limit(1);
+
+    if (next) {
+      await setDisplayName(next.name);
+      return NextResponse.json({ switchedTo: next.name });
+    }
+
+    cookieStore.delete(NAME_COOKIE);
+    return NextResponse.json({ switchedTo: null });
+  } catch (error) {
+    console.error("[auth/users/[name]:DELETE] Error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to delete user" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/users/route.ts
+++ b/src/app/api/auth/users/route.ts
@@ -1,15 +1,15 @@
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
-import { ratings } from "@/lib/db/schema";
+import { users } from "@/lib/db/schema";
+import { asc } from "drizzle-orm";
 
 export async function GET() {
   try {
     const rows = await db
-      .selectDistinct({ userName: ratings.userName })
-      .from(ratings);
-
-    const users = rows.map((r) => r.userName).sort();
-    return NextResponse.json(users);
+      .select({ name: users.name })
+      .from(users)
+      .orderBy(asc(users.name));
+    return NextResponse.json(rows.map((r) => r.name));
   } catch (error) {
     console.error("[auth/users:GET] Error:", error);
     return NextResponse.json([], { status: 200 });

--- a/src/components/__tests__/nav-bar.test.tsx
+++ b/src/components/__tests__/nav-bar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, cleanup, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 
 const push = vi.fn();
 const refresh = vi.fn();
@@ -11,19 +12,43 @@ vi.mock("next/navigation", () => ({
 
 import { NavBar } from "../nav-bar";
 
+type FetchCall = { url: string; init: RequestInit };
+let fetchCalls: FetchCall[] = [];
+
+function mockFetch(
+  routes: Record<string, () => Partial<Response>> = {}
+) {
+  // Match longer (more specific) patterns first so `/api/auth/users/Alice`
+  // takes precedence over `/api/auth/users`.
+  const patterns = Object.entries(routes).sort(
+    ([a], [b]) => b.length - a.length
+  );
+  return vi.spyOn(global, "fetch").mockImplementation(((
+    input: RequestInfo,
+    init?: RequestInit
+  ) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    fetchCalls.push({ url, init: init ?? {} });
+    for (const [pattern, build] of patterns) {
+      if (url.includes(pattern)) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+          ...build(),
+        } as Response);
+      }
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response);
+  }) as typeof fetch);
+}
+
 beforeEach(() => {
   push.mockReset();
   refresh.mockReset();
-  vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
-    const url = typeof input === "string" ? input : (input as Request).url;
-    if (url.endsWith("/api/auth/users")) {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(["Alice", "Bob"]),
-      } as Response);
-    }
-    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
-  }) as typeof fetch);
+  fetchCalls = [];
 });
 
 afterEach(() => {
@@ -32,66 +57,131 @@ afterEach(() => {
 });
 
 describe("NavBar users dropdown", () => {
-  it("opens the users dropdown without throwing when a label is present", async () => {
-    await act(async () => {
-      render(<NavBar userName="Alice" />);
+  it("opens the dropdown and lists all users (including current with a 'you' marker)", async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      "/api/auth/users": () => ({
+        json: () => Promise.resolve(["Alice", "Bob"]),
+      }),
     });
 
-    const trigger = screen.getByRole("button", { name: /Alice/i });
+    render(<NavBar userName="Alice" />);
 
-    // Opening the menu would previously crash because DropdownMenuLabel
-    // (base-ui Menu.GroupLabel) requires a Menu.Group ancestor.
-    await act(async () => {
-      trigger.click();
-    });
+    await user.click(screen.getByRole("button", { name: /Alice/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("Switch user")).toBeInTheDocument();
+      expect(screen.getByText("Users")).toBeInTheDocument();
     });
-
-    // Other users (from mocked fetch, minus current) should render.
     expect(screen.getByText("Bob")).toBeInTheDocument();
+    expect(screen.getByText(/\(you\)/)).toBeInTheDocument();
   });
 
-  it("tolerates a non-array response from /api/auth/users without crashing", async () => {
-    vi.spyOn(global, "fetch").mockImplementation((() =>
-      Promise.resolve({
-        ok: true,
+  it("tolerates a non-array response from /api/auth/users", async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      "/api/auth/users": () => ({
         json: () => Promise.resolve({ error: "unexpected" }),
-      } as Response)) as typeof fetch);
-
-    await act(async () => {
-      render(<NavBar userName="Alice" />);
+      }),
     });
 
-    const trigger = screen.getByRole("button", { name: /Alice/i });
+    render(<NavBar userName="Alice" />);
 
-    await act(async () => {
-      trigger.click();
-    });
+    await user.click(screen.getByRole("button", { name: /Alice/i }));
 
     await waitFor(() => {
-      expect(screen.getByText("Switch user")).toBeInTheDocument();
+      expect(screen.getByText("Users")).toBeInTheDocument();
     });
-
-    expect(screen.getByText("No other users")).toBeInTheDocument();
+    expect(screen.getByText("No users")).toBeInTheDocument();
   });
 
   it("navigates to /add-user when 'Add new user' is clicked", async () => {
-    await act(async () => {
-      render(<NavBar userName="Alice" />);
+    const user = userEvent.setup();
+    mockFetch({
+      "/api/auth/users": () => ({
+        json: () => Promise.resolve(["Alice"]),
+      }),
     });
 
-    const trigger = screen.getByRole("button", { name: /Alice/i });
-    await act(async () => {
-      trigger.click();
-    });
+    render(<NavBar userName="Alice" />);
 
-    const addItem = await screen.findByText("Add new user");
-    await act(async () => {
-      addItem.click();
-    });
+    await user.click(screen.getByRole("button", { name: /Alice/i }));
+    await user.click(await screen.findByText("Add new user"));
 
     expect(push).toHaveBeenCalledWith("/add-user");
+  });
+
+  it("clicking another user POSTs /api/auth/name and refreshes", async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      "/api/auth/users": () => ({
+        json: () => Promise.resolve(["Alice", "Bob"]),
+      }),
+    });
+
+    render(<NavBar userName="Alice" />);
+
+    await user.click(screen.getByRole("button", { name: /Alice/i }));
+    await user.click(await screen.findByText("Bob"));
+
+    await waitFor(() => {
+      const postCall = fetchCalls.find(
+        (c) => c.url.endsWith("/api/auth/name") && c.init.method === "POST"
+      );
+      expect(postCall?.init.body).toBe(
+        JSON.stringify({ displayName: "Bob" })
+      );
+    });
+    expect(refresh).toHaveBeenCalled();
+  });
+
+  it("clicking the ✕ on another user DELETEs them and refreshes", async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      "/api/auth/users": () => ({
+        json: () => Promise.resolve(["Alice", "Bob"]),
+      }),
+      "/api/auth/users/Bob": () => ({
+        json: () => Promise.resolve({ switchedTo: undefined }),
+      }),
+    });
+
+    render(<NavBar userName="Alice" />);
+
+    await user.click(screen.getByRole("button", { name: /Alice/i }));
+    await user.click(
+      await screen.findByRole("button", { name: /Delete Bob/i })
+    );
+
+    await waitFor(() => {
+      const del = fetchCalls.find(
+        (c) => c.url.endsWith("/api/auth/users/Bob") && c.init.method === "DELETE"
+      );
+      expect(del).toBeDefined();
+    });
+    expect(refresh).toHaveBeenCalled();
+    expect(push).not.toHaveBeenCalled();
+  });
+
+  it("deleting the last user navigates home", async () => {
+    const user = userEvent.setup();
+    mockFetch({
+      "/api/auth/users": () => ({
+        json: () => Promise.resolve(["Alice"]),
+      }),
+      "/api/auth/users/Alice": () => ({
+        json: () => Promise.resolve({ switchedTo: null }),
+      }),
+    });
+
+    render(<NavBar userName="Alice" />);
+
+    await user.click(screen.getByRole("button", { name: /Alice/i }));
+    await user.click(
+      await screen.findByRole("button", { name: /Delete Alice/i })
+    );
+
+    await waitFor(() => {
+      expect(push).toHaveBeenCalledWith("/");
+    });
   });
 });

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -6,7 +6,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
 import { ThemeToggle } from "@/components/theme-toggle";
-import { ChevronDown, Plus, User } from "lucide-react";
+import { ChevronDown, Plus, User, X } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -38,6 +38,7 @@ export function NavBar({ userName }: { userName: string }) {
   }, []);
 
   async function switchUser(name: string) {
+    if (name === userName) return;
     await fetch("/api/auth/name", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -46,7 +47,19 @@ export function NavBar({ userName }: { userName: string }) {
     router.refresh();
   }
 
-  const otherUsers = users.filter((u) => u !== userName);
+  async function deleteUser(name: string) {
+    const res = await fetch(
+      `/api/auth/users/${encodeURIComponent(name)}`,
+      { method: "DELETE" }
+    );
+    if (!res.ok) return;
+    const data = (await res.json()) as { switchedTo?: string | null };
+    if (data.switchedTo === null) {
+      router.push("/");
+    } else {
+      router.refresh();
+    }
+  }
 
   return (
     <header className="border-b bg-background">
@@ -87,20 +100,42 @@ export function NavBar({ userName }: { userName: string }) {
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" side="bottom" sideOffset={4}>
               <DropdownMenuGroup>
-                <DropdownMenuLabel>Switch user</DropdownMenuLabel>
-                {otherUsers.map((name) => (
+                <DropdownMenuLabel>Users</DropdownMenuLabel>
+                {users.map((name) => (
                   <DropdownMenuItem
                     key={name}
                     onClick={() => switchUser(name)}
+                    className="flex items-center justify-between gap-2"
                   >
-                    {name}
+                    <span
+                      className={cn(
+                        "flex-1",
+                        name === userName && "font-medium"
+                      )}
+                    >
+                      {name}
+                      {name === userName && (
+                        <span className="ml-1 text-xs text-muted-foreground">
+                          (you)
+                        </span>
+                      )}
+                    </span>
+                    <button
+                      type="button"
+                      aria-label={`Delete ${name}`}
+                      className="rounded p-0.5 text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        deleteUser(name);
+                      }}
+                    >
+                      <X className="h-3 w-3" />
+                    </button>
                   </DropdownMenuItem>
                 ))}
-                {otherUsers.length === 0 && (
+                {users.length === 0 && (
                   <DropdownMenuItem disabled>
-                    <span className="text-muted-foreground">
-                      No other users
-                    </span>
+                    <span className="text-muted-foreground">No users</span>
                   </DropdownMenuItem>
                 )}
               </DropdownMenuGroup>

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -25,12 +25,13 @@ describe("applyMigrations", () => {
     expect(await columnNames(client, "apartments")).toContain("listing_url");
     expect(await columnNames(client, "ratings")).toContain("user_name");
     expect(await columnNames(client, "api_usage")).toContain("service");
+    expect(await columnNames(client, "users")).toContain("name");
 
     const migrations = await client.execute({
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(1);
+    expect(migrations.rows).toHaveLength(2);
   });
 
   it("adds listing_url to a legacy database missing the column", async () => {
@@ -62,6 +63,45 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(1);
+    expect(migrations.rows).toHaveLength(2);
+  });
+
+  it("backfills the users table from distinct rating user_names", async () => {
+    const client = createClient({ url: ":memory:" });
+
+    // Simulate a DB that already has ratings (from before the users table
+    // existed): run only the first migration manually, then add some data.
+    await client.execute({
+      sql: `CREATE TABLE apartments (
+        id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        name text NOT NULL,
+        listing_url text
+      )`,
+      args: [],
+    });
+    await client.execute({
+      sql: `CREATE TABLE ratings (
+        id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        apartment_id integer NOT NULL,
+        user_name text NOT NULL
+      )`,
+      args: [],
+    });
+    await client.execute({
+      sql: "INSERT INTO apartments (name) VALUES ('A'), ('B')",
+      args: [],
+    });
+    await client.execute({
+      sql: "INSERT INTO ratings (apartment_id, user_name) VALUES (1, 'Alice'), (1, 'Bob'), (2, 'Alice')",
+      args: [],
+    });
+
+    await applyMigrations(client);
+
+    const rows = await client.execute({
+      sql: "SELECT name FROM users ORDER BY name",
+      args: [],
+    });
+    expect(rows.rows.map((r) => r.name)).toEqual(["Alice", "Bob"]);
   });
 });

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -52,6 +52,13 @@ export const ratings = sqliteTable(
   ]
 );
 
+export const users = sqliteTable("users", {
+  name: text("name").primaryKey().notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(
+    sql`(unixepoch())`
+  ),
+});
+
 export const apiUsage = sqliteTable("api_usage", {
   id: integer("id").primaryKey({ autoIncrement: true }),
   service: text("service").notNull(), // "gemini" | "google_maps"
@@ -67,4 +74,6 @@ export type Apartment = typeof apartments.$inferSelect;
 export type NewApartment = typeof apartments.$inferInsert;
 export type Rating = typeof ratings.$inferSelect;
 export type NewRating = typeof ratings.$inferInsert;
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
 export type ApiUsage = typeof apiUsage.$inferSelect;


### PR DESCRIPTION
## Summary

Fixes the "I can't see other users even though I added them" bug and adds inline user management.

Users were previously derived from `SELECT DISTINCT user_name FROM ratings`, so anyone who joined via `/add-user` but hadn't rated an apartment yet was invisible in the dropdown. There was also no way to remove a user.

## Changes

### Database
- **Schema**: new `users(name TEXT PRIMARY KEY, created_at INTEGER)` in `src/lib/db/schema.ts`.
- **Migration `drizzle/0001_users_table.sql`**: `CREATE TABLE IF NOT EXISTS` + `INSERT OR IGNORE INTO users SELECT DISTINCT user_name FROM ratings` — idempotent; backfills existing deployments (including Turso on next deploy).

### API
- `GET /api/auth/users` — reads from `users` ordered by name (was: distinct from ratings).
- `POST /api/auth/name` — upserts into `users` before setting the cookie, so every display-name-set registers the user.
- `DELETE /api/auth/users/[name]` **(new)**:
  - Cascades: removes `ratings WHERE user_name = X` and `users WHERE name = X`.
  - Three self-delete branches:
    - **Another user**: `{ switchedTo: undefined }` — client just `router.refresh()`.
    - **Self with others remaining**: switches name cookie to the oldest other user, returns `{ switchedTo: "<name>" }`.
    - **Self as the last user**: clears the name cookie, returns `{ switchedTo: null }`.

### Frontend
- `src/components/nav-bar.tsx`: dropdown lists **all** users with a "(you)" marker on the current one and an ✕ delete button per row (with `stopPropagation` so it doesn't trigger the switch). On last-user deletion → `router.push("/")`; otherwise `router.refresh()`.

### Tests (87/87 passing, was 82)
- `src/lib/db/__tests__/migrate.test.ts`:
  - Updated existing expectations for 2 migrations.
  - New test: backfill populates `users` with distinct names from pre-existing ratings rows.
- `src/app/api/__tests__/auth.test.ts`:
  - Updated `GET` mock to read from `users`.
  - New test: `POST /api/auth/name` upserts and trims whitespace.
- `src/components/__tests__/nav-bar.test.tsx`:
  - Updated for the new "Users" label, "(you)" marker, and all-users listing.
  - New: switch POST flow, ✕-deletes-other-user, last-user-delete navigates home.

## Smoke-tested end-to-end in Docker
- ✅ Add user → appears in list immediately.
- ✅ Delete other user → ratings cascade, user gone.
- ✅ Self-delete with another user → auto-switches cookie.
- ✅ Self-delete as last user → cookie cleared, client sent to `/`.

## Out of scope
- Login page (`/`) polish so the password step is skipped when already authed. Happy to do as a follow-up if the re-prompt after last-user-delete is annoying.