### PR TITLE
fix: add missing 0002_has_washing_machine migration

### DIFF
--- a/drizzle/0000_initial_schema.sql
+++ b/drizzle/0000_initial_schema.sql
@@ -6,7 +6,6 @@ CREATE TABLE IF NOT EXISTS `apartments` (
 	`num_rooms` real,
 	`num_bathrooms` integer,
 	`num_balconies` integer,
-	`has_washing_machine` integer,
 	`rent_chf` real,
 	`distance_bike_min` integer,
 	`distance_transit_min` integer,

--- a/drizzle/0002_has_washing_machine.sql
+++ b/drizzle/0002_has_washing_machine.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `apartments` ADD `has_washing_machine` integer;

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,8 +1,8 @@
 {
   "version": "6",
   "dialect": "sqlite",
-  "id": "1a6848e0-731a-4f91-9395-2275713a1699",
-  "prevId": "00000000-0000-0000-0000-000000000000",
+  "id": "6ed342f7-6d32-4031-af43-d337f17fb3ec",
+  "prevId": "b2d95bb9-97c3-471c-a5a6-58c800f95f39",
   "tables": {
     "apartments": {
       "name": "apartments",
@@ -51,6 +51,13 @@
         },
         "num_balconies": {
           "name": "num_balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_washing_machine": {
+          "name": "has_washing_machine",
           "type": "integer",
           "primaryKey": false,
           "notNull": false,
@@ -288,6 +295,31 @@
           "onUpdate": "no action"
         }
       },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "checkConstraints": {}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1776840392526,
       "tag": "0001_users_table",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1776849182678,
+      "tag": "0002_has_washing_machine",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -23,6 +23,9 @@ describe("applyMigrations", () => {
     await applyMigrations(client);
 
     expect(await columnNames(client, "apartments")).toContain("listing_url");
+    expect(await columnNames(client, "apartments")).toContain(
+      "has_washing_machine"
+    );
     expect(await columnNames(client, "ratings")).toContain("user_name");
     expect(await columnNames(client, "api_usage")).toContain("service");
     expect(await columnNames(client, "users")).toContain("name");
@@ -31,7 +34,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(2);
+    expect(migrations.rows).toHaveLength(3);
   });
 
   it("adds listing_url to a legacy database missing the column", async () => {
@@ -63,7 +66,75 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(2);
+    expect(migrations.rows).toHaveLength(3);
+  });
+
+  it("reconciles a DB that already has has_washing_machine but no 0002 marker", async () => {
+    const client = createClient({ url: ":memory:" });
+
+    // Simulate a DB migrated against PR #42's amended 0000: has the column
+    // and a __drizzle_migrations table with 0000/0001 entries, but no 0002.
+    await client.execute({
+      sql: `CREATE TABLE apartments (
+        id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        name text NOT NULL,
+        has_washing_machine integer,
+        listing_url text
+      )`,
+      args: [],
+    });
+    await client.execute({
+      sql: `CREATE TABLE ratings (
+        id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        apartment_id integer NOT NULL,
+        user_name text NOT NULL,
+        kitchen integer,
+        balconies integer,
+        location integer,
+        floorplan integer,
+        overall_feeling integer,
+        comment text,
+        created_at integer,
+        updated_at integer
+      )`,
+      args: [],
+    });
+    await client.execute({
+      sql: `CREATE UNIQUE INDEX ratings_apartment_user_idx ON ratings (apartment_id, user_name)`,
+      args: [],
+    });
+    await client.execute({
+      sql: `CREATE TABLE api_usage (
+        id integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+        service text NOT NULL,
+        operation text NOT NULL
+      )`,
+      args: [],
+    });
+    await client.execute({
+      sql: `CREATE TABLE users (name text PRIMARY KEY NOT NULL, created_at integer)`,
+      args: [],
+    });
+    await client.execute({
+      sql: `CREATE TABLE __drizzle_migrations (id INTEGER PRIMARY KEY, hash text NOT NULL, created_at numeric)`,
+      args: [],
+    });
+    // Insert old 0000 + 0001 markers (timestamps from journal).
+    await client.execute({
+      sql: "INSERT INTO __drizzle_migrations (hash, created_at) VALUES ('x', 1776832975059), ('y', 1776840392526)",
+      args: [],
+    });
+
+    // Should NOT throw (would without the reconcile step because 0002 would
+    // try to re-add has_washing_machine).
+    await applyMigrations(client);
+
+    // 0002 is now recorded as applied.
+    const rows = await client.execute({
+      sql: "SELECT COUNT(*) as n FROM __drizzle_migrations",
+      args: [],
+    });
+    expect(Number(rows.rows[0].n)).toBe(3);
   });
 
   it("backfills the users table from distinct rating user_names", async () => {

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import fs from "node:fs";
 import { createClient, type Client } from "@libsql/client";
 import { drizzle } from "drizzle-orm/libsql";
 import { migrate } from "drizzle-orm/libsql/migrator";
@@ -31,8 +32,53 @@ async function ensureListingUrlColumn(client: Client): Promise<void> {
   });
 }
 
+async function reconcileHasWashingMachine(client: Client): Promise<void> {
+  // PR #42 amended drizzle/0000_initial_schema.sql to include
+  // has_washing_machine, so DBs that ran that amended 0000 already have the
+  // column but no migration marker for 0002. Without this reconcile, 0002's
+  // ALTER TABLE ADD COLUMN would fail with "duplicate column name."
+  const apartmentsRes = await client.execute({
+    sql: "SELECT name FROM sqlite_master WHERE type='table' AND name='apartments'",
+    args: [],
+  });
+  if (apartmentsRes.rows.length === 0) return;
+
+  const migrationsTableRes = await client.execute({
+    sql: "SELECT name FROM sqlite_master WHERE type='table' AND name='__drizzle_migrations'",
+    args: [],
+  });
+  if (migrationsTableRes.rows.length === 0) return;
+
+  const cols = await client.execute({
+    sql: "PRAGMA table_info(apartments)",
+    args: [],
+  });
+  const hasColumn = cols.rows.some((r) => r.name === "has_washing_machine");
+  if (!hasColumn) return;
+
+  const journalPath = path.join(MIGRATIONS_FOLDER, "meta", "_journal.json");
+  const journal = JSON.parse(fs.readFileSync(journalPath, "utf8")) as {
+    entries: Array<{ tag: string; when: number }>;
+  };
+  const entry = journal.entries.find((e) => e.tag === "0002_has_washing_machine");
+  if (!entry) return;
+
+  const lastRes = await client.execute({
+    sql: "SELECT MAX(created_at) as ts FROM __drizzle_migrations",
+    args: [],
+  });
+  const lastTs = Number(lastRes.rows[0]?.ts ?? 0);
+  if (lastTs >= entry.when) return;
+
+  await client.execute({
+    sql: "INSERT INTO __drizzle_migrations (hash, created_at) VALUES (?, ?)",
+    args: ["repair-has-washing-machine", entry.when],
+  });
+}
+
 export async function applyMigrations(client: Client): Promise<void> {
   await ensureListingUrlColumn(client);
+  await reconcileHasWashingMachine(client);
   const db = drizzle(client, { schema });
   await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
 }


### PR DESCRIPTION
## Summary

Production (Vercel + Turso) is returning 500 on every `GET /api/apartments`:

\`\`\`
Failed query: ... apartments.has_washing_machine ...
no such column: apartments.has_washing_machine
\`\`\`

Root cause: PR #42 added the column to `schema.ts` and amended `drizzle/0000_initial_schema.sql` in place, but never generated a real migration. Turso was already past 0001 when PR #42 deployed, so the amended 0000 never re-ran — the column is still missing there.

Same class of bug as #25 but for a different column.

## Fix

- Revert `drizzle/0000_initial_schema.sql` and `drizzle/meta/0000_snapshot.json` to their pre-#42 state. 0000 is an immutable history point; we shouldn't be editing it in place.
- Add `drizzle/0002_has_washing_machine.sql` as a proper `ALTER TABLE apartments ADD COLUMN has_washing_machine integer`.
- Add `reconcileHasWashingMachine` in `src/lib/db/migrate.ts` for DBs that already ran the amended 0000 (local Docker users and anyone who deployed #42 against a fresh DB): detect that the column is present but the 0002 marker is missing, and stamp 0002 in `__drizzle_migrations` before the drizzle migrator runs. Without this, 0002 would fail with "duplicate column name."

This mirrors the `ensureListingUrlColumn` pattern from #25 — pre-migrator step that heals schema drift rather than letting the migrator crash.

## Scenarios covered
1. **Fresh DB** — 0000 creates apartments (no column), 0001 creates users, 0002 adds the column. ✓
2. **Vercel/Turso (pre-#42 deployed)** — apartments missing column. Reconcile no-ops; drizzle migrator runs 0002 as an ALTER. ✓
3. **Local Docker (ran amended 0000)** — apartments already has the column. Reconcile stamps 0002 as applied; migrator skips. ✓

## Tests (90/90 pass)
- Existing migrate tests updated to expect 3 migration rows.
- New test: DB with column present but no 0002 marker → reconcile lets drizzle migrator complete without throwing; ends up with 3 rows in `__drizzle_migrations`.
- End-to-end Docker rebuild smoke tested: reconcile triggers, API returns 200.