### PR TITLE
feat: human-readable short code per apartment (#31)

### DIFF
--- a/drizzle/0003_short_code.sql
+++ b/drizzle/0003_short_code.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `apartments` ADD `short_code` text;--> statement-breakpoint
+CREATE UNIQUE INDEX `apartments_short_code_unique` ON `apartments` (`short_code`);

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,353 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1ea24975-5207-4373-b36d-dc39d41e7613",
+  "prevId": "6ed342f7-6d32-4031-af43-d337f17fb3ec",
+  "tables": {
+    "apartments": {
+      "name": "apartments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_m2": {
+          "name": "size_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_rooms": {
+          "name": "num_rooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_bathrooms": {
+          "name": "num_bathrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_balconies": {
+          "name": "num_balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_washing_machine": {
+          "name": "has_washing_machine",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rent_chf": {
+          "name": "rent_chf",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_bike_min": {
+          "name": "distance_bike_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_transit_min": {
+          "name": "distance_transit_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_url": {
+          "name": "listing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_extracted_data": {
+          "name": "raw_extracted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "apartments_short_code_unique": {
+          "name": "apartments_short_code_unique",
+          "columns": [
+            "short_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_usage": {
+      "name": "api_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ratings": {
+      "name": "ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kitchen": {
+          "name": "kitchen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "balconies": {
+          "name": "balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "location": {
+          "name": "location",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "floorplan": {
+          "name": "floorplan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "overall_feeling": {
+          "name": "overall_feeling",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "ratings_apartment_user_idx": {
+          "name": "ratings_apartment_user_idx",
+          "columns": [
+            "apartment_id",
+            "user_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ratings_apartment_id_apartments_id_fk": {
+          "name": "ratings_apartment_id_apartments_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1776849182678,
       "tag": "0002_has_washing_machine",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1776851029322,
+      "tag": "0003_short_code",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Separator } from "@/components/ui/separator";
 import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { StarRating } from "@/components/star-rating";
+import { ShortCode } from "@/components/short-code";
 import { WashingMachine } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
@@ -53,6 +54,7 @@ interface ApartmentDetail {
   distanceTransitMin: number | null;
   pdfUrl: string | null;
   listingUrl: string | null;
+  shortCode: string | null;
   ratings: Rating[];
 }
 
@@ -263,8 +265,9 @@ export default function ApartmentDetailPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-start justify-between">
-        <div>
+        <div className="space-y-1">
           <h1 className="text-2xl font-semibold">{apartment.name}</h1>
+          <ShortCode code={apartment.shortCode} />
           {apartment.address && (
             <p className="text-muted-foreground">{apartment.address}</p>
           )}

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StarRating } from "@/components/star-rating";
+import { ShortCode } from "@/components/short-code";
 import { Building2 } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
@@ -26,6 +27,7 @@ interface ApartmentSummary {
   sizeM2: number | null;
   numRooms: number | null;
   rentChf: number | null;
+  shortCode: string | null;
   avgOverall: string | null;
   createdAt: string | null;
 }
@@ -119,6 +121,7 @@ export default function ApartmentsPage() {
                     />
                   )}
                 </div>
+                <ShortCode code={apt.shortCode} />
                 {apt.address && (
                   <p className="text-sm text-muted-foreground">{apt.address}</p>
                 )}

--- a/src/app/api/apartments/route.ts
+++ b/src/app/api/apartments/route.ts
@@ -2,6 +2,20 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { apartments, ratings } from "@/lib/db/schema";
 import { desc, avg, eq } from "drizzle-orm";
+import {
+  buildShortCode,
+  computeShortCodeParts,
+  pickLetters,
+} from "@/lib/short-code";
+
+const MAX_SHORT_CODE_ATTEMPTS = 5;
+
+function isUniqueConstraintError(err: unknown): boolean {
+  return (
+    err instanceof Error &&
+    /unique constraint|UNIQUE constraint/i.test(err.message)
+  );
+}
 
 export async function GET() {
   try {
@@ -20,6 +34,7 @@ export async function GET() {
         distanceTransitMin: apartments.distanceTransitMin,
         pdfUrl: apartments.pdfUrl,
         listingUrl: apartments.listingUrl,
+        shortCode: apartments.shortCode,
         createdAt: apartments.createdAt,
         avgKitchen: avg(ratings.kitchen),
         avgBalconies: avg(ratings.balconies),
@@ -46,28 +61,52 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
 
-    const result = await db
-      .insert(apartments)
-      .values({
-        name: body.name,
-        address: body.address,
-        sizeM2: body.sizeM2,
-        numRooms: body.numRooms,
-        numBathrooms: body.numBathrooms,
-        numBalconies: body.numBalconies,
-        hasWashingMachine: body.hasWashingMachine ?? null,
-        rentChf: body.rentChf,
-        distanceBikeMin: body.distanceBikeMin,
-        distanceTransitMin: body.distanceTransitMin,
-        pdfUrl: body.pdfUrl,
-        listingUrl: body.listingUrl || null,
-        rawExtractedData: body.rawExtractedData
-          ? JSON.stringify(body.rawExtractedData)
-          : null,
-      })
-      .returning();
+    // Compute derived parts once (postcode extraction can hit an API);
+    // only the random letters change on unique-constraint retries.
+    const parts = await computeShortCodeParts({
+      numRooms: body.numRooms ?? null,
+      numBathrooms: body.numBathrooms ?? null,
+      hasWashingMachine: body.hasWashingMachine ?? null,
+      address: body.address ?? null,
+    });
 
-    return NextResponse.json(result[0], { status: 201 });
+    for (let attempt = 0; attempt < MAX_SHORT_CODE_ATTEMPTS; attempt++) {
+      const shortCode = buildShortCode(parts, pickLetters());
+      try {
+        const result = await db
+          .insert(apartments)
+          .values({
+            name: body.name,
+            address: body.address,
+            sizeM2: body.sizeM2,
+            numRooms: body.numRooms,
+            numBathrooms: body.numBathrooms,
+            numBalconies: body.numBalconies,
+            hasWashingMachine: body.hasWashingMachine ?? null,
+            rentChf: body.rentChf,
+            distanceBikeMin: body.distanceBikeMin,
+            distanceTransitMin: body.distanceTransitMin,
+            pdfUrl: body.pdfUrl,
+            listingUrl: body.listingUrl || null,
+            shortCode,
+            rawExtractedData: body.rawExtractedData
+              ? JSON.stringify(body.rawExtractedData)
+              : null,
+          })
+          .returning();
+        return NextResponse.json(result[0], { status: 201 });
+      } catch (err) {
+        if (
+          isUniqueConstraintError(err) &&
+          attempt < MAX_SHORT_CODE_ATTEMPTS - 1
+        ) {
+          continue;
+        }
+        throw err;
+      }
+    }
+
+    throw new Error("Failed to generate a unique short code after retries");
   } catch (error) {
     console.error("[apartments:POST] Error:", error);
     return NextResponse.json(

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { StarRating } from "@/components/star-rating";
+import { ShortCode } from "@/components/short-code";
 import { cn } from "@/lib/utils";
 import { BarChart3 } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
@@ -30,6 +31,7 @@ interface ApartmentWithRatings {
   rentChf: number | null;
   distanceBikeMin: number | null;
   distanceTransitMin: number | null;
+  shortCode: string | null;
   ratings: {
     userName: string;
     kitchen: number;
@@ -188,8 +190,9 @@ export default function ComparePage() {
                   className="min-w-[160px] px-4 py-3 text-left font-medium"
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <div>
+                    <div className="space-y-1">
                       <div className="font-semibold">{apt.name}</div>
+                      <ShortCode code={apt.shortCode} />
                       {apt.address && (
                         <div className="text-xs font-normal text-muted-foreground">
                           {apt.address}

--- a/src/components/short-code.tsx
+++ b/src/components/short-code.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export function ShortCode({
+  code,
+  className,
+}: {
+  code: string | null | undefined;
+  className?: string;
+}) {
+  const [copied, setCopied] = useState(false);
+
+  if (!code) return null;
+
+  async function handleCopy(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(code!);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Silently ignore clipboard errors (HTTP contexts, etc.)
+    }
+  }
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-foreground/80",
+        className
+      )}
+    >
+      <span>{code}</span>
+      <button
+        type="button"
+        aria-label={copied ? "Copied" : `Copy ${code}`}
+        onClick={handleCopy}
+        className="rounded p-0.5 text-muted-foreground hover:bg-background hover:text-foreground"
+      >
+        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+      </button>
+    </span>
+  );
+}

--- a/src/lib/__tests__/geocode.test.ts
+++ b/src/lib/__tests__/geocode.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    insert: vi.fn(() => ({ values: vi.fn(async () => {}) })),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apiUsage: {},
+}));
+
+import { extractPostcode } from "../geocode";
+
+beforeEach(() => {
+  delete process.env.GOOGLE_MAPS_API_KEY;
+  delete process.env.OPENROUTESERVICE_API_KEY;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("extractPostcode — regex branch", () => {
+  it("pulls a 4-digit Swiss postcode", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    expect(
+      await extractPostcode("Steinenvorstadt 10, 4057 Basel")
+    ).toBe("4057");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("pulls a 5-digit German postcode", async () => {
+    expect(await extractPostcode("Unter den Linden 1, 10115 Berlin")).toBe(
+      "10115"
+    );
+  });
+
+  it("pulls a 5-digit US postcode", async () => {
+    expect(
+      await extractPostcode("1 Market St, San Francisco, CA 94107")
+    ).toBe("94107");
+  });
+
+  it("pulls a UK postcode with a space", async () => {
+    expect(await extractPostcode("10 Downing St, London SW1A 1AA")).toBe(
+      "SW1A1AA"
+    );
+  });
+
+  it("pulls a UK postcode with no space", async () => {
+    expect(await extractPostcode("Foo Rd, London SW1A1AA")).toBe("SW1A1AA");
+  });
+
+  it("returns null for an empty or non-postcode address", async () => {
+    expect(await extractPostcode("")).toBeNull();
+    expect(await extractPostcode("   ")).toBeNull();
+  });
+});
+
+describe("extractPostcode — Google fallback", () => {
+  it("calls Google Geocoding when regex fails and the key is set", async () => {
+    process.env.GOOGLE_MAPS_API_KEY = "k";
+    const fetchSpy = vi
+      .spyOn(global, "fetch")
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            results: [
+              {
+                address_components: [
+                  {
+                    long_name: "8001",
+                    types: ["postal_code"],
+                  },
+                ],
+              },
+            ],
+          }),
+      } as Response);
+
+    const result = await extractPostcode("Some place without a numeric code");
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain("maps.googleapis.com/maps/api/geocode/json");
+    expect(result).toBe("8001");
+  });
+
+  it("returns null when Google returns no postal_code component", async () => {
+    process.env.GOOGLE_MAPS_API_KEY = "k";
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ results: [] }),
+    } as Response);
+
+    expect(
+      await extractPostcode("Some place without a numeric code")
+    ).toBeNull();
+  });
+});
+
+describe("extractPostcode — ORS fallback", () => {
+  it("uses OpenRouteService when Google is absent", async () => {
+    process.env.OPENROUTESERVICE_API_KEY = "k";
+    const fetchSpy = vi.spyOn(global, "fetch").mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          features: [{ properties: { postalcode: "  4057 " } }],
+        }),
+    } as Response);
+
+    const result = await extractPostcode("Plain address");
+
+    expect(fetchSpy).toHaveBeenCalled();
+    const url = String(fetchSpy.mock.calls[0][0]);
+    expect(url).toContain("api.openrouteservice.org/geocode/search");
+    expect(result).toBe("4057");
+  });
+});
+
+describe("extractPostcode — no providers available", () => {
+  it("returns null when regex fails and neither key is set", async () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    expect(await extractPostcode("A street with no digits")).toBeNull();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/short-code.test.ts
+++ b/src/lib/__tests__/short-code.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/geocode", () => ({
+  extractPostcode: vi.fn(),
+}));
+
+import { extractPostcode } from "@/lib/geocode";
+import {
+  buildShortCode,
+  computeShortCodeParts,
+  generateShortCode,
+  pickLetters,
+} from "../short-code";
+
+const mockedExtractPostcode = vi.mocked(extractPostcode);
+
+beforeEach(() => {
+  mockedExtractPostcode.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("pickLetters", () => {
+  it("returns a 3-letter string from the allowed alphabet (no I/O/L)", () => {
+    for (let i = 0; i < 50; i++) {
+      const letters = pickLetters();
+      expect(letters).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ]{3}$/);
+    }
+  });
+
+  it("produces varied prefixes across many calls", () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 200; i++) seen.add(pickLetters());
+    // With 12,167 possibilities, 200 samples should have few collisions.
+    expect(seen.size).toBeGreaterThan(150);
+  });
+});
+
+describe("computeShortCodeParts", () => {
+  it("formats full data and calls extractPostcode once with the address", async () => {
+    mockedExtractPostcode.mockResolvedValue("4057");
+    const parts = await computeShortCodeParts({
+      numRooms: 3.5,
+      numBathrooms: 2,
+      hasWashingMachine: true,
+      address: "Steinenvorstadt 10, 4057 Basel",
+    });
+    expect(parts).toEqual({
+      rooms: "3.5",
+      baths: "2",
+      wash: "Y",
+      postcode: "4057",
+    });
+    expect(mockedExtractPostcode).toHaveBeenCalledWith(
+      "Steinenvorstadt 10, 4057 Basel"
+    );
+  });
+
+  it("renders ? for every missing field", async () => {
+    const parts = await computeShortCodeParts({
+      numRooms: null,
+      numBathrooms: null,
+      hasWashingMachine: null,
+      address: null,
+    });
+    expect(parts).toEqual({ rooms: "?", baths: "?", wash: "?", postcode: "?" });
+    expect(mockedExtractPostcode).not.toHaveBeenCalled();
+  });
+
+  it("renders WN for hasWashingMachine=false", async () => {
+    mockedExtractPostcode.mockResolvedValue("10115");
+    const parts = await computeShortCodeParts({
+      numRooms: 2,
+      numBathrooms: 1,
+      hasWashingMachine: false,
+      address: "Berlin 10115",
+    });
+    expect(parts.wash).toBe("N");
+  });
+
+  it("falls back to ? when address is present but geocode yields null", async () => {
+    mockedExtractPostcode.mockResolvedValue(null);
+    const parts = await computeShortCodeParts({
+      numRooms: 3,
+      numBathrooms: 1,
+      hasWashingMachine: true,
+      address: "Somewhere unknown",
+    });
+    expect(parts.postcode).toBe("?");
+  });
+});
+
+describe("buildShortCode", () => {
+  it("assembles all segments", () => {
+    const code = buildShortCode(
+      { rooms: "3.5", baths: "2", wash: "Y", postcode: "4057" },
+      "JQI"
+    );
+    expect(code).toBe("JQI-3.5B-2b-WY-4057");
+  });
+
+  it("keeps the dot for half-rooms", () => {
+    const code = buildShortCode(
+      { rooms: "3.5", baths: "1", wash: "N", postcode: "4056" },
+      "KPM"
+    );
+    expect(code).toContain("3.5B");
+  });
+
+  it("renders ? segments for missing data", () => {
+    const code = buildShortCode(
+      { rooms: "?", baths: "1", wash: "?", postcode: "?" },
+      "JQI"
+    );
+    expect(code).toBe("JQI-?B-1b-W?-?");
+  });
+
+  it("handles UK-style postcode", () => {
+    const code = buildShortCode(
+      { rooms: "2", baths: "1", wash: "Y", postcode: "SW1A1AA" },
+      "DZV"
+    );
+    expect(code).toBe("DZV-2B-1b-WY-SW1A1AA");
+  });
+});
+
+describe("generateShortCode integration", () => {
+  it("pulls letters from pickLetters when none provided", async () => {
+    mockedExtractPostcode.mockResolvedValue("4057");
+    const code = await generateShortCode({
+      numRooms: 3,
+      numBathrooms: 1,
+      hasWashingMachine: true,
+      address: "Basel 4057",
+    });
+    expect(code).toMatch(/^[ABCDEFGHJKMNPQRSTUVWXYZ]{3}-3B-1b-WY-4057$/);
+  });
+
+  it("accepts an explicit letters argument (useful for retry loops)", async () => {
+    mockedExtractPostcode.mockResolvedValue("4057");
+    const code = await generateShortCode(
+      {
+        numRooms: 3,
+        numBathrooms: 1,
+        hasWashingMachine: true,
+        address: "Basel 4057",
+      },
+      "XYZ"
+    );
+    expect(code).toBe("XYZ-3B-1b-WY-4057");
+  });
+});

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -34,7 +34,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(3);
+    expect(migrations.rows).toHaveLength(4);
   });
 
   it("adds listing_url to a legacy database missing the column", async () => {
@@ -66,7 +66,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(3);
+    expect(migrations.rows).toHaveLength(4);
   });
 
   it("reconciles a DB that already has has_washing_machine but no 0002 marker", async () => {
@@ -129,12 +129,13 @@ describe("applyMigrations", () => {
     // try to re-add has_washing_machine).
     await applyMigrations(client);
 
-    // 0002 is now recorded as applied.
+    // 0002 recorded via reconcile + 0003 run normally = 4 total
+    // (0000/0001 were seeded, 0002 stamped by reconcile, 0003 by migrator).
     const rows = await client.execute({
       sql: "SELECT COUNT(*) as n FROM __drizzle_migrations",
       args: [],
     });
-    expect(Number(rows.rows[0].n)).toBe(3);
+    expect(Number(rows.rows[0].n)).toBe(4);
   });
 
   it("backfills the users table from distinct rating user_names", async () => {

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -76,11 +76,85 @@ async function reconcileHasWashingMachine(client: Client): Promise<void> {
   });
 }
 
+async function backfillShortCodes(client: Client): Promise<void> {
+  // After 0003 adds short_code as nullable, any pre-existing rows need a
+  // code. New inserts generate one at POST time; this handles the gap.
+  // Idempotent: only rows with NULL short_code are processed.
+  const tables = await client.execute({
+    sql: "SELECT name FROM sqlite_master WHERE type='table' AND name='apartments'",
+    args: [],
+  });
+  if (tables.rows.length === 0) return;
+
+  const cols = await client.execute({
+    sql: "PRAGMA table_info(apartments)",
+    args: [],
+  });
+  const colNames = new Set(cols.rows.map((r) => String(r.name)));
+  const required = [
+    "short_code",
+    "num_rooms",
+    "num_bathrooms",
+    "has_washing_machine",
+    "address",
+  ];
+  if (required.some((c) => !colNames.has(c))) return;
+
+  const pending = await client.execute({
+    sql: `SELECT id, num_rooms, num_bathrooms, has_washing_machine, address
+          FROM apartments WHERE short_code IS NULL`,
+    args: [],
+  });
+  if (pending.rows.length === 0) return;
+
+  const { computeShortCodeParts, buildShortCode, pickLetters } = await import(
+    "@/lib/short-code"
+  );
+
+  for (const row of pending.rows) {
+    const input = {
+      numRooms:
+        row.num_rooms != null ? Number(row.num_rooms) : null,
+      numBathrooms:
+        row.num_bathrooms != null ? Number(row.num_bathrooms) : null,
+      hasWashingMachine:
+        row.has_washing_machine == null
+          ? null
+          : Number(row.has_washing_machine) === 1,
+      address:
+        typeof row.address === "string" && row.address.length > 0
+          ? row.address
+          : null,
+    };
+    const parts = await computeShortCodeParts(input);
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const code = buildShortCode(parts, pickLetters());
+      try {
+        await client.execute({
+          sql: "UPDATE apartments SET short_code = ? WHERE id = ?",
+          args: [code, row.id as number],
+        });
+        break;
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          /unique/i.test(err.message) &&
+          attempt < 4
+        ) {
+          continue;
+        }
+        throw err;
+      }
+    }
+  }
+}
+
 export async function applyMigrations(client: Client): Promise<void> {
   await ensureListingUrlColumn(client);
   await reconcileHasWashingMachine(client);
   const db = drizzle(client, { schema });
   await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+  await backfillShortCodes(client);
 }
 
 function createDefaultClient(): Client {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -15,6 +15,7 @@ export const apartments = sqliteTable("apartments", {
   distanceTransitMin: integer("distance_transit_min"),
   pdfUrl: text("pdf_url"),
   listingUrl: text("listing_url"),
+  shortCode: text("short_code").unique(),
   rawExtractedData: text("raw_extracted_data"),
   createdAt: integer("created_at", { mode: "timestamp" }).default(
     sql`(unixepoch())`

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -1,0 +1,89 @@
+import { db } from "@/lib/db";
+import { apiUsage } from "@/lib/db/schema";
+
+// Common postcode shapes, cheapest-first.
+// CH/US/DE: 4–5 digits surrounded by non-digits (or string edges).
+// UK: alphanumeric like "SW1A 1AA" or "EC1A1BB".
+const PATTERNS: RegExp[] = [
+  /(?<![A-Z0-9])([0-9]{4,5})(?![0-9])/,
+  /(?<![A-Z0-9])([A-Z]{1,2}[0-9][A-Z0-9]?)\s?([0-9][A-Z]{2})(?![A-Z0-9])/i,
+];
+
+function normalizePostcode(raw: string): string {
+  return raw.replace(/\s+/g, "").toUpperCase();
+}
+
+function tryRegex(address: string): string | null {
+  for (const re of PATTERNS) {
+    const m = address.match(re);
+    if (!m) continue;
+    if (m.length > 2 && m[1] && m[2]) {
+      return normalizePostcode(m[1] + m[2]);
+    }
+    return normalizePostcode(m[1]);
+  }
+  return null;
+}
+
+async function logUsage(service: string) {
+  try {
+    await db.insert(apiUsage).values({ service, operation: "geocode" });
+  } catch {
+    // Don't fail the geocode if usage logging fails.
+  }
+}
+
+async function tryGoogleGeocode(address: string): Promise<string | null> {
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const url = new URL("https://maps.googleapis.com/maps/api/geocode/json");
+    url.searchParams.set("address", address);
+    url.searchParams.set("key", apiKey);
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    await logUsage("google_maps");
+    const components = data.results?.[0]?.address_components ?? [];
+    const hit = components.find((c: { types?: string[] }) =>
+      c.types?.includes("postal_code")
+    );
+    return hit?.long_name ? normalizePostcode(String(hit.long_name)) : null;
+  } catch {
+    return null;
+  }
+}
+
+async function tryOrsGeocode(address: string): Promise<string | null> {
+  const apiKey = process.env.OPENROUTESERVICE_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const url = new URL("https://api.openrouteservice.org/geocode/search");
+    url.searchParams.set("api_key", apiKey);
+    url.searchParams.set("text", address);
+    url.searchParams.set("size", "1");
+    const res = await fetch(url.toString());
+    const data = await res.json();
+    await logUsage("openrouteservice");
+    const raw = data.features?.[0]?.properties?.postalcode;
+    return raw ? normalizePostcode(String(raw)) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function extractPostcode(
+  address: string
+): Promise<string | null> {
+  if (!address.trim()) return null;
+
+  const regexHit = tryRegex(address);
+  if (regexHit) return regexHit;
+
+  const googleHit = await tryGoogleGeocode(address);
+  if (googleHit) return googleHit;
+
+  const orsHit = await tryOrsGeocode(address);
+  if (orsHit) return orsHit;
+
+  return null;
+}

--- a/src/lib/short-code.ts
+++ b/src/lib/short-code.ts
@@ -1,0 +1,63 @@
+import { extractPostcode } from "@/lib/geocode";
+
+// 23-letter pool: A–Z minus visually ambiguous letters (I, O, L).
+const LETTER_POOL = "ABCDEFGHJKMNPQRSTUVWXYZ";
+
+export function pickLetters(): string {
+  let out = "";
+  for (let i = 0; i < 3; i++) {
+    out += LETTER_POOL[Math.floor(Math.random() * LETTER_POOL.length)];
+  }
+  return out;
+}
+
+export interface ShortCodeInput {
+  numRooms: number | null;
+  numBathrooms: number | null;
+  hasWashingMachine: boolean | null;
+  address: string | null;
+}
+
+export interface ShortCodeParts {
+  rooms: string;
+  baths: string;
+  wash: string;
+  postcode: string;
+}
+
+function formatInt(v: number | null): string {
+  return v == null ? "?" : String(v);
+}
+
+function formatWashing(v: boolean | null): string {
+  if (v === true) return "Y";
+  if (v === false) return "N";
+  return "?";
+}
+
+export async function computeShortCodeParts(
+  input: ShortCodeInput
+): Promise<ShortCodeParts> {
+  const postcode = input.address ? await extractPostcode(input.address) : null;
+  return {
+    rooms: formatInt(input.numRooms),
+    baths: formatInt(input.numBathrooms),
+    wash: formatWashing(input.hasWashingMachine),
+    postcode: postcode ?? "?",
+  };
+}
+
+export function buildShortCode(
+  parts: ShortCodeParts,
+  letters: string = pickLetters()
+): string {
+  return `${letters}-${parts.rooms}B-${parts.baths}b-W${parts.wash}-${parts.postcode}`;
+}
+
+export async function generateShortCode(
+  input: ShortCodeInput,
+  letters: string = pickLetters()
+): Promise<string> {
+  const parts = await computeShortCodeParts(input);
+  return buildShortCode(parts, letters);
+}


### PR DESCRIPTION
## Summary

Closes #31. Every apartment now carries a code like `JQI-3.5B-2b-WY-4057` — random 3-letter prefix + rooms + bathrooms + washing-machine + postcode. Visible on the list, detail, and compare views with a copy-to-clipboard button.

## Architecture

- **`src/lib/short-code.ts`** — splits generation into `computeShortCodeParts` (expensive: postcode extraction) and `buildShortCode` (cheap: segment assembly), so the retry loop on collision only regenerates the 3 random letters, not the postcode.
- **`src/lib/geocode.ts`** — `extractPostcode(address)` tries regex first, then Google Geocoding, then OpenRouteService. Each external call logged to `api_usage` as `operation: "geocode"`.
- **POST /api/apartments** — compute parts once, loop up to 5 times with fresh letters on unique-constraint violations, throw on exhaustion.
- **Backfill** — runs inside `migrate.ts` after the drizzle migrator. Idempotent (`WHERE short_code IS NULL`). Guarded against minimal test DBs.

## Letter pool

23 letters (A–Z minus I, O, L — visually ambiguous), giving 23³ = 12,167 prefixes. Ample for this app's scale.

## Open-question decision (recap)

Went with **Option A** — `short_code` stays nullable at the schema level, uniqueness enforced via index. The app is the sole writer; every new insert generates a code, and the backfill on startup catches existing rows. Avoids a SQLite table-rebuild migration to enforce NOT NULL.

## Tests (115/115 passing, 22 new)

- `src/lib/__tests__/short-code.test.ts` — format (full CH/DE/US/UK), half-rooms preserve the dot, `WY`/`WN`/`W?` states, `?` fallback per field, varied prefixes across 200 calls, letter pool excludes I/O/L, explicit-letters override.
- `src/lib/__tests__/geocode.test.ts` — regex hits per country, Google fallback, ORS fallback when no Google key, returns null when no provider.
- `src/lib/db/__tests__/migrate.test.ts` — updated counts to expect 4 migrations.

## Smoke-tested end-to-end

1. Rebuild Docker. Existing "Flat A" row was backfilled to `BQX-3.5B-1b-WY-?` (no postcode in its address).
2. POST a new apartment with address "Steinenvorstadt 10, 4057 Basel" → `BDY-3.5B-2b-WY-4057` via regex, no API call.
3. GET `/api/apartments` returns both codes; different random prefixes.