### PR TITLE
fix: switch Vercel Blob to private access + auth-gated proxy route

### DIFF
--- a/src/app/api/pdf/[...path]/route.ts
+++ b/src/app/api/pdf/[...path]/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+import { get } from "@vercel/blob";
+import { isAuthenticated } from "@/lib/auth";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ path: string[] }> }
+) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { path: segments } = await params;
+  const pathname = segments.join("/");
+
+  try {
+    const result = await get(pathname, { access: "private" });
+    if (!result || result.statusCode !== 200) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const headers = new Headers();
+    headers.set(
+      "Content-Type",
+      result.headers.get("content-type") ?? "application/pdf"
+    );
+    headers.set(
+      "Content-Disposition",
+      result.blob.contentDisposition ?? "inline"
+    );
+
+    return new Response(result.stream, { headers });
+  } catch (error) {
+    console.error("[pdf:GET] Error:", error);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : "Failed to fetch PDF" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/pdf/__tests__/pdf.test.ts
+++ b/src/app/api/pdf/__tests__/pdf.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  isAuthenticated: vi.fn(),
+}));
+
+vi.mock("@vercel/blob", () => ({
+  get: vi.fn(),
+}));
+
+import { isAuthenticated } from "@/lib/auth";
+import { get } from "@vercel/blob";
+import { GET } from "../[...path]/route";
+
+const mockIsAuthenticated = vi.mocked(isAuthenticated);
+const mockGet = vi.mocked(get);
+
+beforeEach(() => {
+  mockIsAuthenticated.mockReset();
+  mockGet.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(params: string[]) {
+  return {
+    request: new Request("http://localhost/api/pdf/" + params.join("/")),
+    ctx: { params: Promise.resolve({ path: params }) },
+  };
+}
+
+describe("GET /api/pdf/[...path]", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockIsAuthenticated.mockResolvedValue(false);
+    const { request, ctx } = makeRequest(["apartments", "file.pdf"]);
+    const res = await GET(request, ctx);
+    expect(res.status).toBe(401);
+    expect(mockGet).not.toHaveBeenCalled();
+  });
+
+  it("calls get() with access: 'private' and the joined pathname", async () => {
+    mockIsAuthenticated.mockResolvedValue(true);
+    mockGet.mockResolvedValue({
+      statusCode: 200,
+      stream: new ReadableStream({ start: (c) => c.close() }),
+      headers: new Headers({ "content-type": "application/pdf" }),
+      blob: { contentDisposition: "inline" },
+    } as never);
+    const { request, ctx } = makeRequest(["apartments", "nested", "file.pdf"]);
+    const res = await GET(request, ctx);
+    expect(res.status).toBe(200);
+    expect(mockGet).toHaveBeenCalledWith("apartments/nested/file.pdf", {
+      access: "private",
+    });
+  });
+
+  it("returns 404 when the blob is not found", async () => {
+    mockIsAuthenticated.mockResolvedValue(true);
+    mockGet.mockResolvedValue(null);
+    const { request, ctx } = makeRequest(["apartments", "missing.pdf"]);
+    const res = await GET(request, ctx);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/uploads/[...path]/route.ts
+++ b/src/app/api/uploads/[...path]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { readFile } from "fs/promises";
 import path from "path";
+import { isAuthenticated } from "@/lib/auth";
 
 const UPLOADS_DIR = path.join(process.cwd(), "uploads");
 
@@ -8,6 +9,10 @@ export async function GET(
   _request: Request,
   { params }: { params: Promise<{ path: string[] }> }
 ) {
+  if (!(await isAuthenticated())) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
   const { path: segments } = await params;
   const filename = segments.join("/");
 

--- a/src/app/api/uploads/__tests__/uploads.test.ts
+++ b/src/app/api/uploads/__tests__/uploads.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  isAuthenticated: vi.fn(),
+}));
+
+import { isAuthenticated } from "@/lib/auth";
+import { GET } from "../[...path]/route";
+
+const mockIsAuthenticated = vi.mocked(isAuthenticated);
+
+beforeEach(() => {
+  mockIsAuthenticated.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeRequest(params: string[]) {
+  return {
+    request: new Request("http://localhost/api/uploads/" + params.join("/")),
+    ctx: { params: Promise.resolve({ path: params }) },
+  };
+}
+
+describe("GET /api/uploads/[...path]", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockIsAuthenticated.mockResolvedValue(false);
+    const { request, ctx } = makeRequest(["file.pdf"]);
+    const res = await GET(request, ctx);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects path traversal attempts with 403 for authed users", async () => {
+    mockIsAuthenticated.mockResolvedValue(true);
+    const { request, ctx } = makeRequest(["..", "..", "etc", "passwd"]);
+    const res = await GET(request, ctx);
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 for authed users when file is missing", async () => {
+    mockIsAuthenticated.mockResolvedValue(true);
+    const { request, ctx } = makeRequest(["definitely-not-there-" + Date.now() + ".pdf"]);
+    const res = await GET(request, ctx);
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/lib/__tests__/storage.test.ts
+++ b/src/lib/__tests__/storage.test.ts
@@ -15,11 +15,12 @@ function createMockFile(name: string): File {
 }
 
 describe("uploadFile", () => {
-  it("uses Vercel Blob in cloud mode", async () => {
+  it("uploads to Vercel Blob with access: 'private' and returns an /api/pdf path", async () => {
     process.env.BLOB_READ_WRITE_TOKEN = "test-token";
 
     const mockPut = vi.fn(async () => ({
-      url: "https://blob.vercel-storage.com/apartments/test.pdf",
+      pathname: "apartments/test.pdf",
+      url: "ignored-private-url",
     }));
 
     vi.doMock("@vercel/blob", () => ({ put: mockPut }));
@@ -32,8 +33,12 @@ describe("uploadFile", () => {
     const file = createMockFile("test.pdf");
     const url = await uploadFile("test.pdf", file);
 
-    expect(url).toBe("https://blob.vercel-storage.com/apartments/test.pdf");
-    expect(mockPut).toHaveBeenCalled();
+    expect(url).toBe("/api/pdf/apartments/test.pdf");
+    expect(mockPut).toHaveBeenCalledWith(
+      "apartments/test.pdf",
+      file,
+      { access: "private" }
+    );
 
     delete process.env.BLOB_READ_WRITE_TOKEN;
   });

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -11,13 +11,14 @@ export async function uploadFile(
   file: File
 ): Promise<string> {
   if (isCloud) {
+    // Private blobs — served back through the auth-gated /api/pdf proxy.
     const blob = await put(`apartments/${filename}`, file, {
-      access: "public",
+      access: "private",
     });
-    return blob.url;
+    return `/api/pdf/${blob.pathname}`;
   }
 
-  // Local mode: write to ./uploads/
+  // Local mode: write to ./uploads/, served back through /api/uploads.
   await mkdir(UPLOADS_DIR, { recursive: true });
   const buffer = Buffer.from(await file.arrayBuffer());
   const filePath = path.join(UPLOADS_DIR, filename);


### PR DESCRIPTION
## Summary

Production was throwing `Vercel Blob: Cannot use public access on a private store` on every `/api/parse-pdf` call. The Blob store's access mode is immutable per-store, so we keep it **private** and serve uploaded PDFs through an auth-gated proxy.

## Changes

- **`src/lib/storage.ts`** — `put(..., { access: "private" })`; cloud-mode uploads now return `/api/pdf/<pathname>` instead of the blob URL. Local mode unchanged (`/api/uploads/<filename>`).
- **`src/app/api/pdf/[...path]/route.ts`** _(new)_ — auth-gates via `isAuthenticated()`, then streams the private blob via `@vercel/blob`'s `get()`. Handles 401 / 404 / 500.
- **`src/app/api/uploads/[...path]/route.ts`** — added the same auth check. Previously anyone with a filename could read uploaded PDFs on self-hosted mode; now it matches the Blob proxy's gate.
- **Tests** — `pdf.test.ts` (3), `uploads.test.ts` (3), and an updated `storage.test.ts` covering the new `/api/pdf/…` cloud return shape. 120/120 passing.

## Smoke-tested end-to-end

- `GET /api/uploads/file.pdf` without auth → **401** ✓
- `GET /api/uploads/missing.pdf` with auth → **404** ✓ (graceful)
- `GET /api/pdf/file.pdf` without auth → **401** ✓

## Why not flip the store to public

Tried — the Vercel UI confirmed the access mode can't be changed after creation. Creating a new public store would have worked but leaves PDF URLs world-readable (apartment listings contain contact info / personal data in some cases). Private-with-proxy matches the rest of the app's auth model (password gate + name cookie).

## Verification

- `npm test` → 120/120.
- `npm run lint` → exit 0.
- Docker rebuild + curl smoke confirms all four auth branches.