### PR TITLE
feat: add Cancel button to the rating form (#49)

### DIFF
--- a/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
+++ b/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
@@ -142,7 +142,13 @@ describe("Apartment detail edit flow", () => {
     await user.clear(nameInput);
     await user.type(nameInput, "Something else");
 
-    await user.click(screen.getByRole("button", { name: /^Cancel$/ }));
+    // Two Cancel buttons exist on the page (rating form + edit form);
+    // click the enabled one (edit form).
+    const cancels = screen.getAllByRole("button", { name: /^Cancel$/ });
+    const editCancel = cancels.find(
+      (b) => !(b as HTMLButtonElement).disabled
+    )!;
+    await user.click(editCancel);
 
     // No PATCH was made.
     expect(
@@ -169,7 +175,11 @@ describe("Apartment detail edit flow", () => {
     await user.click(screen.getByRole("button", { name: /^Edit$/ }));
     expect(screen.getByRole("button", { name: /Delete/i })).toBeDisabled();
 
-    await user.click(screen.getByRole("button", { name: /^Cancel$/ }));
+    const cancels = screen.getAllByRole("button", { name: /^Cancel$/ });
+    const editCancel = cancels.find(
+      (b) => !(b as HTMLButtonElement).disabled
+    )!;
+    await user.click(editCancel);
     expect(screen.getByRole("button", { name: /Delete/i })).not.toBeDisabled();
 
     // "within" import just to keep the import list stable.

--- a/src/app/apartments/[id]/__tests__/rating-cancel.test.tsx
+++ b/src/app/apartments/[id]/__tests__/rating-cancel.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "42" }),
+  useRouter: () => ({ push, refresh }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const BASE_APARTMENT = {
+  id: 42,
+  name: "Test Flat",
+  address: null,
+  sizeM2: null,
+  numRooms: null,
+  numBathrooms: null,
+  numBalconies: null,
+  hasWashingMachine: null,
+  rentChf: null,
+  distanceBikeMin: null,
+  distanceTransitMin: null,
+  pdfUrl: null,
+  listingUrl: null,
+  shortCode: "ABC-?B-?b-W?-?",
+  ratings: [
+    {
+      id: 1,
+      userName: "Alice",
+      kitchen: 3,
+      balconies: 3,
+      location: 3,
+      floorplan: 3,
+      overallFeeling: 3,
+      comment: "saved text",
+    },
+  ],
+};
+
+beforeEach(() => {
+  push.mockReset();
+  refresh.mockReset();
+  // Current user is Alice (via cookie)
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    get: () => "flatpare-name=Alice",
+    set: () => {},
+  });
+
+  vi.spyOn(global, "fetch").mockImplementation(((
+    input: RequestInfo,
+    init?: RequestInit
+  ) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    const method = init?.method ?? "GET";
+    if (url.endsWith("/api/apartments/42") && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(BASE_APARTMENT),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  }) as typeof fetch);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Rating cancel", () => {
+  it("Save and Cancel are disabled when the rating is pristine", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByRole("button", { name: /Save Rating/ })
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^Cancel$/ })).toBeDisabled();
+  });
+
+  it("Cancel reverts an unsaved comment change and re-disables both buttons", async () => {
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+
+    const comment = screen.getByPlaceholderText(
+      /Notes about this apartment/i
+    ) as HTMLTextAreaElement;
+    expect(comment.value).toBe("saved text");
+
+    await user.clear(comment);
+    await user.type(comment, "edited but not saved");
+    expect(comment.value).toBe("edited but not saved");
+
+    // Dirty → buttons active
+    expect(
+      screen.getByRole("button", { name: /Save Rating/ })
+    ).not.toBeDisabled();
+    expect(
+      screen.getByRole("button", { name: /^Cancel$/ })
+    ).not.toBeDisabled();
+
+    await user.click(screen.getByRole("button", { name: /^Cancel$/ }));
+
+    // Reverted
+    expect(comment.value).toBe("saved text");
+    expect(
+      screen.getByRole("button", { name: /Save Rating/ })
+    ).toBeDisabled();
+    expect(screen.getByRole("button", { name: /^Cancel$/ })).toBeDisabled();
+  });
+});

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -77,14 +77,16 @@ export default function ApartmentDetailPage() {
   const [apartment, setApartment] = useState<ApartmentDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
-  const [myRating, setMyRating] = useState({
+  const EMPTY_RATING = {
     kitchen: 0,
     balconies: 0,
     location: 0,
     floorplan: 0,
     overallFeeling: 0,
     comment: "",
-  });
+  };
+  const [myRating, setMyRating] = useState(EMPTY_RATING);
+  const [cleanRating, setCleanRating] = useState(EMPTY_RATING);
   const [saving, setSaving] = useState(false);
   const [userName, setUserName] = useState("");
   const [error, setError] = useState<ErrorState | null>(null);
@@ -100,16 +102,18 @@ export default function ApartmentDetailPage() {
     const name = getCookieValue("flatpare-name") ?? "";
     setUserName(name);
     const existing = data.ratings?.find((r) => r.userName === name);
-    if (existing) {
-      setMyRating({
-        kitchen: existing.kitchen,
-        balconies: existing.balconies,
-        location: existing.location,
-        floorplan: existing.floorplan,
-        overallFeeling: existing.overallFeeling,
-        comment: existing.comment || "",
-      });
-    }
+    const snapshot = existing
+      ? {
+          kitchen: existing.kitchen,
+          balconies: existing.balconies,
+          location: existing.location,
+          floorplan: existing.floorplan,
+          overallFeeling: existing.overallFeeling,
+          comment: existing.comment || "",
+        }
+      : EMPTY_RATING;
+    setMyRating(snapshot);
+    setCleanRating(snapshot);
   }
 
   async function reloadApartment() {
@@ -163,6 +167,7 @@ export default function ApartmentDetailPage() {
     return () => {
       cancelled = true;
     };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params.id]);
 
   async function handleDelete() {
@@ -235,6 +240,18 @@ export default function ApartmentDetailPage() {
       setSavingEdit(false);
     }
   }
+
+  function handleCancelRating() {
+    setMyRating(cleanRating);
+  }
+
+  const isRatingDirty =
+    myRating.kitchen !== cleanRating.kitchen ||
+    myRating.balconies !== cleanRating.balconies ||
+    myRating.location !== cleanRating.location ||
+    myRating.floorplan !== cleanRating.floorplan ||
+    myRating.overallFeeling !== cleanRating.overallFeeling ||
+    myRating.comment !== cleanRating.comment;
 
   async function handleSaveRating() {
     setSaving(true);
@@ -461,9 +478,21 @@ export default function ApartmentDetailPage() {
               rows={3}
             />
           </div>
-          <Button onClick={handleSaveRating} disabled={saving}>
-            {saving ? "Saving..." : "Save Rating"}
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              onClick={handleSaveRating}
+              disabled={saving || !isRatingDirty}
+            >
+              {saving ? "Saving..." : "Save Rating"}
+            </Button>
+            <Button
+              variant="outline"
+              onClick={handleCancelRating}
+              disabled={saving || !isRatingDirty}
+            >
+              Cancel
+            </Button>
+          </div>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary

Closes #49. Stars / comment changes in the rating card can now be discarded without hitting Save or browser-back.

## Changes

- Track a `cleanRating` snapshot alongside `myRating`; seed both from the loaded apartment (or an empty rating if the user hasn't rated yet). Re-seed after a successful save so Cancel/Save disable again.
- New `isRatingDirty` flag (stars + comment diff). Save and Cancel are both disabled when pristine.
- New **Cancel** button next to **Save Rating**; reverts `myRating` to the snapshot. No API call.
- Edit-flow tests updated: two Cancel buttons coexist now (edit form + rating form), so those tests pick the enabled one.

## Tests (122/122)

- `src/app/apartments/[id]/__tests__/rating-cancel.test.tsx` — pristine disables both buttons; edit + Cancel reverts to saved text and re-disables.
- Edit-flow tests still pass with the disambiguation tweak.