### PR TITLE
feat: make apartment short code more prominent (#52)

### DIFF
--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -310,8 +310,8 @@ export default function ApartmentDetailPage() {
     <div className="space-y-6">
       <div className="flex items-start justify-between">
         <div className="space-y-1">
+          <ShortCode code={apartment.shortCode} size="lg" />
           <h1 className="text-2xl font-semibold">{apartment.name}</h1>
-          <ShortCode code={apartment.shortCode} />
           {apartment.address && (
             <AddressLink
               address={apartment.address}

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -112,6 +112,7 @@ export default function ApartmentsPage() {
           <Link key={apt.id} href={`/apartments/${apt.id}`}>
             <Card className="transition-shadow hover:shadow-md">
               <CardContent className="space-y-2 p-4">
+                <ShortCode code={apt.shortCode} size="md" />
                 <div className="flex items-start justify-between">
                   <h3 className="font-medium leading-tight">{apt.name}</h3>
                   {apt.avgOverall && (
@@ -122,7 +123,6 @@ export default function ApartmentsPage() {
                     />
                   )}
                 </div>
-                <ShortCode code={apt.shortCode} />
                 {apt.address && (
                   <AddressLink
                     address={apt.address}

--- a/src/components/__tests__/short-code.test.tsx
+++ b/src/components/__tests__/short-code.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, screen, cleanup } from "@testing-library/react";
+import { ShortCode } from "../short-code";
+
+afterEach(() => cleanup());
+
+describe("ShortCode", () => {
+  it("renders nothing when code is null", () => {
+    const { container } = render(<ShortCode code={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders with sm size by default", () => {
+    render(<ShortCode code="JQI-3B-2b-WY-4057" />);
+    const wrapper = screen.getByText("JQI-3B-2b-WY-4057").parentElement!;
+    expect(wrapper).toHaveAttribute("data-short-code-size", "sm");
+  });
+
+  it("respects size='lg' for the prominent variant", () => {
+    render(<ShortCode code="JQI-3B-2b-WY-4057" size="lg" />);
+    const wrapper = screen.getByText("JQI-3B-2b-WY-4057").parentElement!;
+    expect(wrapper).toHaveAttribute("data-short-code-size", "lg");
+    expect(wrapper.className).toContain("text-base");
+  });
+
+  it("respects size='md'", () => {
+    render(<ShortCode code="JQI-3B-2b-WY-4057" size="md" />);
+    const wrapper = screen.getByText("JQI-3B-2b-WY-4057").parentElement!;
+    expect(wrapper).toHaveAttribute("data-short-code-size", "md");
+    expect(wrapper.className).toContain("text-sm");
+  });
+});

--- a/src/components/short-code.tsx
+++ b/src/components/short-code.tsx
@@ -4,11 +4,27 @@ import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+type Size = "sm" | "md" | "lg";
+
+const sizeClasses: Record<Size, string> = {
+  sm: "px-1.5 py-0.5 text-xs",
+  md: "px-2 py-0.5 text-sm",
+  lg: "px-2.5 py-1 text-base",
+};
+
+const iconClasses: Record<Size, string> = {
+  sm: "h-3 w-3",
+  md: "h-3.5 w-3.5",
+  lg: "h-4 w-4",
+};
+
 export function ShortCode({
   code,
+  size = "sm",
   className,
 }: {
   code: string | null | undefined;
+  size?: Size;
   className?: string;
 }) {
   const [copied, setCopied] = useState(false);
@@ -29,8 +45,10 @@ export function ShortCode({
 
   return (
     <span
+      data-short-code-size={size}
       className={cn(
-        "inline-flex items-center gap-1 rounded border border-border bg-muted/40 px-1.5 py-0.5 font-mono text-xs text-foreground/80",
+        "inline-flex items-center gap-1 rounded border border-border bg-muted/60 font-mono font-medium text-foreground tracking-tight",
+        sizeClasses[size],
         className
       )}
     >
@@ -41,7 +59,11 @@ export function ShortCode({
         onClick={handleCopy}
         className="rounded p-0.5 text-muted-foreground hover:bg-background hover:text-foreground"
       >
-        {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+        {copied ? (
+          <Check className={iconClasses[size]} />
+        ) : (
+          <Copy className={iconClasses[size]} />
+        )}
       </button>
     </span>
   );


### PR DESCRIPTION
## Summary

Closes #52. The short code is now the "eyebrow" of the apartment — rendered above the title, in a stronger, bigger font, so you can grab it at a glance for chat.

## Changes

- **`src/components/short-code.tsx`** — new `size` prop (`"sm" | "md" | "lg"`, default `"sm"`). Stronger default contrast (`text-foreground`, `bg-muted/60`, `font-medium`, `tracking-tight`). Icon sizes scale with text.
- **`src/app/apartments/[id]/page.tsx`** — detail header: code rendered **above** the apartment name at `size="lg"`.
- **`src/app/apartments/page.tsx`** — list card: code moved **above** the title at `size="md"`.
- **`src/app/compare/page.tsx`** — layout unchanged (cramped column); inherits the better contrast at `size="sm"`.

## Tests (129/129)

- `src/components/__tests__/short-code.test.tsx` — renders nothing for null, defaults to sm, applies lg/md size classes.