### PR TITLE
feat: remove Ollama — PDF parsing uses Gemini (online) only (#29)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,17 +10,13 @@ TURSO_AUTH_TOKEN=
 # Vercel Blob storage (omit for local filesystem)
 BLOB_READ_WRITE_TOKEN=
 
-# Google Gemini for PDF parsing (omit to use Ollama or manual entry)
+# Google Gemini for PDF parsing (omit to fall back to manual entry)
 GOOGLE_GENERATIVE_AI_API_KEY=
 
 # Google Maps Distance Matrix API (omit to use OpenRouteService or manual entry)
 GOOGLE_MAPS_API_KEY=
 
 # --- Local/self-hosted mode (free alternatives) ---
-
-# Ollama for PDF parsing (omit if using Gemini)
-# OLLAMA_BASE_URL=http://localhost:11434
-# OLLAMA_MODEL=llava
 
 # OpenRouteService for distance calculation (omit if using Google Maps)
 # OPENROUTESERVICE_API_KEY=

--- a/README.md
+++ b/README.md
@@ -123,18 +123,6 @@ npm run dev
 
 Data lives in `./data/flatpare.db`; uploaded PDFs go to `./uploads/`. Both are gitignored.
 
-**Optional — Ollama for PDF parsing**
-
-```bash
-ollama pull llava
-ollama serve
-```
-
-```env
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=llava
-```
-
 **Optional — OpenRouteService for bike distance**
 
 Sign up at [openrouteservice.org/dev](https://openrouteservice.org/dev/#/signup) (free, no credit card). Transit is not supported — enter manually.
@@ -154,13 +142,6 @@ Use a different host port:
 
 ```bash
 PORT=8080 docker compose up -d
-```
-
-With host-installed Ollama for PDF parsing:
-
-```env
-OLLAMA_BASE_URL=http://host.docker.internal:11434
-OLLAMA_MODEL=llava
 ```
 
 Rebuild after updates:
@@ -183,7 +164,7 @@ docker compose up -d
 | ORM | [Drizzle ORM](https://orm.drizzle.team) | Same |
 | Styling | Tailwind CSS + [shadcn/ui](https://ui.shadcn.com) | Same |
 | File Storage | [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) | Local filesystem |
-| PDF Parsing | [Vercel AI SDK](https://sdk.vercel.ai) + Google Gemini | Ollama (local LLM) or manual entry |
+| PDF Parsing | [Vercel AI SDK](https://sdk.vercel.ai) + Google Gemini | Google Gemini or manual entry |
 | Distance API | Google Maps Distance Matrix | [OpenRouteService](https://openrouteservice.org) (free) or manual entry |
 | Deployment | [Vercel](https://vercel.com) | Any Node.js host |
 
@@ -214,7 +195,7 @@ src/
   lib/
     db/                         # Drizzle schema + client
     auth.ts                     # Cookie/session helpers
-    parse-pdf.ts                # AI extraction (Gemini / Ollama)
+    parse-pdf.ts                # AI extraction (Gemini)
     distance.ts                 # Distance (Google Maps / OpenRouteService)
     storage.ts                  # File storage (Blob / filesystem)
   proxy.ts                      # Auth proxy (Next.js 16)
@@ -226,7 +207,7 @@ src/
 <summary><strong>Architecture</strong></summary>
 
 - **Authentication:** shared password gate with HTTP-only cookies; no accounts. The auth proxy (`proxy.ts`) redirects unauthenticated requests.
-- **PDF flow:** upload → store → AI extraction → structured data → user reviews & saves. Provider auto-selects between Gemini, Ollama, and manual entry.
+- **PDF flow:** upload → store → AI extraction → structured data → user reviews & saves. Uses Google Gemini when configured; falls back to manual entry.
 - **Distance:** Google Maps preferred, OpenRouteService fallback. Returns bike and transit minutes.
 - **Ratings:** one upsert per user per apartment across 5 categories; averages drive the comparison grid.
 - **Storage:** Turso or local SQLite for data; Vercel Blob or `./uploads/` for files.
@@ -266,8 +247,6 @@ src/
 | `BLOB_READ_WRITE_TOKEN` | No | Cloud | Vercel Blob token (auto-set on Vercel) |
 | `GOOGLE_GENERATIVE_AI_API_KEY` | No | Cloud | Google Gemini API key for PDF parsing |
 | `GOOGLE_MAPS_API_KEY` | No | Cloud | Google Maps for distance calculation |
-| `OLLAMA_BASE_URL` | No | Local | Ollama server URL (e.g. `http://localhost:11434`) |
-| `OLLAMA_MODEL` | No | Local | Ollama model name (default: `llava`) |
 | `OPENROUTESERVICE_API_KEY` | No | Local | Free distance calculation alternative |
 | `DISABLE_SECURE_COOKIES` | No | Local | Set to bypass secure cookie flag in dev |
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "dependencies": {
         "@ai-sdk/google": "^3.0.64",
-        "@ai-sdk/openai": "^3.0.53",
         "@base-ui/react": "^1.4.0",
         "@libsql/client": "^0.17.2",
         "@vercel/blob": "^2.3.3",
@@ -74,22 +73,6 @@
       "version": "3.0.64",
       "resolved": "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.64.tgz",
       "integrity": "sha512-CbR82EgGPNrj/6q0HtclwuCqe0/pDShyv3nWDP/A9DroujzWXnLMlUJVrgPOsg4b40zQCwwVs2XSKCxvt/4QaA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ai-sdk/provider": "3.0.8",
-        "@ai-sdk/provider-utils": "4.0.23"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.76 || ^4.1.8"
-      }
-    },
-    "node_modules/@ai-sdk/openai": {
-      "version": "3.0.53",
-      "resolved": "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.53.tgz",
-      "integrity": "sha512-Wld+Rbc05KaUn08uBt06eEuwcgalcIFtIl32Yp+GxuZXUQwOb6YeAuq+C6da4ch6BurFoqEaLemJVwjBb7x+PQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/provider": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.64",
-    "@ai-sdk/openai": "^3.0.53",
     "@base-ui/react": "^1.4.0",
     "@libsql/client": "^0.17.2",
     "@vercel/blob": "^2.3.3",

--- a/src/app/api/__tests__/parse-pdf.test.ts
+++ b/src/app/api/__tests__/parse-pdf.test.ts
@@ -22,7 +22,6 @@ import { POST } from "../../api/parse-pdf/route";
 beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-  delete process.env.OLLAMA_BASE_URL;
 });
 
 afterEach(() => {

--- a/src/app/api/parse-pdf/route.ts
+++ b/src/app/api/parse-pdf/route.ts
@@ -20,9 +20,7 @@ export async function POST(request: Request) {
     const pdfUrl = await uploadFile(filename, file);
 
     // Try AI extraction — if no AI provider is configured, return empty extraction
-    const hasAI =
-      !!process.env.GOOGLE_GENERATIVE_AI_API_KEY ||
-      !!process.env.OLLAMA_BASE_URL;
+    const hasAI = !!process.env.GOOGLE_GENERATIVE_AI_API_KEY;
 
     if (!hasAI) {
       return NextResponse.json({

--- a/src/content/guide.md
+++ b/src/content/guide.md
@@ -55,7 +55,7 @@ Scroll horizontally to see all apartments if there are more than fit on screen.
 
 - Supports single or bulk PDF upload
 - Files are stored locally (self-hosted) or in Vercel Blob (cloud)
-- AI extraction uses Google Gemini or a local Ollama model
+- AI extraction uses Google Gemini
 
 ### Distance Calculation
 
@@ -82,5 +82,4 @@ This helps you track spending if you're using paid APIs.
 
 - **Bulk upload:** You can select multiple PDFs at once on the Upload page
 - **Re-rate anytime:** Your ratings are saved per user; just go back to the apartment and change them
-- **Works offline:** In self-hosted mode with Ollama, everything runs locally with no external API calls
 - **Mobile-friendly:** Use the bottom navigation bar on your phone

--- a/src/lib/__tests__/parse-pdf.test.ts
+++ b/src/lib/__tests__/parse-pdf.test.ts
@@ -24,10 +24,6 @@ vi.mock("@ai-sdk/google", () => ({
   google: vi.fn(() => "gemini-model"),
 }));
 
-vi.mock("@ai-sdk/openai", () => ({
-  createOpenAI: vi.fn(() => vi.fn(() => "ollama-model")),
-}));
-
 import { extractApartmentData, apartmentExtractionSchema } from "../parse-pdf";
 import { generateText } from "ai";
 
@@ -35,8 +31,6 @@ const mockedGenerateText = vi.mocked(generateText);
 
 beforeEach(() => {
   delete process.env.GOOGLE_GENERATIVE_AI_API_KEY;
-  delete process.env.OLLAMA_BASE_URL;
-  delete process.env.OLLAMA_MODEL;
 });
 
 afterEach(() => {
@@ -170,27 +164,6 @@ describe("extractApartmentData", () => {
       data: "base64pdf",
       mediaType: "application/pdf",
     });
-  });
-
-  it("uses Ollama when OLLAMA_BASE_URL is set", async () => {
-    process.env.OLLAMA_BASE_URL = "http://localhost:11434";
-
-    mockedGenerateText.mockResolvedValue({
-      output: {
-        name: "Ollama Apt",
-        address: null,
-        sizeM2: null,
-        numRooms: null,
-        numBathrooms: null,
-        numBalconies: null,
-        hasWashingMachine: null,
-        rentChf: null,
-      },
-      usage: { inputTokens: 50, outputTokens: 25 },
-    } as never);
-
-    const result = await extractApartmentData("base64pdf");
-    expect(result.name).toBe("Ollama Apt");
   });
 
   it("throws when no AI provider is configured", async () => {

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -1,6 +1,5 @@
 import { generateText, Output } from "ai";
 import { google } from "@ai-sdk/google";
-import { createOpenAI } from "@ai-sdk/openai";
 import { z } from "zod";
 import { db } from "@/lib/db";
 import { apiUsage } from "@/lib/db/schema";
@@ -46,24 +45,10 @@ export const apartmentExtractionSchema = z.object({
 export type ApartmentExtraction = z.infer<typeof apartmentExtractionSchema>;
 
 function getModel() {
-  // Cloud mode: Google Gemini
   if (process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
     return {
       model: google("gemini-2.5-flash"),
       service: "gemini" as const,
-    };
-  }
-
-  // Local mode: Ollama via OpenAI-compatible API
-  if (process.env.OLLAMA_BASE_URL) {
-    const ollama = createOpenAI({
-      baseURL: `${process.env.OLLAMA_BASE_URL}/v1`,
-      apiKey: "ollama", // Ollama doesn't need a real key
-    });
-    const modelName = process.env.OLLAMA_MODEL || "llava";
-    return {
-      model: ollama(modelName),
-      service: "ollama" as const,
     };
   }
 


### PR DESCRIPTION
## Summary

Closes #29. Drops every Ollama touchpoint; Gemini is the only AI provider path left. Manual entry still works when no provider is configured.

## Changes

- **`src/lib/parse-pdf.ts`** — remove the `OLLAMA_BASE_URL` branch in `getModel`, remove the `@ai-sdk/openai` import.
- **`src/app/api/parse-pdf/route.ts`** — `hasAI` now depends only on `GOOGLE_GENERATIVE_AI_API_KEY`.
- **Tests** — drop Ollama case in `src/lib/__tests__/parse-pdf.test.ts` and `src/app/api/__tests__/parse-pdf.test.ts`. Gemini + no-provider paths unchanged.
- **`package.json`** — remove `@ai-sdk/openai` (Ollama shim was the only consumer).
- **`.env.example`, `README.md`, `src/content/guide.md`** — every Ollama reference removed.

## Explicitly unchanged

Per the issue: Docker, local SQLite fallback, local filesystem storage fallback, OpenRouteService, `DISABLE_SECURE_COOKIES`, manual-entry PDF flow.

## Verification (all green locally)

- `npm test` → **114/114** (one Ollama test removed, rest untouched).
- `npm run lint` → exit 0.
- `npm run build` → clean.
- Grepped the repo — zero remaining `ollama`/`@ai-sdk/openai` references.