### PR TITLE
feat: address renders as Google Maps link (#51)

### DIFF
--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Label } from "@/components/ui/label";
 import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
+import { AddressLink } from "@/components/address-link";
 import { WashingMachine } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
@@ -312,7 +313,10 @@ export default function ApartmentDetailPage() {
           <h1 className="text-2xl font-semibold">{apartment.name}</h1>
           <ShortCode code={apartment.shortCode} />
           {apartment.address && (
-            <p className="text-muted-foreground">{apartment.address}</p>
+            <AddressLink
+              address={apartment.address}
+              className="text-muted-foreground"
+            />
           )}
         </div>
         <div className="flex items-center gap-2">

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -7,6 +7,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
+import { AddressLink } from "@/components/address-link";
 import { Building2 } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
@@ -123,7 +124,10 @@ export default function ApartmentsPage() {
                 </div>
                 <ShortCode code={apt.shortCode} />
                 {apt.address && (
-                  <p className="text-sm text-muted-foreground">{apt.address}</p>
+                  <AddressLink
+                    address={apt.address}
+                    className="text-sm text-muted-foreground"
+                  />
                 )}
                 <div className="flex flex-wrap gap-2">
                   {apt.rentChf && (

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
+import { AddressLink } from "@/components/address-link";
 import { cn } from "@/lib/utils";
 import { BarChart3 } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
@@ -194,9 +195,10 @@ export default function ComparePage() {
                       <div className="font-semibold">{apt.name}</div>
                       <ShortCode code={apt.shortCode} />
                       {apt.address && (
-                        <div className="text-xs font-normal text-muted-foreground">
-                          {apt.address}
-                        </div>
+                        <AddressLink
+                          address={apt.address}
+                          className="text-xs font-normal text-muted-foreground"
+                        />
                       )}
                     </div>
                     <Button

--- a/src/components/__tests__/address-link.test.tsx
+++ b/src/components/__tests__/address-link.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AddressLink } from "../address-link";
+
+let openMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  openMock = vi.fn();
+  vi.stubGlobal("open", openMock);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("AddressLink", () => {
+  it("renders nothing when address is null", () => {
+    const { container } = render(<AddressLink address={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("opens Google Maps in a new tab when clicked", async () => {
+    const user = userEvent.setup();
+    render(<AddressLink address="Sonnenweg 3, 8001 Zurich" />);
+
+    const btn = screen.getByRole("button", {
+      name: /Open Sonnenweg 3, 8001 Zurich in Google Maps/,
+    });
+    await user.click(btn);
+
+    expect(openMock).toHaveBeenCalledOnce();
+    const [url, target, features] = openMock.mock.calls[0];
+    expect(url).toBe(
+      "https://www.google.com/maps/search/?api=1&query=Sonnenweg%203%2C%208001%20Zurich"
+    );
+    expect(target).toBe("_blank");
+    expect(String(features)).toContain("noopener");
+  });
+
+  it("stops propagation so outer <Link> wrappers don't navigate", async () => {
+    const user = userEvent.setup();
+    const outer = vi.fn();
+    render(
+      <div onClick={outer}>
+        <AddressLink address="Some St 1" />
+      </div>
+    );
+    await user.click(screen.getByRole("button"));
+    expect(openMock).toHaveBeenCalled();
+    expect(outer).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/address-link.tsx
+++ b/src/components/address-link.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { cn } from "@/lib/utils";
+
+function mapsUrl(address: string): string {
+  return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(
+    address
+  )}`;
+}
+
+// Rendered as a <button> (not <a>) so it can be safely nested inside
+// other links (e.g. the apartment list card's <Link> wrapper) without
+// producing invalid-HTML nesting warnings.
+export function AddressLink({
+  address,
+  className,
+}: {
+  address: string | null | undefined;
+  className?: string;
+}) {
+  if (!address) return null;
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        window.open(mapsUrl(address), "_blank", "noopener,noreferrer");
+      }}
+      className={cn(
+        "text-left underline-offset-2 hover:underline hover:text-foreground",
+        className
+      )}
+      aria-label={`Open ${address} in Google Maps`}
+    >
+      {address}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

Closes #51. Any apartment address shown in the UI is now clickable — opens Google Maps in a new tab at that location.

## Implementation

New reusable `<AddressLink>` in `src/components/address-link.tsx`. Renders as a `<button>` (not `<a>`) for two reasons:

1. The apartment list card is wrapped in a Next `<Link>`; nesting an `<a>` inside would be invalid HTML and produce dev warnings.
2. A button can safely `stopPropagation` on click so the outer card link doesn't also navigate.

Click handler calls `window.open(mapsUrl, "_blank", "noopener,noreferrer")`. URL is the official [Google Maps search URL](https://developers.google.com/maps/documentation/urls/get-started) — no API key required:

```
https://www.google.com/maps/search/?api=1&query=<encoded-address>
```

## Call sites wired

- `src/app/apartments/page.tsx` — list card
- `src/app/apartments/[id]/page.tsx` — detail header
- `src/app/compare/page.tsx` — compare grid column header

## Tests (125/125)

- `src/components/__tests__/address-link.test.tsx` — null-address renders nothing, click opens correct Maps URL, click doesn't propagate.