### PR TITLE
feat: Rated indicator on apartment list cards (#58)

### DIFF
--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge";
 import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
 import { AddressLink } from "@/components/address-link";
-import { Building2 } from "lucide-react";
+import { Building2, CheckCircle2, Circle } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
   type ErrorDetails,
@@ -30,6 +30,7 @@ interface ApartmentSummary {
   rentChf: number | null;
   shortCode: string | null;
   avgOverall: string | null;
+  myRating: number | null;
   createdAt: string | null;
 }
 
@@ -112,7 +113,26 @@ export default function ApartmentsPage() {
           <Link key={apt.id} href={`/apartments/${apt.id}`}>
             <Card className="transition-shadow hover:shadow-md">
               <CardContent className="space-y-2 p-4">
-                <ShortCode code={apt.shortCode} size="md" />
+                <div className="flex items-start justify-between gap-2">
+                  <ShortCode code={apt.shortCode} size="md" />
+                  {apt.myRating !== null ? (
+                    <Badge
+                      variant="secondary"
+                      className="gap-1 border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300"
+                    >
+                      <CheckCircle2 className="h-3 w-3" />
+                      Rated
+                    </Badge>
+                  ) : (
+                    <Badge
+                      variant="outline"
+                      className="gap-1 text-muted-foreground"
+                    >
+                      <Circle className="h-3 w-3" />
+                      Not yet rated
+                    </Badge>
+                  )}
+                </div>
                 <div className="flex items-start justify-between">
                   <h3 className="font-medium leading-tight">{apt.name}</h3>
                   {apt.avgOverall && (

--- a/src/app/api/__tests__/apartments.test.ts
+++ b/src/app/api/__tests__/apartments.test.ts
@@ -47,6 +47,22 @@ vi.mock("drizzle-orm", () => ({
   eq: vi.fn(),
 }));
 
+const mockGetDisplayName = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getDisplayName: () => mockGetDisplayName(),
+}));
+
+vi.mock("@/lib/short-code", () => ({
+  computeShortCodeParts: vi.fn(async () => ({
+    rooms: "?",
+    baths: "?",
+    wash: "?",
+    postcode: "?",
+  })),
+  buildShortCode: vi.fn(() => "ABC-?B-?b-W?-?"),
+  pickLetters: vi.fn(() => "ABC"),
+}));
+
 import { GET, POST } from "../../api/apartments/route";
 import { GET as getById, PATCH, DELETE } from "../../api/apartments/[id]/route";
 
@@ -59,11 +75,12 @@ afterEach(() => {
 });
 
 describe("GET /api/apartments", () => {
-  it("returns list of apartments", async () => {
+  it("returns list of apartments with myRating=null when no user cookie", async () => {
     const apartments = [
       { id: 1, name: "Apt 1", avgOverall: "4.5" },
       { id: 2, name: "Apt 2", avgOverall: null },
     ];
+    mockGetDisplayName.mockResolvedValue(null);
 
     mockSelect.mockReturnValue({
       from: vi.fn().mockReturnValue({
@@ -78,7 +95,52 @@ describe("GET /api/apartments", () => {
     const res = await GET();
     expect(res.status).toBe(200);
     const data = await res.json();
-    expect(data).toEqual(apartments);
+    expect(data).toEqual([
+      { id: 1, name: "Apt 1", avgOverall: "4.5", myRating: null },
+      { id: 2, name: "Apt 2", avgOverall: null, myRating: null },
+    ]);
+  });
+
+  it("populates myRating per apartment when the user has rated some of them", async () => {
+    const apartments = [
+      { id: 1, name: "Apt 1", avgOverall: "4.5" },
+      { id: 2, name: "Apt 2", avgOverall: null },
+      { id: 3, name: "Apt 3", avgOverall: "3.0" },
+    ];
+    mockGetDisplayName.mockResolvedValue("Alice");
+
+    // First select call: apartments with avgs
+    mockSelect
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          leftJoin: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue(apartments),
+            }),
+          }),
+        }),
+      })
+      // Second select call: Alice's ratings — she rated apartments 1 and 3.
+      .mockReturnValueOnce({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([
+            { apartmentId: 1, overallFeeling: 4 },
+            { apartmentId: 3, overallFeeling: 2 },
+          ]),
+        }),
+      });
+
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.map((a: { id: number; myRating: number | null }) => ({
+      id: a.id,
+      myRating: a.myRating,
+    }))).toEqual([
+      { id: 1, myRating: 4 },
+      { id: 2, myRating: null },
+      { id: 3, myRating: 2 },
+    ]);
   });
 });
 

--- a/src/app/api/apartments/route.ts
+++ b/src/app/api/apartments/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { apartments, ratings } from "@/lib/db/schema";
 import { desc, avg, eq } from "drizzle-orm";
+import { getDisplayName } from "@/lib/auth";
 import {
   buildShortCode,
   computeShortCodeParts,
@@ -47,7 +48,29 @@ export async function GET() {
       .groupBy(apartments.id)
       .orderBy(desc(apartments.createdAt));
 
-    return NextResponse.json(allApartments);
+    // Decorate with the current user's own rating (or null if not rated yet)
+    // so the list card can show a "Rated"/"Not yet rated" indicator.
+    const currentUser = await getDisplayName();
+    const myRatingByApt = new Map<number, number>();
+    if (currentUser) {
+      const myRows = await db
+        .select({
+          apartmentId: ratings.apartmentId,
+          overallFeeling: ratings.overallFeeling,
+        })
+        .from(ratings)
+        .where(eq(ratings.userName, currentUser));
+      for (const r of myRows) {
+        myRatingByApt.set(r.apartmentId, r.overallFeeling ?? 0);
+      }
+    }
+
+    const withMyRating = allApartments.map((a) => ({
+      ...a,
+      myRating: myRatingByApt.has(a.id) ? myRatingByApt.get(a.id)! : null,
+    }));
+
+    return NextResponse.json(withMyRating);
   } catch (error) {
     console.error("[apartments:GET] Error:", error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary

Closes #58. Each apartment card now shows whether **you** have already rated it or not, at a glance.

## Implementation

- **`/api/apartments` GET** — reads the `flatpare-name` cookie, runs one extra indexed query (`SELECT apartment_id, overall_feeling FROM ratings WHERE user_name = $me`), decorates each apartment with `myRating: number | null`. `null` = no rating row for the current user.
- **List card (`src/app/apartments/page.tsx`)** — green ✓ "Rated" badge when `myRating !== null`; muted "Not yet rated" outline badge when null. `avgOverall` stars stay as the group signal.

## Tests (137/137)

- `apartments.test.ts` — updated existing GET test to assert the new `myRating: null` default; new test asserts per-apartment population when the user has rated some of them.