### PR TITLE
feat: small Google Map on the apartment detail page (#57)

### DIFF
--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -11,6 +11,7 @@ import { Label } from "@/components/ui/label";
 import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
 import { AddressLink } from "@/components/address-link";
+import { ApartmentMap } from "@/components/apartment-map";
 import { WashingMachine } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
@@ -56,6 +57,7 @@ interface ApartmentDetail {
   pdfUrl: string | null;
   listingUrl: string | null;
   shortCode: string | null;
+  mapEmbedUrl: string | null;
   ratings: Rating[];
 }
 
@@ -451,6 +453,8 @@ export default function ApartmentDetailPage() {
           )}
         </div>
       )}
+
+      <ApartmentMap embedUrl={apartment.mapEmbedUrl} title={apartment.name} />
 
       <Separator />
 

--- a/src/app/api/apartments/[id]/route.ts
+++ b/src/app/api/apartments/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { apartments, ratings } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
+import { buildMapEmbedUrl } from "@/lib/map-embed";
 
 export async function GET(
   _request: Request,
@@ -29,6 +30,7 @@ export async function GET(
     return NextResponse.json({
       ...apartment[0],
       ratings: apartmentRatings,
+      mapEmbedUrl: buildMapEmbedUrl(apartment[0].address),
     });
   } catch (error) {
     console.error("[apartments/id:GET] Error:", error);

--- a/src/components/__tests__/apartment-map.test.tsx
+++ b/src/components/__tests__/apartment-map.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup } from "@testing-library/react";
+import { ApartmentMap } from "../apartment-map";
+
+afterEach(() => cleanup());
+
+describe("ApartmentMap", () => {
+  it("renders nothing when embedUrl is null", () => {
+    const { container } = render(
+      <ApartmentMap embedUrl={null} title="Test" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an iframe with the given src and a title", () => {
+    const url =
+      "https://www.google.com/maps/embed/v1/place?key=k&q=Basel+4057";
+    const { container } = render(
+      <ApartmentMap embedUrl={url} title="Sonnenweg 3" />
+    );
+    const iframe = container.querySelector("iframe")!;
+    expect(iframe).not.toBeNull();
+    expect(iframe.getAttribute("src")).toBe(url);
+    expect(iframe.getAttribute("title")).toBe("Map for Sonnenweg 3");
+    expect(iframe.getAttribute("loading")).toBe("lazy");
+  });
+});

--- a/src/components/apartment-map.tsx
+++ b/src/components/apartment-map.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+export function ApartmentMap({
+  embedUrl,
+  title,
+}: {
+  embedUrl: string | null | undefined;
+  title: string;
+}) {
+  if (!embedUrl) return null;
+  return (
+    <div className="overflow-hidden rounded-lg border">
+      <iframe
+        title={`Map for ${title}`}
+        src={embedUrl}
+        width="100%"
+        height="260"
+        loading="lazy"
+        referrerPolicy="no-referrer-when-downgrade"
+        allowFullScreen
+        style={{ border: 0, display: "block" }}
+      />
+    </div>
+  );
+}

--- a/src/lib/__tests__/map-embed.test.ts
+++ b/src/lib/__tests__/map-embed.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { buildMapEmbedUrl } from "../map-embed";
+
+beforeEach(() => {
+  delete process.env.GOOGLE_MAPS_API_KEY;
+});
+
+afterEach(() => {
+  delete process.env.GOOGLE_MAPS_API_KEY;
+});
+
+describe("buildMapEmbedUrl", () => {
+  it("returns null when no API key is set", () => {
+    expect(buildMapEmbedUrl("Steinenvorstadt 10, 4057 Basel")).toBeNull();
+  });
+
+  it("returns null when the address is null", () => {
+    process.env.GOOGLE_MAPS_API_KEY = "k";
+    expect(buildMapEmbedUrl(null)).toBeNull();
+  });
+
+  it("returns null when the address is empty/whitespace", () => {
+    process.env.GOOGLE_MAPS_API_KEY = "k";
+    expect(buildMapEmbedUrl("")).toBeNull();
+    expect(buildMapEmbedUrl("   ")).toBeNull();
+  });
+
+  it("builds an Embed API URL with the key + encoded address", () => {
+    process.env.GOOGLE_MAPS_API_KEY = "test-key";
+    const url = buildMapEmbedUrl("Steinenvorstadt 10, 4057 Basel");
+    expect(url).toContain("https://www.google.com/maps/embed/v1/place");
+    expect(url).toContain("key=test-key");
+    expect(url).toContain("q=Steinenvorstadt+10%2C+4057+Basel");
+  });
+
+  it("trims leading/trailing whitespace from the address", () => {
+    process.env.GOOGLE_MAPS_API_KEY = "k";
+    const url = buildMapEmbedUrl("  Sonnenweg 3  ");
+    expect(url).toContain("q=Sonnenweg+3");
+    expect(url).not.toContain("+++");
+  });
+});

--- a/src/lib/map-embed.ts
+++ b/src/lib/map-embed.ts
@@ -1,0 +1,14 @@
+// Returns a Google Maps Embed API URL for the given address,
+// or null when either the address or GOOGLE_MAPS_API_KEY is missing.
+// Requires the "Maps Embed API" enabled in Google Cloud Console.
+export function buildMapEmbedUrl(address: string | null | undefined): string | null {
+  const key = process.env.GOOGLE_MAPS_API_KEY;
+  if (!key) return null;
+  if (!address || !address.trim()) return null;
+  const base = "https://www.google.com/maps/embed/v1/place";
+  const params = new URLSearchParams({
+    key,
+    q: address.trim(),
+  });
+  return `${base}?${params.toString()}`;
+}


### PR DESCRIPTION
## Summary

Closes #57. Apartment detail page now shows a small Google Map (iframe embed) pinned at the apartment's address.

## Implementation

- **`src/lib/map-embed.ts`** — `buildMapEmbedUrl(address)` assembles `https://www.google.com/maps/embed/v1/place?key=<KEY>&q=<address>` when both `GOOGLE_MAPS_API_KEY` and a non-empty address are present; returns `null` otherwise.
- **`/api/apartments/[id]` GET** — includes `mapEmbedUrl` on the response. Keeps the key server-managed (reuses the existing `GOOGLE_MAPS_API_KEY`).
- **`src/components/apartment-map.tsx`** — small iframe, 260px height, rounded border, `loading="lazy"`, `referrerPolicy="no-referrer-when-downgrade"`. Renders nothing when `embedUrl` is null.
- **Detail page** — map appears between the metrics strip and the rating section.

## Requirements on Google Cloud

The `GOOGLE_MAPS_API_KEY` needs **Maps Embed API** enabled (separate from Distance Matrix). The key will appear in the iframe URL in the DOM, which is expected for the Embed API — restrict it via HTTP referrer in the Cloud Console for production.

## Tests (136/136)

- `src/lib/__tests__/map-embed.test.ts` — null cases (no key / no address / whitespace-only), proper URL + encoding, whitespace trimming.
- `src/components/__tests__/apartment-map.test.tsx` — null URL → no iframe; valid URL → iframe with src + title + lazy-loading.