### PR TITLE
fix: clear remaining ESLint errors and tighten CI (#36)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,10 +18,8 @@ jobs:
 
       - run: npm ci
 
-      # TODO: remove continue-on-error once #36 is resolved
       - name: Lint
         run: npm run lint
-        continue-on-error: true
 
       - name: Test
         run: npm test

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button, buttonVariants } from "@/components/ui/button";
@@ -92,7 +92,27 @@ export default function ApartmentDetailPage() {
   const [editForm, setEditForm] = useState<ApartmentForm | null>(null);
   const [savingEdit, setSavingEdit] = useState(false);
 
-  const loadApartment = useCallback(async () => {
+  // Shared applier so both the initial effect and event-driven reloads
+  // converge on the same state updates.
+  function applyApartmentData(data: ApartmentDetail) {
+    setApartment(data);
+    setError(null);
+    const name = getCookieValue("flatpare-name") ?? "";
+    setUserName(name);
+    const existing = data.ratings?.find((r) => r.userName === name);
+    if (existing) {
+      setMyRating({
+        kitchen: existing.kitchen,
+        balconies: existing.balconies,
+        location: existing.location,
+        floorplan: existing.floorplan,
+        overallFeeling: existing.overallFeeling,
+        comment: existing.comment || "",
+      });
+    }
+  }
+
+  async function reloadApartment() {
     const url = `/api/apartments/${params.id}`;
     try {
       const res = await fetch(url);
@@ -101,43 +121,49 @@ export default function ApartmentDetailPage() {
           headline: "Couldn't load apartment",
           details: await fetchErrorFromResponse(res, url),
         });
-        setLoading(false);
         return;
       }
-      const data = await res.json();
-      setApartment(data);
-      setError(null);
-
-      const name = getCookieValue("flatpare-name") ?? "";
-      setUserName(name);
-
-      const existing = data.ratings?.find(
-        (r: Rating) => r.userName === name
-      );
-      if (existing) {
-        setMyRating({
-          kitchen: existing.kitchen,
-          balconies: existing.balconies,
-          location: existing.location,
-          floorplan: existing.floorplan,
-          overallFeeling: existing.overallFeeling,
-          comment: existing.comment || "",
-        });
-      }
-
-      setLoading(false);
+      applyApartmentData(await res.json());
     } catch (err) {
       setError({
         headline: "Couldn't load apartment",
         details: fetchErrorFromException(err, url),
       });
-      setLoading(false);
     }
-  }, [params.id]);
+  }
 
   useEffect(() => {
-    loadApartment();
-  }, [loadApartment]);
+    let cancelled = false;
+    const url = `/api/apartments/${params.id}`;
+    void (async () => {
+      try {
+        const res = await fetch(url);
+        if (cancelled) return;
+        if (!res.ok) {
+          setError({
+            headline: "Couldn't load apartment",
+            details: await fetchErrorFromResponse(res, url),
+          });
+          setLoading(false);
+          return;
+        }
+        const data = (await res.json()) as ApartmentDetail;
+        if (cancelled) return;
+        applyApartmentData(data);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError({
+          headline: "Couldn't load apartment",
+          details: fetchErrorFromException(err, url),
+        });
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [params.id]);
 
   async function handleDelete() {
     if (!confirm("Delete this apartment? This cannot be undone.")) return;
@@ -197,7 +223,7 @@ export default function ApartmentDetailPage() {
         setSavingEdit(false);
         return;
       }
-      await loadApartment();
+      await reloadApartment();
       setEditing(false);
       setEditForm(null);
       setSavingEdit(false);
@@ -227,7 +253,7 @@ export default function ApartmentDetailPage() {
         setSaving(false);
         return;
       }
-      await loadApartment();
+      await reloadApartment();
       setSaving(false);
     } catch (err) {
       setError({

--- a/src/components/__tests__/nav-bar.test.tsx
+++ b/src/components/__tests__/nav-bar.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, cleanup, act, waitFor } from "@testing-library/react";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const push = vi.fn();

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { Sun, Moon, Monitor } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -11,11 +11,20 @@ const themes = [
   { value: "system", icon: Monitor, label: "System" },
 ] as const;
 
+// Returns false during SSR and the first client render, true thereafter.
+// Using useSyncExternalStore avoids the setState-in-effect anti-pattern
+// of the older `useEffect(() => setMounted(true), [])` idiom.
+function useIsClient(): boolean {
+  return useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  );
+}
+
 export function ThemeToggle() {
   const { theme, setTheme } = useTheme();
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
+  const mounted = useIsClient();
 
   if (!mounted) {
     return <div className="h-8 w-20" />;

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -6,7 +6,7 @@ vi.mock("next/headers", () => {
   return {
     cookies: vi.fn(async () => ({
       get: (name: string) => cookieStore.get(name),
-      set: (name: string, value: string, _options?: Record<string, unknown>) => {
+      set: (name: string, value: string) => {
         cookieStore.set(name, { value });
       },
       _store: cookieStore,


### PR DESCRIPTION
## Summary

Closes #36. `npm run lint` now exits 0 with no errors or warnings, and CI's lint step no longer needs `continue-on-error`.

## Changes

- **`src/components/theme-toggle.tsx`** — swap `useEffect(() => setMounted(true), [])` for a `useSyncExternalStore`-based `useIsClient` hook. Proper React 18+ pattern; no cascading render.
- **`src/app/apartments/[id]/page.tsx`** — inline the initial fetch in the load effect as an async IIFE with a `cancelled` flag; extract `applyApartmentData` (shared state updater) and keep `reloadApartment` for post-mutation refreshes. `handleSaveRating` and `handleSaveEdit` now call `reloadApartment`. Drops the `useCallback` + `useEffect([loadApartment])` coupling that triggered `react-hooks/set-state-in-effect`.
- **`src/lib/__tests__/auth.test.ts`** — drop the unused `_options` param from the `cookies().set` mock.
- **`src/components/__tests__/nav-bar.test.tsx`** — drop the unused `act` import.
- **`.github/workflows/test.yml`** — remove `continue-on-error: true` (and the TODO) on the lint step.

## Tests (115/115) + lint + build

- `npm run lint` → exit 0, zero problems.
- `npm test` → 115/115 passing.
- `npm run build` → clean.

Edit-flow and nav-bar tests exercise the refactored detail page and pass unchanged.