### PR TITLE
feat: edit UI for apartment fields on the detail page (#40)

### DIFF
--- a/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
+++ b/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "42" }),
+  useRouter: () => ({ push, refresh: vi.fn() }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const APARTMENT_V1 = {
+  id: 42,
+  name: "Sonnenweg 3",
+  address: "Sonnenweg 3, 8001 Zurich",
+  sizeM2: 60,
+  numRooms: 2.5,
+  numBathrooms: 1,
+  numBalconies: 1,
+  hasWashingMachine: null,
+  rentChf: 2200,
+  distanceBikeMin: 12,
+  distanceTransitMin: 25,
+  pdfUrl: null,
+  listingUrl: null,
+  ratings: [],
+};
+
+const APARTMENT_V2 = {
+  ...APARTMENT_V1,
+  name: "Sonnenweg 3b",
+  rentChf: 2400,
+  hasWashingMachine: true,
+};
+
+type FetchCall = { url: string; init: RequestInit };
+let fetchCalls: FetchCall[] = [];
+
+beforeEach(() => {
+  push.mockReset();
+  fetchCalls = [];
+
+  // First GET → V1, second GET (after PATCH) → V2.
+  let getCount = 0;
+  vi.spyOn(global, "fetch").mockImplementation(((
+    input: RequestInfo,
+    init?: RequestInit
+  ) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    fetchCalls.push({ url, init: init ?? {} });
+    const method = init?.method ?? "GET";
+
+    if (url.endsWith("/api/apartments/42") && method === "GET") {
+      getCount += 1;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve(getCount === 1 ? APARTMENT_V1 : APARTMENT_V2),
+      } as Response);
+    }
+    if (url.endsWith("/api/apartments/42") && method === "PATCH") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(APARTMENT_V2),
+      } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response);
+  }) as typeof fetch);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Apartment detail edit flow", () => {
+  it("opens the edit form, saves changes, and re-renders with updated values", async () => {
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+
+    // Wait for initial load.
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/CHF 2,200/)).toBeInTheDocument();
+
+    // Click Edit.
+    await user.click(screen.getByRole("button", { name: /^Edit$/ }));
+
+    // Form is visible with pre-populated values.
+    const nameInput = screen.getByLabelText(/Name/i) as HTMLInputElement;
+    const rentInput = screen.getByLabelText(/Rent/i) as HTMLInputElement;
+    expect(nameInput.value).toBe("Sonnenweg 3");
+    expect(rentInput.value).toBe("2200");
+
+    // Change fields.
+    await user.clear(nameInput);
+    await user.type(nameInput, "Sonnenweg 3b");
+    await user.clear(rentInput);
+    await user.type(rentInput, "2400");
+
+    // Toggle washing machine to Yes.
+    await user.click(screen.getByRole("button", { name: /^Yes$/ }));
+
+    // Save.
+    await user.click(screen.getByRole("button", { name: /^Save$/ }));
+
+    await waitFor(() => {
+      const patchCall = fetchCalls.find(
+        (c) => c.url.endsWith("/api/apartments/42") && c.init.method === "PATCH"
+      );
+      expect(patchCall).toBeDefined();
+      const body = JSON.parse((patchCall!.init.body as string) ?? "{}");
+      expect(body.name).toBe("Sonnenweg 3b");
+      expect(body.rentChf).toBe(2400);
+      expect(body.hasWashingMachine).toBe(true);
+    });
+
+    // Edit form closed, read-only view shows updated values.
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3b")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/CHF 2,400/)).toBeInTheDocument();
+  });
+
+  it("Cancel discards edits and returns to read-only view", async () => {
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Edit$/ }));
+
+    const nameInput = screen.getByLabelText(/Name/i) as HTMLInputElement;
+    await user.clear(nameInput);
+    await user.type(nameInput, "Something else");
+
+    await user.click(screen.getByRole("button", { name: /^Cancel$/ }));
+
+    // No PATCH was made.
+    expect(
+      fetchCalls.find((c) => c.init.method === "PATCH")
+    ).toBeUndefined();
+
+    // Read-only view still shows the original name.
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+  });
+
+  it("disables Delete while editing and re-enables it after Cancel", async () => {
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+
+    const deleteBefore = screen.getByRole("button", { name: /Delete/i });
+    expect(deleteBefore).not.toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /^Edit$/ }));
+    expect(screen.getByRole("button", { name: /Delete/i })).toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /^Cancel$/ }));
+    expect(screen.getByRole("button", { name: /Delete/i })).not.toBeDisabled();
+
+    // "within" import just to keep the import list stable.
+    void within;
+  });
+});

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -12,6 +12,12 @@ import { StarRating } from "@/components/star-rating";
 import { WashingMachine } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
+  ApartmentFormFields,
+  formFromApartment,
+  formToPayload,
+  type ApartmentForm,
+} from "@/components/apartment-form-fields";
+import {
   type ErrorDetails,
   fetchErrorFromResponse,
   fetchErrorFromException,
@@ -80,6 +86,9 @@ export default function ApartmentDetailPage() {
   const [saving, setSaving] = useState(false);
   const [userName, setUserName] = useState("");
   const [error, setError] = useState<ErrorState | null>(null);
+  const [editing, setEditing] = useState(false);
+  const [editForm, setEditForm] = useState<ApartmentForm | null>(null);
+  const [savingEdit, setSavingEdit] = useState(false);
 
   const loadApartment = useCallback(async () => {
     const url = `/api/apartments/${params.id}`;
@@ -149,6 +158,53 @@ export default function ApartmentDetailPage() {
         details: fetchErrorFromException(err, url),
       });
       setDeleting(false);
+    }
+  }
+
+  function startEdit() {
+    if (!apartment) return;
+    setEditForm(formFromApartment(apartment));
+    setEditing(true);
+    setError(null);
+  }
+
+  function cancelEdit() {
+    setEditing(false);
+    setEditForm(null);
+  }
+
+  async function handleSaveEdit() {
+    if (!editForm) return;
+    if (!editForm.name.trim()) {
+      setError({ headline: "Name is required" });
+      return;
+    }
+    setSavingEdit(true);
+    const url = `/api/apartments/${params.id}`;
+    try {
+      const res = await fetch(url, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(formToPayload(editForm)),
+      });
+      if (!res.ok) {
+        setError({
+          headline: "Couldn't save changes",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setSavingEdit(false);
+        return;
+      }
+      await loadApartment();
+      setEditing(false);
+      setEditForm(null);
+      setSavingEdit(false);
+    } catch (err) {
+      setError({
+        headline: "Couldn't save changes",
+        details: fetchErrorFromException(err, url),
+      });
+      setSavingEdit(false);
     }
   }
 
@@ -238,10 +294,19 @@ export default function ApartmentDetailPage() {
               URL missing
             </Badge>
           )}
+          {!editing && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={startEdit}
+            >
+              Edit
+            </Button>
+          )}
           <Button
             variant="destructive"
             size="sm"
-            disabled={deleting}
+            disabled={deleting || editing}
             onClick={handleDelete}
           >
             {deleting ? "Deleting..." : "Delete"}
@@ -253,54 +318,89 @@ export default function ApartmentDetailPage() {
         <ErrorDisplay headline={error.headline} details={error.details} />
       )}
 
-      {/* Apartment metrics */}
-      <div className="flex flex-wrap gap-2">
-        {apartment.rentChf && (
-          <Badge variant="secondary">
-            CHF {apartment.rentChf.toLocaleString()}/mo
-          </Badge>
-        )}
-        {apartment.sizeM2 && (
-          <Badge variant="secondary">{apartment.sizeM2} m²</Badge>
-        )}
-        {apartment.numRooms && (
-          <Badge variant="secondary">{apartment.numRooms} rooms</Badge>
-        )}
-        {apartment.numBathrooms != null && (
-          <Badge variant="secondary">{apartment.numBathrooms} bath</Badge>
-        )}
-        {apartment.numBalconies != null && (
-          <Badge variant="secondary">
-            {apartment.numBalconies} balcon{apartment.numBalconies !== 1 ? "ies" : "y"}
-          </Badge>
-        )}
-        <Badge
-          variant="secondary"
-          title={
-            apartment.hasWashingMachine === true
-              ? "Washing machine: yes"
+      {/* Apartment metrics or edit form */}
+      {editing && editForm ? (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">Edit apartment</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <ApartmentFormFields
+              form={editForm}
+              onChange={(field, value) =>
+                setEditForm((prev) =>
+                  prev ? { ...prev, [field]: value } : prev
+                )
+              }
+              onWashingMachineChange={(v) =>
+                setEditForm((prev) =>
+                  prev ? { ...prev, hasWashingMachine: v } : prev
+                )
+              }
+            />
+            <div className="flex gap-2">
+              <Button onClick={handleSaveEdit} disabled={savingEdit}>
+                {savingEdit ? "Saving..." : "Save"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={cancelEdit}
+                disabled={savingEdit}
+              >
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {apartment.rentChf && (
+            <Badge variant="secondary">
+              CHF {apartment.rentChf.toLocaleString()}/mo
+            </Badge>
+          )}
+          {apartment.sizeM2 && (
+            <Badge variant="secondary">{apartment.sizeM2} m²</Badge>
+          )}
+          {apartment.numRooms && (
+            <Badge variant="secondary">{apartment.numRooms} rooms</Badge>
+          )}
+          {apartment.numBathrooms != null && (
+            <Badge variant="secondary">{apartment.numBathrooms} bath</Badge>
+          )}
+          {apartment.numBalconies != null && (
+            <Badge variant="secondary">
+              {apartment.numBalconies} balcon{apartment.numBalconies !== 1 ? "ies" : "y"}
+            </Badge>
+          )}
+          <Badge
+            variant="secondary"
+            title={
+              apartment.hasWashingMachine === true
+                ? "Washing machine: yes"
+                : apartment.hasWashingMachine === false
+                  ? "Washing machine: no (or shared)"
+                  : "Washing machine: unknown"
+            }
+            className="gap-1"
+          >
+            <WashingMachine className="h-3 w-3" />
+            {apartment.hasWashingMachine === true
+              ? "Yes"
               : apartment.hasWashingMachine === false
-                ? "Washing machine: no (or shared)"
-                : "Washing machine: unknown"
-          }
-          className="gap-1"
-        >
-          <WashingMachine className="h-3 w-3" />
-          {apartment.hasWashingMachine === true
-            ? "Yes"
-            : apartment.hasWashingMachine === false
-              ? "No"
-              : "?"}
-        </Badge>
-        {apartment.distanceBikeMin && (
-          <Badge variant="outline">{apartment.distanceBikeMin} min bike</Badge>
-        )}
-        {apartment.distanceTransitMin && (
-          <Badge variant="outline">
-            {apartment.distanceTransitMin} min transit
+                ? "No"
+                : "?"}
           </Badge>
-        )}
-      </div>
+          {apartment.distanceBikeMin && (
+            <Badge variant="outline">{apartment.distanceBikeMin} min bike</Badge>
+          )}
+          {apartment.distanceTransitMin && (
+            <Badge variant="outline">
+              {apartment.distanceTransitMin} min transit
+            </Badge>
+          )}
+        </div>
+      )}
 
       <Separator />
 

--- a/src/app/apartments/new/page.tsx
+++ b/src/app/apartments/new/page.tsx
@@ -3,12 +3,17 @@
 import { useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 import { ErrorDisplay } from "@/components/error-display";
+import {
+  ApartmentFormFields,
+  emptyApartmentForm,
+  formFromExtracted,
+  formToPayload,
+  type ApartmentForm,
+} from "@/components/apartment-form-fields";
 import {
   type ErrorDetails,
   fetchErrorFromResponse,
@@ -19,38 +24,6 @@ interface ErrorState {
   headline: string;
   details?: ErrorDetails;
 }
-
-type ApartmentForm = {
-  name: string;
-  address: string;
-  sizeM2: string;
-  numRooms: string;
-  numBathrooms: string;
-  numBalconies: string;
-  hasWashingMachine: boolean | null;
-  rentChf: string;
-  distanceBikeMin: string;
-  distanceTransitMin: string;
-  pdfUrl: string;
-  listingUrl: string;
-  rawExtractedData: Record<string, unknown> | null;
-};
-
-const emptyForm: ApartmentForm = {
-  name: "",
-  address: "",
-  sizeM2: "",
-  numRooms: "",
-  numBathrooms: "",
-  numBalconies: "",
-  hasWashingMachine: null,
-  rentChf: "",
-  distanceBikeMin: "",
-  distanceTransitMin: "",
-  pdfUrl: "",
-  listingUrl: "",
-  rawExtractedData: null,
-};
 
 type UploadItem = {
   id: string;
@@ -63,54 +36,6 @@ type UploadItem = {
   discarded: boolean;
 };
 
-function formFromExtracted(
-  extracted: Record<string, unknown>,
-  pdfUrl: string
-): ApartmentForm {
-  return {
-    name: (extracted.name as string) || "",
-    address: (extracted.address as string) || "",
-    sizeM2: extracted.sizeM2 != null ? String(extracted.sizeM2) : "",
-    numRooms: extracted.numRooms != null ? String(extracted.numRooms) : "",
-    numBathrooms:
-      extracted.numBathrooms != null ? String(extracted.numBathrooms) : "",
-    numBalconies:
-      extracted.numBalconies != null ? String(extracted.numBalconies) : "",
-    hasWashingMachine:
-      typeof extracted.hasWashingMachine === "boolean"
-        ? extracted.hasWashingMachine
-        : null,
-    rentChf: extracted.rentChf != null ? String(extracted.rentChf) : "",
-    distanceBikeMin: "",
-    distanceTransitMin: "",
-    pdfUrl,
-    listingUrl: (extracted.listingUrl as string) || "",
-    rawExtractedData: extracted,
-  };
-}
-
-function formToPayload(form: ApartmentForm) {
-  return {
-    name: form.name,
-    address: form.address || null,
-    sizeM2: form.sizeM2 ? parseFloat(form.sizeM2) : null,
-    numRooms: form.numRooms ? parseFloat(form.numRooms) : null,
-    numBathrooms: form.numBathrooms ? parseInt(form.numBathrooms) : null,
-    numBalconies: form.numBalconies ? parseInt(form.numBalconies) : null,
-    hasWashingMachine: form.hasWashingMachine,
-    rentChf: form.rentChf ? parseFloat(form.rentChf) : null,
-    distanceBikeMin: form.distanceBikeMin
-      ? parseInt(form.distanceBikeMin)
-      : null,
-    distanceTransitMin: form.distanceTransitMin
-      ? parseInt(form.distanceTransitMin)
-      : null,
-    pdfUrl: form.pdfUrl || null,
-    listingUrl: form.listingUrl || null,
-    rawExtractedData: form.rawExtractedData,
-  };
-}
-
 export default function UploadPage() {
   const router = useRouter();
   // "upload" = drop zone, "processing" = batch in progress, "review" = edit & save, "single" = manual entry
@@ -118,7 +43,7 @@ export default function UploadPage() {
     "upload" | "processing" | "review" | "single"
   >("upload");
   const [items, setItems] = useState<UploadItem[]>([]);
-  const [singleForm, setSingleForm] = useState<ApartmentForm>(emptyForm);
+  const [singleForm, setSingleForm] = useState<ApartmentForm>(emptyApartmentForm);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<ErrorState | null>(null);
   const [dragOver, setDragOver] = useState(false);
@@ -151,7 +76,7 @@ export default function UploadPage() {
       id: `${Date.now()}-${Math.random().toString(36).slice(2)}`,
       fileName: file.name,
       status: "queued" as const,
-      form: emptyForm,
+      form: emptyApartmentForm,
       expanded: false,
       saved: false,
       discarded: false,
@@ -413,7 +338,7 @@ export default function UploadPage() {
           <Button
             variant="link"
             onClick={() => {
-              setSingleForm(emptyForm);
+              setSingleForm(emptyApartmentForm);
               setStep("single");
             }}
           >
@@ -616,7 +541,7 @@ export default function UploadPage() {
                 type="button"
                 variant="outline"
                 onClick={() => {
-                  setSingleForm(emptyForm);
+                  setSingleForm(emptyApartmentForm);
                   setStep("upload");
                 }}
               >
@@ -626,155 +551,6 @@ export default function UploadPage() {
           </form>
         </CardContent>
       </Card>
-    </div>
-  );
-}
-
-// --- Shared form fields component ---
-
-function ApartmentFormFields({
-  form,
-  onChange,
-  onWashingMachineChange,
-}: {
-  form: ApartmentForm;
-  onChange: (field: keyof ApartmentForm, value: string) => void;
-  onWashingMachineChange: (value: boolean | null) => void;
-}) {
-  return (
-    <div className="space-y-4">
-      <div className="space-y-2">
-        <Label>Name *</Label>
-        <Input
-          value={form.name}
-          onChange={(e) => onChange("name", e.target.value)}
-          placeholder="Apartment name"
-        />
-      </div>
-      <div className="space-y-2">
-        <Label>Address</Label>
-        <Input
-          value={form.address}
-          onChange={(e) => onChange("address", e.target.value)}
-          placeholder="Street, postcode, city"
-        />
-      </div>
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label>Rent (CHF/mo)</Label>
-          <Input
-            type="number"
-            value={form.rentChf}
-            onChange={(e) => onChange("rentChf", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>Size (m²)</Label>
-          <Input
-            type="number"
-            value={form.sizeM2}
-            onChange={(e) => onChange("sizeM2", e.target.value)}
-          />
-        </div>
-      </div>
-      <div className="grid grid-cols-3 gap-4">
-        <div className="space-y-2">
-          <Label>Rooms</Label>
-          <Input
-            type="number"
-            step="0.5"
-            value={form.numRooms}
-            onChange={(e) => onChange("numRooms", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>Baths</Label>
-          <Input
-            type="number"
-            value={form.numBathrooms}
-            onChange={(e) => onChange("numBathrooms", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>Balconies</Label>
-          <Input
-            type="number"
-            value={form.numBalconies}
-            onChange={(e) => onChange("numBalconies", e.target.value)}
-          />
-        </div>
-      </div>
-      <div className="space-y-2">
-        <Label>Washing machine</Label>
-        <WashingMachineToggle
-          value={form.hasWashingMachine}
-          onChange={onWashingMachineChange}
-        />
-      </div>
-      <div className="space-y-2">
-        <Label>Listing URL</Label>
-        <Input
-          value={form.listingUrl}
-          onChange={(e) => onChange("listingUrl", e.target.value)}
-          placeholder="https://..."
-        />
-      </div>
-      <div className="grid grid-cols-2 gap-4">
-        <div className="space-y-2">
-          <Label>Bike to SBB (min)</Label>
-          <Input
-            type="number"
-            value={form.distanceBikeMin}
-            onChange={(e) => onChange("distanceBikeMin", e.target.value)}
-          />
-        </div>
-        <div className="space-y-2">
-          <Label>Transit to SBB (min)</Label>
-          <Input
-            type="number"
-            value={form.distanceTransitMin}
-            onChange={(e) => onChange("distanceTransitMin", e.target.value)}
-          />
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function WashingMachineToggle({
-  value,
-  onChange,
-}: {
-  value: boolean | null;
-  onChange: (v: boolean | null) => void;
-}) {
-  const options: Array<{ key: "yes" | "no" | "unknown"; label: string; v: boolean | null }> = [
-    { key: "yes", label: "Yes", v: true },
-    { key: "no", label: "No", v: false },
-    { key: "unknown", label: "Unknown", v: null },
-  ];
-  return (
-    <div className="inline-flex rounded-md border">
-      {options.map((opt, i) => {
-        const selected = value === opt.v;
-        return (
-          <button
-            key={opt.key}
-            type="button"
-            onClick={() => onChange(opt.v)}
-            className={cn(
-              "px-3 py-1.5 text-sm transition-colors",
-              i > 0 && "border-l",
-              selected
-                ? "bg-primary text-primary-foreground"
-                : "bg-background text-muted-foreground hover:bg-accent hover:text-foreground"
-            )}
-            aria-pressed={selected}
-          >
-            {opt.label}
-          </button>
-        );
-      })}
     </div>
   );
 }

--- a/src/components/apartment-form-fields.tsx
+++ b/src/components/apartment-form-fields.tsx
@@ -1,0 +1,284 @@
+"use client";
+
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+export type ApartmentForm = {
+  name: string;
+  address: string;
+  sizeM2: string;
+  numRooms: string;
+  numBathrooms: string;
+  numBalconies: string;
+  hasWashingMachine: boolean | null;
+  rentChf: string;
+  distanceBikeMin: string;
+  distanceTransitMin: string;
+  pdfUrl: string;
+  listingUrl: string;
+  rawExtractedData: Record<string, unknown> | null;
+};
+
+export const emptyApartmentForm: ApartmentForm = {
+  name: "",
+  address: "",
+  sizeM2: "",
+  numRooms: "",
+  numBathrooms: "",
+  numBalconies: "",
+  hasWashingMachine: null,
+  rentChf: "",
+  distanceBikeMin: "",
+  distanceTransitMin: "",
+  pdfUrl: "",
+  listingUrl: "",
+  rawExtractedData: null,
+};
+
+export function formFromExtracted(
+  extracted: Record<string, unknown>,
+  pdfUrl: string
+): ApartmentForm {
+  return {
+    name: (extracted.name as string) || "",
+    address: (extracted.address as string) || "",
+    sizeM2: extracted.sizeM2 != null ? String(extracted.sizeM2) : "",
+    numRooms: extracted.numRooms != null ? String(extracted.numRooms) : "",
+    numBathrooms:
+      extracted.numBathrooms != null ? String(extracted.numBathrooms) : "",
+    numBalconies:
+      extracted.numBalconies != null ? String(extracted.numBalconies) : "",
+    hasWashingMachine:
+      typeof extracted.hasWashingMachine === "boolean"
+        ? extracted.hasWashingMachine
+        : null,
+    rentChf: extracted.rentChf != null ? String(extracted.rentChf) : "",
+    distanceBikeMin: "",
+    distanceTransitMin: "",
+    pdfUrl,
+    listingUrl: (extracted.listingUrl as string) || "",
+    rawExtractedData: extracted,
+  };
+}
+
+export type ApartmentLike = {
+  name: string;
+  address: string | null;
+  sizeM2: number | null;
+  numRooms: number | null;
+  numBathrooms: number | null;
+  numBalconies: number | null;
+  hasWashingMachine: boolean | null;
+  rentChf: number | null;
+  distanceBikeMin: number | null;
+  distanceTransitMin: number | null;
+  pdfUrl: string | null;
+  listingUrl: string | null;
+};
+
+export function formFromApartment(apt: ApartmentLike): ApartmentForm {
+  const numOrEmpty = (v: number | null | undefined) =>
+    v != null ? String(v) : "";
+  return {
+    name: apt.name,
+    address: apt.address ?? "",
+    sizeM2: numOrEmpty(apt.sizeM2),
+    numRooms: numOrEmpty(apt.numRooms),
+    numBathrooms: numOrEmpty(apt.numBathrooms),
+    numBalconies: numOrEmpty(apt.numBalconies),
+    hasWashingMachine: apt.hasWashingMachine,
+    rentChf: numOrEmpty(apt.rentChf),
+    distanceBikeMin: numOrEmpty(apt.distanceBikeMin),
+    distanceTransitMin: numOrEmpty(apt.distanceTransitMin),
+    pdfUrl: apt.pdfUrl ?? "",
+    listingUrl: apt.listingUrl ?? "",
+    rawExtractedData: null,
+  };
+}
+
+export function formToPayload(form: ApartmentForm) {
+  return {
+    name: form.name,
+    address: form.address || null,
+    sizeM2: form.sizeM2 ? parseFloat(form.sizeM2) : null,
+    numRooms: form.numRooms ? parseFloat(form.numRooms) : null,
+    numBathrooms: form.numBathrooms ? parseInt(form.numBathrooms) : null,
+    numBalconies: form.numBalconies ? parseInt(form.numBalconies) : null,
+    hasWashingMachine: form.hasWashingMachine,
+    rentChf: form.rentChf ? parseFloat(form.rentChf) : null,
+    distanceBikeMin: form.distanceBikeMin
+      ? parseInt(form.distanceBikeMin)
+      : null,
+    distanceTransitMin: form.distanceTransitMin
+      ? parseInt(form.distanceTransitMin)
+      : null,
+    pdfUrl: form.pdfUrl || null,
+    listingUrl: form.listingUrl || null,
+    rawExtractedData: form.rawExtractedData,
+  };
+}
+
+export function ApartmentFormFields({
+  form,
+  onChange,
+  onWashingMachineChange,
+  idPrefix = "apt",
+}: {
+  form: ApartmentForm;
+  onChange: (field: keyof ApartmentForm, value: string) => void;
+  onWashingMachineChange: (value: boolean | null) => void;
+  idPrefix?: string;
+}) {
+  const id = (field: string) => `${idPrefix}-${field}`;
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor={id("name")}>Name *</Label>
+        <Input
+          id={id("name")}
+          value={form.name}
+          onChange={(e) => onChange("name", e.target.value)}
+          placeholder="Apartment name"
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={id("address")}>Address</Label>
+        <Input
+          id={id("address")}
+          value={form.address}
+          onChange={(e) => onChange("address", e.target.value)}
+          placeholder="Street, postcode, city"
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor={id("rent")}>Rent (CHF/mo)</Label>
+          <Input
+            id={id("rent")}
+            type="number"
+            value={form.rentChf}
+            onChange={(e) => onChange("rentChf", e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={id("size")}>Size (m²)</Label>
+          <Input
+            id={id("size")}
+            type="number"
+            value={form.sizeM2}
+            onChange={(e) => onChange("sizeM2", e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="grid grid-cols-3 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor={id("rooms")}>Rooms</Label>
+          <Input
+            id={id("rooms")}
+            type="number"
+            step="0.5"
+            value={form.numRooms}
+            onChange={(e) => onChange("numRooms", e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={id("baths")}>Baths</Label>
+          <Input
+            id={id("baths")}
+            type="number"
+            value={form.numBathrooms}
+            onChange={(e) => onChange("numBathrooms", e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={id("balconies")}>Balconies</Label>
+          <Input
+            id={id("balconies")}
+            type="number"
+            value={form.numBalconies}
+            onChange={(e) => onChange("numBalconies", e.target.value)}
+          />
+        </div>
+      </div>
+      <div className="space-y-2">
+        <Label>Washing machine</Label>
+        <WashingMachineToggle
+          value={form.hasWashingMachine}
+          onChange={onWashingMachineChange}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor={id("listing-url")}>Listing URL</Label>
+        <Input
+          id={id("listing-url")}
+          value={form.listingUrl}
+          onChange={(e) => onChange("listingUrl", e.target.value)}
+          placeholder="https://..."
+        />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor={id("bike")}>Bike to SBB (min)</Label>
+          <Input
+            id={id("bike")}
+            type="number"
+            value={form.distanceBikeMin}
+            onChange={(e) => onChange("distanceBikeMin", e.target.value)}
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor={id("transit")}>Transit to SBB (min)</Label>
+          <Input
+            id={id("transit")}
+            type="number"
+            value={form.distanceTransitMin}
+            onChange={(e) => onChange("distanceTransitMin", e.target.value)}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function WashingMachineToggle({
+  value,
+  onChange,
+}: {
+  value: boolean | null;
+  onChange: (v: boolean | null) => void;
+}) {
+  const options: Array<{
+    key: "yes" | "no" | "unknown";
+    label: string;
+    v: boolean | null;
+  }> = [
+    { key: "yes", label: "Yes", v: true },
+    { key: "no", label: "No", v: false },
+    { key: "unknown", label: "Unknown", v: null },
+  ];
+  return (
+    <div className="inline-flex rounded-md border">
+      {options.map((opt, i) => {
+        const selected = value === opt.v;
+        return (
+          <button
+            key={opt.key}
+            type="button"
+            onClick={() => onChange(opt.v)}
+            className={cn(
+              "px-3 py-1.5 text-sm transition-colors",
+              i > 0 && "border-l",
+              selected
+                ? "bg-primary text-primary-foreground"
+                : "bg-background text-muted-foreground hover:bg-accent hover:text-foreground"
+            )}
+            aria-pressed={selected}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #40. Adds an edit mode to `apartments/[id]` so extracted fields (and newer additions like `hasWashingMachine`) can be corrected without re-uploading. `PATCH /api/apartments/[id]` already existed; this wires up the UI.

## Approach

Option 2 from the issue — dedicated edit mode with a Save/Cancel form. Reuses the exact same form component as the upload-review step by extracting it to a shared module.

## Changes

- **New**: `src/components/apartment-form-fields.tsx` — `ApartmentFormFields`, `WashingMachineToggle`, `ApartmentForm` type, and helpers: `emptyApartmentForm`, `formFromExtracted`, `formFromApartment` (new), `formToPayload`.
- **`src/app/apartments/new/page.tsx`** — imports from the shared module; behavior unchanged.
- **`src/app/apartments/[id]/page.tsx`** — Edit button next to Delete. Clicking it replaces the metrics strip with a `Card` containing the form + Save/Cancel. Save calls `PATCH /api/apartments/[id]` with `formToPayload(editForm)`, reloads on 200. Delete is disabled while editing. Ratings cards stay visible and interactive.
- A11y: all form inputs now have `htmlFor`/`id` pairs.

## Tests (93/93 passing)

- `src/app/apartments/[id]/__tests__/edit-flow.test.tsx` — three scenarios:
  1. Open edit, change name/rent, toggle washing machine, Save → asserts PATCH body shape and re-rendered read-only values.
  2. Cancel discards edits, no PATCH is made.
  3. Delete is disabled while editing, re-enabled on Cancel.

## Smoke-tested end-to-end in Docker

1. `POST /api/apartments` → create.
2. `PATCH /api/apartments/[id]` with updated fields.
3. `GET /api/apartments/[id]` confirms name, rent, hasWashingMachine, listingUrl all round-trip.