### PR TITLE
feat: prev/next pager on apartment detail (#62)

### DIFF
--- a/docs/superpowers/plans/2026-04-24-apartment-pager.md
+++ b/docs/superpowers/plans/2026-04-24-apartment-pager.md
@@ -1,0 +1,704 @@
+# Apartment Pager Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Previous / Next buttons to `/apartments/[id]` that navigate between apartments in the order set by the list page's sort controls. Works on direct URL navigation.
+
+**Architecture:** A new `useApartmentPager(currentId)` hook fetches `/api/apartments` once on mount, reads the sort preference from localStorage (two keys already shipped in #61), sorts client-side with the existing `compareApartments`, and derives `position`, `prevId`, `nextId`. The detail page renders a compact pager row above the apartment header and calls `router.push` on click. A small refactor moves the sort localStorage keys and validators from `src/app/apartments/page.tsx` into `src/lib/apartment-sort.ts` so both pages import from one place.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Vitest + React Testing Library (with `renderHook`), Tailwind, `lucide-react` icons.
+
+**Spec:** [`docs/superpowers/specs/2026-04-24-apartment-pager-design.md`](../specs/2026-04-24-apartment-pager-design.md)
+**Issue:** [#62](https://github.com/brlauuu/flatpare/issues/62)
+
+---
+
+## File Structure
+
+### Files created
+
+- `src/lib/use-apartment-pager.ts` — hook: fetches list, reads sort, derives prev/current/next.
+- `src/lib/__tests__/use-apartment-pager.test.tsx` — hook unit tests via `renderHook`.
+- `src/app/apartments/[id]/__tests__/pager.test.tsx` — detail-page integration tests for the pager UI.
+
+### Files modified
+
+- `src/lib/apartment-sort.ts` — additionally exports `SORT_FIELD_STORAGE_KEY`, `SORT_DIRECTION_STORAGE_KEY`, `SORT_CHANGE_EVENT`, `SORT_FIELD_IDS`, `isSortField`, `isSortDirection`.
+- `src/app/apartments/page.tsx` — remove local definitions of the above, import them from `@/lib/apartment-sort`.
+- `src/app/apartments/[id]/page.tsx` — add `useApartmentPager` call and render the pager row above the existing header block.
+
+### No renames / deletions.
+
+---
+
+## Task 1: Move sort constants and validators into `apartment-sort.ts`
+
+Pure refactor to give both the list page and the new hook a single source of truth for sort-related localStorage keys and validators. Zero behavior change.
+
+**Files:**
+- Modify: `src/lib/apartment-sort.ts` (add exports at the bottom)
+- Modify: `src/app/apartments/page.tsx` (remove local defs, import from the shared module)
+
+- [ ] **Step 1: Add exports to `src/lib/apartment-sort.ts`**
+
+Append these exports to the end of the file:
+
+```ts
+export const SORT_FIELD_STORAGE_KEY = "flatpare-apartments-sort-field";
+export const SORT_DIRECTION_STORAGE_KEY = "flatpare-apartments-sort-direction";
+export const SORT_CHANGE_EVENT = "flatpare-apartments-sort-change";
+
+export const SORT_FIELD_IDS = Object.keys(SORT_FIELD_LABELS) as SortField[];
+
+export function isSortField(v: string): v is SortField {
+  return (SORT_FIELD_IDS as string[]).includes(v);
+}
+
+export function isSortDirection(v: string): v is SortDirection {
+  return v === "asc" || v === "desc";
+}
+```
+
+- [ ] **Step 2: Remove local copies from `src/app/apartments/page.tsx`**
+
+Delete lines that define `SORT_FIELD_STORAGE_KEY`, `SORT_DIRECTION_STORAGE_KEY`, `SORT_CHANGE_EVENT`, `SORT_FIELD_IDS`, `isSortField`, `isSortDirection` from `src/app/apartments/page.tsx`. Extend the existing import from `@/lib/apartment-sort` to include them:
+
+```tsx
+import {
+  compareApartments,
+  SORT_FIELD_LABELS,
+  SORT_FIELD_STORAGE_KEY,
+  SORT_DIRECTION_STORAGE_KEY,
+  SORT_CHANGE_EVENT,
+  SORT_FIELD_IDS,
+  isSortField,
+  isSortDirection,
+  type SortDirection,
+  type SortField,
+} from "@/lib/apartment-sort";
+```
+
+(Your existing import may be partial; replace it entirely with the block above.)
+
+- [ ] **Step 3: Run the full test suite and lint**
+
+Run: `npm test && npm run lint`
+Expected: all tests pass (existing view-toggle + sort tests on the list page), no lint errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/apartment-sort.ts src/app/apartments/page.tsx
+git commit -m "refactor: move sort constants and validators into apartment-sort module"
+```
+
+---
+
+## Task 2: `useApartmentPager` hook with TDD
+
+Write the hook's unit tests first, then implement. The hook fetches the list, reads sort state once, and returns `position` / `prevId` / `nextId` plus loading/error metadata.
+
+**Files:**
+- Create: `src/lib/use-apartment-pager.ts`
+- Test: `src/lib/__tests__/use-apartment-pager.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/lib/__tests__/use-apartment-pager.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useApartmentPager } from "@/lib/use-apartment-pager";
+
+const LIST = [
+  {
+    id: 1,
+    name: "Sonnenweg 3",
+    address: null,
+    sizeM2: 60,
+    numRooms: 2.5,
+    rentChf: 2200,
+    shortCode: "ABC-2.5B-WY-4057",
+    avgOverall: null,
+    myRating: null,
+    createdAt: "2026-01-15T10:00:00Z",
+  },
+  {
+    id: 2,
+    name: "Bergstrasse 12",
+    address: null,
+    sizeM2: 45,
+    numRooms: 2,
+    rentChf: 1800,
+    shortCode: "DEF-2B-W-4058",
+    avgOverall: "3.5",
+    myRating: 4,
+    createdAt: "2026-03-20T10:00:00Z",
+  },
+  {
+    id: 3,
+    name: "Seeblick 7",
+    address: null,
+    sizeM2: 80,
+    numRooms: 3.5,
+    rentChf: null,
+    shortCode: "GHI-3.5B-WY-4059",
+    avgOverall: "4.5",
+    myRating: null,
+    createdAt: "2026-02-10T10:00:00Z",
+  },
+];
+
+// Default (createdAt desc) order: Bergstrasse (id 2), Seeblick (id 3), Sonnenweg (id 1).
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.spyOn(global, "fetch").mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(LIST),
+  } as Response);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useApartmentPager", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useApartmentPager(2));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.total).toBe(0);
+    expect(result.current.position).toBeNull();
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resolves to correct position and neighbors under default sort (createdAt desc)", async () => {
+    // Default order: Bergstrasse (2, newest), Seeblick (3), Sonnenweg (1, oldest).
+    // Middle apartment = Seeblick (id 3): position 2, prev 2, next 1.
+    const { result } = renderHook(() => useApartmentPager(3));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.total).toBe(3);
+    expect(result.current.position).toBe(2);
+    expect(result.current.prevId).toBe(2);
+    expect(result.current.nextId).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("honors sort preference stored in localStorage", async () => {
+    // rentChf asc: Bergstrasse (1800, id 2), Sonnenweg (2200, id 1), Seeblick (null last, id 3).
+    localStorage.setItem("flatpare-apartments-sort-field", "rentChf");
+    localStorage.setItem("flatpare-apartments-sort-direction", "asc");
+    const { result } = renderHook(() => useApartmentPager(1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.position).toBe(2);
+    expect(result.current.prevId).toBe(2);
+    expect(result.current.nextId).toBe(3);
+  });
+
+  it("returns prevId null on the first apartment in order", async () => {
+    // Default order: Bergstrasse (2) is first.
+    const { result } = renderHook(() => useApartmentPager(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.position).toBe(1);
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBe(3);
+  });
+
+  it("returns nextId null on the last apartment in order", async () => {
+    // Default order: Sonnenweg (1) is last.
+    const { result } = renderHook(() => useApartmentPager(1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.position).toBe(3);
+    expect(result.current.prevId).toBe(3);
+    expect(result.current.nextId).toBeNull();
+  });
+
+  it("returns null position and null ids when current id is not in the list", async () => {
+    const { result } = renderHook(() => useApartmentPager(9999));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.total).toBe(3);
+    expect(result.current.position).toBeNull();
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBeNull();
+  });
+
+  it("falls back to defaults when localStorage has invalid sort values", async () => {
+    localStorage.setItem("flatpare-apartments-sort-field", "bogus");
+    localStorage.setItem("flatpare-apartments-sort-direction", "sideways");
+    const { result } = renderHook(() => useApartmentPager(3));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Defaults → createdAt desc → Seeblick is position 2.
+    expect(result.current.position).toBe(2);
+    expect(result.current.prevId).toBe(2);
+    expect(result.current.nextId).toBe(1);
+  });
+
+  it("surfaces an error when the list fetch fails", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      clone() {
+        return this;
+      },
+      text: () => Promise.resolve("boom"),
+      headers: new Headers(),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useApartmentPager(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.total).toBe(0);
+    expect(result.current.position).toBeNull();
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBeNull();
+  });
+
+  // Silence unused-import warning without removing act (exported here
+  // to signal the hook is designed to work with `act` in future tests).
+  void act;
+});
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+Run: `npm test -- src/lib/__tests__/use-apartment-pager.test.tsx`
+Expected: all 8 tests fail with `Cannot find module '@/lib/use-apartment-pager'`.
+
+- [ ] **Step 3: Create the hook**
+
+Create `src/lib/use-apartment-pager.ts`:
+
+```ts
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  compareApartments,
+  isSortDirection,
+  isSortField,
+  SORT_DIRECTION_STORAGE_KEY,
+  SORT_FIELD_STORAGE_KEY,
+  type SortableApartment,
+  type SortDirection,
+  type SortField,
+} from "@/lib/apartment-sort";
+import {
+  type ErrorDetails,
+  fetchErrorFromException,
+  fetchErrorFromResponse,
+} from "@/lib/fetch-error";
+
+export interface ApartmentPagerResult {
+  loading: boolean;
+  error: ErrorDetails | null;
+  total: number;
+  position: number | null;
+  prevId: number | null;
+  nextId: number | null;
+}
+
+function readSortField(): SortField {
+  const raw = window.localStorage.getItem(SORT_FIELD_STORAGE_KEY);
+  return raw !== null && isSortField(raw) ? raw : "createdAt";
+}
+
+function readSortDirection(): SortDirection {
+  const raw = window.localStorage.getItem(SORT_DIRECTION_STORAGE_KEY);
+  return raw !== null && isSortDirection(raw) ? raw : "desc";
+}
+
+export function useApartmentPager(currentId: number): ApartmentPagerResult {
+  const [apartments, setApartments] = useState<SortableApartment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ErrorDetails | null>(null);
+
+  // Read sort preference once on mount — detail page does not need same-tab
+  // sync because the user cannot change sort while on the detail page.
+  const [sortField] = useState<SortField>(() => readSortField());
+  const [sortDirection] = useState<SortDirection>(() => readSortDirection());
+
+  useEffect(() => {
+    let cancelled = false;
+    const url = "/api/apartments";
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(await fetchErrorFromResponse(res, url));
+          setLoading(false);
+          return;
+        }
+        const data = (await res.json()) as SortableApartment[];
+        if (cancelled) return;
+        setApartments(data);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError(fetchErrorFromException(err, url));
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return useMemo(() => {
+    if (loading || error) {
+      return {
+        loading,
+        error,
+        total: apartments.length,
+        position: null,
+        prevId: null,
+        nextId: null,
+      };
+    }
+    const sorted = [...apartments].sort((a, b) =>
+      compareApartments(a, b, sortField, sortDirection)
+    );
+    const index = sorted.findIndex((a) => a.id === currentId);
+    if (index === -1) {
+      return {
+        loading: false,
+        error: null,
+        total: sorted.length,
+        position: null,
+        prevId: null,
+        nextId: null,
+      };
+    }
+    return {
+      loading: false,
+      error: null,
+      total: sorted.length,
+      position: index + 1,
+      prevId: index > 0 ? sorted[index - 1].id : null,
+      nextId: index < sorted.length - 1 ? sorted[index + 1].id : null,
+    };
+  }, [loading, error, apartments, sortField, sortDirection, currentId]);
+}
+```
+
+- [ ] **Step 4: Run the tests — they should pass**
+
+Run: `npm test -- src/lib/__tests__/use-apartment-pager.test.tsx`
+Expected: 8 tests pass.
+
+- [ ] **Step 5: Full suite + lint**
+
+Run: `npm test && npm run lint`
+Expected: all tests pass, lint clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/use-apartment-pager.ts src/lib/__tests__/use-apartment-pager.test.tsx
+git commit -m "feat: add useApartmentPager hook"
+```
+
+---
+
+## Task 3: Render the pager in the apartment detail page
+
+Wire `useApartmentPager` into `src/app/apartments/[id]/page.tsx` and render a compact row above the apartment header. Write integration tests in a new file (detail page already has two other test files; add a third for the pager).
+
+**Files:**
+- Modify: `src/app/apartments/[id]/page.tsx`
+- Test: `src/app/apartments/[id]/__tests__/pager.test.tsx`
+
+- [ ] **Step 1: Write the failing integration tests**
+
+Create `src/app/apartments/[id]/__tests__/pager.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const pushMock = vi.fn();
+let currentParamsId = "3";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: currentParamsId }),
+  useRouter: () => ({ push: pushMock, refresh: vi.fn() }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const LIST = [
+  {
+    id: 1,
+    name: "Sonnenweg 3",
+    address: null,
+    sizeM2: 60,
+    numRooms: 2.5,
+    rentChf: 2200,
+    shortCode: "ABC-2.5B-WY-4057",
+    avgOverall: null,
+    myRating: null,
+    createdAt: "2026-01-15T10:00:00Z",
+  },
+  {
+    id: 2,
+    name: "Bergstrasse 12",
+    address: null,
+    sizeM2: 45,
+    numRooms: 2,
+    rentChf: 1800,
+    shortCode: "DEF-2B-W-4058",
+    avgOverall: "3.5",
+    myRating: 4,
+    createdAt: "2026-03-20T10:00:00Z",
+  },
+  {
+    id: 3,
+    name: "Seeblick 7",
+    address: null,
+    sizeM2: 80,
+    numRooms: 3.5,
+    rentChf: null,
+    shortCode: "GHI-3.5B-WY-4059",
+    avgOverall: "4.5",
+    myRating: null,
+    createdAt: "2026-02-10T10:00:00Z",
+  },
+];
+
+function apartmentResponse(id: number) {
+  const apt = LIST.find((a) => a.id === id);
+  return {
+    ok: true,
+    json: () => Promise.resolve({ ...apt, ratings: [] }),
+  } as Response;
+}
+
+function listResponse() {
+  return {
+    ok: true,
+    json: () => Promise.resolve(LIST),
+  } as Response;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  pushMock.mockReset();
+  vi.spyOn(global, "fetch").mockImplementation((input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url === "/api/apartments") return Promise.resolve(listResponse());
+    const match = url.match(/\/api\/apartments\/(\d+)$/);
+    if (match) return Promise.resolve(apartmentResponse(Number(match[1])));
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Apartment detail page — pager", () => {
+  it("renders position and enabled buttons for a middle apartment", async () => {
+    currentParamsId = "3"; // Seeblick — middle under default sort
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Seeblick 7")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("2 of 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Previous/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /Next/i })).toBeEnabled();
+  });
+
+  it("clicking Next navigates to nextId", async () => {
+    currentParamsId = "3"; // Seeblick → next is Sonnenweg (id 1) under default sort.
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("2 of 3")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Next/i }));
+    expect(pushMock).toHaveBeenCalledWith("/apartments/1");
+  });
+
+  it("disables Previous on the first apartment", async () => {
+    currentParamsId = "2"; // Bergstrasse — first under default sort.
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("1 of 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Previous/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Next/i })).toBeEnabled();
+  });
+
+  it("disables Next on the last apartment and Previous navigates", async () => {
+    currentParamsId = "1"; // Sonnenweg — last under default sort.
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("3 of 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /Previous/i }));
+    expect(pushMock).toHaveBeenCalledWith("/apartments/3");
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to confirm they fail**
+
+Run: `npm test -- src/app/apartments/\[id\]/__tests__/pager.test.tsx`
+Expected: all 4 tests fail — no pager UI yet.
+
+- [ ] **Step 3: Wire the pager into the detail page**
+
+Edit `src/app/apartments/[id]/page.tsx`.
+
+Add imports near the top (with the other imports):
+
+```tsx
+import { ArrowLeft, ArrowRight, WashingMachine } from "lucide-react";
+import { useApartmentPager } from "@/lib/use-apartment-pager";
+```
+
+(The existing `import { WashingMachine } from "lucide-react"` is being extended to also import the arrow icons. If your editor prefers separate import lines, that's fine — the end result must import all three.)
+
+Inside `ApartmentDetailPage()`, near the other hook calls (after `const params = useParams();` and any existing `useState`/`useEffect` declarations — before the `if (loading)` / `if (error)` early returns), add:
+
+```tsx
+const pager = useApartmentPager(Number(params.id));
+```
+
+In the JSX, inside the top-level `<div className="space-y-6">` (around line 311), insert the pager row as the FIRST child — immediately above the existing `<div className="flex items-start justify-between">` header row:
+
+```tsx
+<div className="flex items-center gap-3">
+  <Button
+    type="button"
+    variant="outline"
+    size="sm"
+    disabled={pager.prevId === null}
+    onClick={() => {
+      if (pager.prevId !== null) router.push(`/apartments/${pager.prevId}`);
+    }}
+  >
+    <ArrowLeft className="h-4 w-4" />
+    Previous
+  </Button>
+  {pager.position !== null && pager.total > 0 && (
+    <span className="text-sm text-muted-foreground">
+      {pager.position} of {pager.total}
+    </span>
+  )}
+  <Button
+    type="button"
+    variant="outline"
+    size="sm"
+    disabled={pager.nextId === null}
+    onClick={() => {
+      if (pager.nextId !== null) router.push(`/apartments/${pager.nextId}`);
+    }}
+  >
+    Next
+    <ArrowRight className="h-4 w-4" />
+  </Button>
+</div>
+```
+
+Placement note: the wrapping `<div className="space-y-6">` adds vertical spacing between children, so the pager row will sit above the header with the same gap as the other sections.
+
+- [ ] **Step 4: Run the tests to confirm they pass**
+
+Run: `npm test -- src/app/apartments/\[id\]/__tests__/pager.test.tsx`
+Expected: 4 tests pass.
+
+- [ ] **Step 5: Run the full test suite and lint**
+
+Run: `npm test && npm run lint`
+Expected: all tests pass, lint clean.
+
+- [ ] **Step 6: Run the build as a final check**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/app/apartments/[id]/page.tsx \
+        src/app/apartments/[id]/__tests__/pager.test.tsx
+git commit -m "feat: add prev/next pager to apartment detail page (#62)"
+```
+
+---
+
+## Task 4: Open PR and wrap up
+
+**Files:** none — workflow only.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin 62-apartment-pager`
+Expected: branch published to origin.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat: prev/next pager on apartment detail (#62)" \
+  --body "$(cat <<'EOF'
+## Summary
+- New \`useApartmentPager\` hook fetches the apartment list and derives \`position\`, \`prevId\`, \`nextId\` from the user's current sort preference in localStorage (respects #61 sort)
+- Detail page gets a compact "[← Previous] N of M [Next →]" row above the header; buttons disabled at the edges
+- Refactor: moved sort localStorage keys and validators from \`src/app/apartments/page.tsx\` into \`src/lib/apartment-sort.ts\` so both pages import from one place
+
+## Test plan
+- [ ] \`npm test\` passes (new: 8 hook tests + 4 integration tests)
+- [ ] \`npm run lint\` clean
+- [ ] \`npm run build\` succeeds
+- [ ] Vercel preview: navigate between apartments with sort field/direction changed on list page, verify order
+
+Closes #62
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Watch CI**
+
+Run: `gh pr checks --watch`
+Expected: all checks pass.
+
+- [ ] **Step 4: Hand back to the controller** — merge decision is the user's.
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- Pager UI above header with Prev / position / Next — Task 3 ✓
+- Disabled buttons at the edges — Task 3 Step 3 (`disabled={pager.prevId === null}`, etc.) ✓
+- Sort source = localStorage keys from #61 — Task 2 Step 3 (`readSortField` / `readSortDirection`) ✓
+- Read once on mount (no same-tab sync) — Task 2 Step 3 (lazy `useState` init) ✓
+- Current-id-not-in-list edge case → `position: null`, both ids `null` — Task 2 Step 3 (findIndex → -1 path) + test coverage Task 2 Step 1 ✓
+- Fetch error → disabled buttons, hidden position, no banner — Task 2 Step 3 (error branch returns nulls), Task 3 Step 3 (position only rendered when non-null), test coverage Task 2 Step 1 ✓
+- Refactor shared sort helpers — Task 1 ✓
+- SSR-safe: detail page is `"use client"`; hook does not run on the server (no initial-render localStorage read problem). The lazy `useState` initializer runs on mount in client components, consistent with the existing page's model.
+- Works for direct URL navigation — the hook makes its own `/api/apartments` call, independent of the list page ✓
+
+**Placeholder scan:** no TBDs, no "implement error handling", no "similar to Task N". Every code step has full code.
+
+**Type consistency:**
+- `useApartmentPager(currentId: number)` in Task 2 matches call site `Number(params.id)` in Task 3.
+- `ApartmentPagerResult` fields (`loading`, `error`, `total`, `position`, `prevId`, `nextId`) match the spec and the integration test assertions.
+- `SortableApartment` import from `@/lib/apartment-sort` is an existing export.
+- The JSON shape returned by `/api/apartments` is an array of `ApartmentSummary`-shaped objects; `SortableApartment` is a structural subset, so the `as SortableApartment[]` cast in the hook is safe. (Same pattern as the list page already uses.)
+
+No gaps.

--- a/docs/superpowers/specs/2026-04-24-apartment-pager-design.md
+++ b/docs/superpowers/specs/2026-04-24-apartment-pager-design.md
@@ -1,0 +1,125 @@
+# Apartment pager — design
+
+**Issue:** [#62 — I want next and previous button when I'm in the apartment view](https://github.com/brlauuu/flatpare/issues/62)
+**Date:** 2026-04-24
+
+## Problem
+
+When viewing a single apartment at `/apartments/[id]`, there's no way to move to the adjacent apartment without returning to the list first. Add Previous / Next buttons that navigate between apartments in the order set by the list page's sort controls (shipped in #61).
+
+## Scope
+
+One compact pager row at the top of the detail page, driven by the sort stored in localStorage. Disabled at the edges. Works on direct URL navigation (bookmarks, shared links, browser back).
+
+## UI
+
+Above the apartment header block (`<ShortCode>` + `<h1>`), a left-aligned row:
+
+```
+[← Previous]   3 of 17   [Next →]
+```
+
+- Two `<Button variant="outline" size="sm">` with `ArrowLeft` / `ArrowRight` from `lucide-react`.
+- Position text: `"{position} of {total}"` in `text-sm text-muted-foreground`.
+- Previous disabled when `prevId === null`; Next disabled when `nextId === null`.
+- Click handler: `router.push(`/apartments/${prevOrNextId}`)`.
+- While the list fetch is in flight, both buttons render disabled and the position text is hidden — the row holds its vertical space so the header below doesn't jump when the data arrives.
+
+### Placements considered and rejected
+
+- Inline with the header's action row (right side): already crowded with PDF, Listing, Edit, Delete.
+- Floating fixed arrows on the viewport edges: overkill for this app.
+
+## Data flow
+
+Parallel to the existing single-apartment fetch, a second fetch retrieves the full list. The detail page reads the user's current sort preference from localStorage, sorts the list client-side with `compareApartments`, locates the current id, and derives prev/next.
+
+### Sort state source
+
+Same two keys as the list page:
+
+- `flatpare-apartments-sort-field` (default `createdAt`)
+- `flatpare-apartments-sort-direction` (default `desc`)
+
+Read once on mount via a plain lazy `useState(() => ...)` — the detail page does not need same-tab sync, because the user cannot change sort preferences while on a detail page. Keeping the state local and synchronous avoids dragging `useSyncExternalStore` into this code path.
+
+### Current-apartment-not-in-list edge case
+
+If the fetched list does not contain the current `id` (apartment was just deleted on another tab, or was uploaded after the list fetch started), the pager renders both buttons disabled, position text hidden — same as the loading state visually.
+
+### Error handling
+
+The list fetch is a secondary data source. On failure the pager renders both buttons disabled and hides the position text — same visual state as loading. The error is not surfaced to the user; a secondary-data failure that just removes a convenience feature doesn't warrant an error banner. The existing `ErrorDisplay` continues to own the primary single-apartment fetch failure flow.
+
+## New module: `useApartmentPager`
+
+```ts
+// src/lib/use-apartment-pager.ts
+export function useApartmentPager(currentId: number): {
+  loading: boolean;
+  error: ErrorDetails | null;
+  total: number;
+  position: number | null;
+  prevId: number | null;
+  nextId: number | null;
+};
+```
+
+- `loading: true` until the list fetch resolves.
+- `error` populated only if the list fetch fails.
+- `total` reflects the fetched list length (regardless of whether `currentId` is in it).
+- `position` is 1-based; `null` when not found or while loading.
+- `prevId` / `nextId` are the adjacent ids in sort order, or `null` at the edges / when not found / while loading.
+
+### Internals
+
+1. `useEffect` fetches `/api/apartments` once on mount, stores `apartments`, sets `loading` / `error`.
+2. Lazy `useState` init reads both sort keys from localStorage, validates with `isSortField` / `isSortDirection`, falls back to defaults.
+3. `useMemo` sorts via `compareApartments(a, b, sortField, sortDirection)`.
+4. Derived values via simple array indexing.
+
+The hook is the only new reusable unit. The detail page wires it directly — no additional component extraction.
+
+## Refactor: shared sort-state helpers
+
+Currently these constants and helpers live in `src/app/apartments/page.tsx`:
+
+- `SORT_FIELD_STORAGE_KEY`, `SORT_DIRECTION_STORAGE_KEY`, `SORT_CHANGE_EVENT`
+- `isSortField`, `isSortDirection`, `SORT_FIELD_IDS`
+
+Move them into `src/lib/apartment-sort.ts` and re-export. `src/app/apartments/page.tsx` imports them from the new location. No behavior change; existing tests continue to pass.
+
+## Testing
+
+### New — `src/lib/__tests__/use-apartment-pager.test.tsx`
+
+TDD for the hook. Tests render a tiny probe component, mock `global.fetch` to return a controlled 3-apartment list, seed localStorage as needed, and assert the returned values:
+
+1. `loading: true` initially; `position: null`, `prevId: null`, `nextId: null`.
+2. After fetch resolves with defaults (`createdAt` desc), `total === 3` and position matches the expected index + 1.
+3. Seed `sort-field=rentChf, direction=asc` → ordering reflects that sort.
+4. First apartment in order: `prevId === null`, `nextId` populated.
+5. Last apartment in order: `nextId === null`, `prevId` populated.
+6. Middle apartment: both populated.
+7. Current id absent from the list: `position === null`, both ids `null`, `total` still equals the list length.
+8. Fetch failure: `error` populated, `position === null`, `prevId === null`, `nextId === null`.
+
+### New — `src/app/apartments/[id]/__tests__/pager.test.tsx`
+
+Integration tests for the detail page:
+
+1. After load, the row shows `"2 of 3"` and both buttons are enabled.
+2. Clicking Next calls `router.push("/apartments/{nextId}")`.
+3. On the first apartment, Previous is disabled (`aria-disabled` or the button's `disabled` attribute); Next navigates correctly.
+4. On the last apartment, Next is disabled; Previous navigates correctly.
+
+### Existing — view toggle + sort tests
+
+Unchanged. The constants-and-helpers refactor keeps the same localStorage keys and validation behavior; existing tests import through a new path (if they import the constants directly) or don't import at all (if they use the string values), so they remain green.
+
+## Out of scope
+
+- No URL query-string sync of sort state — we already have localStorage.
+- No keyboard shortcuts (←/→ keys). Could be added as a follow-up.
+- No wrap-around at the edges — decided explicitly against it.
+- No persistence of a separate "detail-page sort" — the detail page reflects whatever sort the list had.

--- a/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
+++ b/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
@@ -85,7 +85,9 @@ afterEach(() => {
 });
 
 describe("Apartment detail edit flow", () => {
-  it("opens the edit form, saves changes, and re-renders with updated values", async () => {
+  it(
+    "opens the edit form, saves changes, and re-renders with updated values",
+    async () => {
     const user = userEvent.setup();
     render(<ApartmentDetailPage />);
 
@@ -132,7 +134,9 @@ describe("Apartment detail edit flow", () => {
       expect(screen.getByText("Sonnenweg 3b")).toBeInTheDocument();
     });
     expect(screen.getByText(/CHF 2,400/)).toBeInTheDocument();
-  });
+    },
+    10000
+  );
 
   it("Cancel discards edits and returns to read-only view", async () => {
     const user = userEvent.setup();

--- a/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
+++ b/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
@@ -52,6 +52,12 @@ beforeEach(() => {
     fetchCalls.push({ url, init: init ?? {} });
     const method = init?.method ?? "GET";
 
+    if (url === "/api/apartments" && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }
     if (url.endsWith("/api/apartments/42") && method === "GET") {
       getCount += 1;
       return Promise.resolve({

--- a/src/app/apartments/[id]/__tests__/pager.test.tsx
+++ b/src/app/apartments/[id]/__tests__/pager.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const pushMock = vi.fn();
+let currentParamsId = "3";
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: currentParamsId }),
+  useRouter: () => ({ push: pushMock, refresh: vi.fn() }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const LIST = [
+  {
+    id: 1,
+    name: "Sonnenweg 3",
+    address: null,
+    sizeM2: 60,
+    numRooms: 2.5,
+    rentChf: 2200,
+    shortCode: "ABC-2.5B-WY-4057",
+    avgOverall: null,
+    myRating: null,
+    createdAt: "2026-01-15T10:00:00Z",
+  },
+  {
+    id: 2,
+    name: "Bergstrasse 12",
+    address: null,
+    sizeM2: 45,
+    numRooms: 2,
+    rentChf: 1800,
+    shortCode: "DEF-2B-W-4058",
+    avgOverall: "3.5",
+    myRating: 4,
+    createdAt: "2026-03-20T10:00:00Z",
+  },
+  {
+    id: 3,
+    name: "Seeblick 7",
+    address: null,
+    sizeM2: 80,
+    numRooms: 3.5,
+    rentChf: null,
+    shortCode: "GHI-3.5B-WY-4059",
+    avgOverall: "4.5",
+    myRating: null,
+    createdAt: "2026-02-10T10:00:00Z",
+  },
+];
+
+function apartmentResponse(id: number) {
+  const apt = LIST.find((a) => a.id === id);
+  return {
+    ok: true,
+    json: () => Promise.resolve({ ...apt, ratings: [] }),
+  } as Response;
+}
+
+function listResponse() {
+  return {
+    ok: true,
+    json: () => Promise.resolve(LIST),
+  } as Response;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  pushMock.mockReset();
+  vi.spyOn(global, "fetch").mockImplementation((input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url === "/api/apartments") return Promise.resolve(listResponse());
+    const match = url.match(/\/api\/apartments\/(\d+)$/);
+    if (match) return Promise.resolve(apartmentResponse(Number(match[1])));
+    return Promise.reject(new Error(`Unexpected fetch: ${url}`));
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Apartment detail page — pager", () => {
+  it("renders position and enabled buttons for a middle apartment", async () => {
+    currentParamsId = "3"; // Seeblick — middle under default sort
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Seeblick 7")).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(screen.getByText("2 of 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Previous/i })).toBeEnabled();
+    expect(screen.getByRole("button", { name: /Next/i })).toBeEnabled();
+  });
+
+  it("clicking Next navigates to nextId", async () => {
+    currentParamsId = "3"; // Seeblick → next is Sonnenweg (id 1) under default sort.
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("2 of 3")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Next/i }));
+    expect(pushMock).toHaveBeenCalledWith("/apartments/1");
+  });
+
+  it("disables Previous on the first apartment", async () => {
+    currentParamsId = "2"; // Bergstrasse — first under default sort.
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("1 of 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Previous/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Next/i })).toBeEnabled();
+  });
+
+  it("disables Next on the last apartment and Previous navigates", async () => {
+    currentParamsId = "1"; // Sonnenweg — last under default sort.
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("3 of 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: /Previous/i }));
+    expect(pushMock).toHaveBeenCalledWith("/apartments/3");
+  });
+});

--- a/src/app/apartments/[id]/__tests__/rating-cancel.test.tsx
+++ b/src/app/apartments/[id]/__tests__/rating-cancel.test.tsx
@@ -61,6 +61,12 @@ beforeEach(() => {
     const url = typeof input === "string" ? input : (input as Request).url;
     fetchCalls.push({ url, init: init ?? {} });
     const method = init?.method ?? "GET";
+    if (url === "/api/apartments" && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }
     if (url.endsWith("/api/apartments/42") && method === "GET") {
       return Promise.resolve({
         ok: true,

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -12,7 +12,7 @@ import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
 import { AddressLink } from "@/components/address-link";
 import { ApartmentMap } from "@/components/apartment-map";
-import { WashingMachine } from "lucide-react";
+import { ArrowLeft, ArrowRight, WashingMachine } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
   ApartmentFormFields,
@@ -25,6 +25,7 @@ import {
   fetchErrorFromResponse,
   fetchErrorFromException,
 } from "@/lib/fetch-error";
+import { useApartmentPager } from "@/lib/use-apartment-pager";
 
 interface ErrorState {
   headline: string;
@@ -77,6 +78,7 @@ function getCookieValue(name: string): string | null {
 export default function ApartmentDetailPage() {
   const params = useParams();
   const router = useRouter();
+  const pager = useApartmentPager(Number(params.id));
   const [apartment, setApartment] = useState<ApartmentDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [deleting, setDeleting] = useState(false);
@@ -309,6 +311,37 @@ export default function ApartmentDetailPage() {
 
   return (
     <div className="space-y-6">
+      <div className="flex items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={pager.prevId === null}
+          onClick={() => {
+            if (pager.prevId !== null) router.push(`/apartments/${pager.prevId}`);
+          }}
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Previous
+        </Button>
+        {pager.position !== null && pager.total > 0 && (
+          <span className="text-sm text-muted-foreground">
+            {pager.position} of {pager.total}
+          </span>
+        )}
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={pager.nextId === null}
+          onClick={() => {
+            if (pager.nextId !== null) router.push(`/apartments/${pager.nextId}`);
+          }}
+        >
+          Next
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
       <div className="flex items-start justify-between">
         <div className="space-y-1">
           <ShortCode code={apartment.shortCode} size="lg" />

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -35,6 +35,12 @@ import { usePersistedEnum } from "@/lib/use-persisted-enum";
 import {
   compareApartments,
   SORT_FIELD_LABELS,
+  SORT_FIELD_STORAGE_KEY,
+  SORT_DIRECTION_STORAGE_KEY,
+  SORT_CHANGE_EVENT,
+  SORT_FIELD_IDS,
+  isSortField,
+  isSortDirection,
   type SortDirection,
   type SortField,
 } from "@/lib/apartment-sort";
@@ -65,19 +71,6 @@ function isViewMode(v: string): v is ViewMode {
   return v === "grid" || v === "list";
 }
 
-const SORT_FIELD_STORAGE_KEY = "flatpare-apartments-sort-field";
-const SORT_DIRECTION_STORAGE_KEY = "flatpare-apartments-sort-direction";
-const SORT_CHANGE_EVENT = "flatpare-apartments-sort-change";
-
-const SORT_FIELD_IDS = Object.keys(SORT_FIELD_LABELS) as SortField[];
-
-function isSortField(v: string): v is SortField {
-  return (SORT_FIELD_IDS as string[]).includes(v);
-}
-
-function isSortDirection(v: string): v is SortDirection {
-  return v === "asc" || v === "desc";
-}
 
 export default function ApartmentsPage() {
   const [apartments, setApartments] = useState<ApartmentSummary[]>([]);

--- a/src/lib/__tests__/use-apartment-pager.test.tsx
+++ b/src/lib/__tests__/use-apartment-pager.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import { useApartmentPager } from "@/lib/use-apartment-pager";
+
+const LIST = [
+  {
+    id: 1,
+    name: "Sonnenweg 3",
+    address: null,
+    sizeM2: 60,
+    numRooms: 2.5,
+    rentChf: 2200,
+    shortCode: "ABC-2.5B-WY-4057",
+    avgOverall: null,
+    myRating: null,
+    createdAt: "2026-01-15T10:00:00Z",
+  },
+  {
+    id: 2,
+    name: "Bergstrasse 12",
+    address: null,
+    sizeM2: 45,
+    numRooms: 2,
+    rentChf: 1800,
+    shortCode: "DEF-2B-W-4058",
+    avgOverall: "3.5",
+    myRating: 4,
+    createdAt: "2026-03-20T10:00:00Z",
+  },
+  {
+    id: 3,
+    name: "Seeblick 7",
+    address: null,
+    sizeM2: 80,
+    numRooms: 3.5,
+    rentChf: null,
+    shortCode: "GHI-3.5B-WY-4059",
+    avgOverall: "4.5",
+    myRating: null,
+    createdAt: "2026-02-10T10:00:00Z",
+  },
+];
+
+// Default (createdAt desc) order: Bergstrasse (id 2), Seeblick (id 3), Sonnenweg (id 1).
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.spyOn(global, "fetch").mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(LIST),
+  } as Response);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useApartmentPager", () => {
+  it("returns loading state initially", () => {
+    const { result } = renderHook(() => useApartmentPager(2));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.total).toBe(0);
+    expect(result.current.position).toBeNull();
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("resolves to correct position and neighbors under default sort (createdAt desc)", async () => {
+    // Default order: Bergstrasse (2, newest), Seeblick (3), Sonnenweg (1, oldest).
+    // Middle apartment = Seeblick (id 3): position 2, prev 2, next 1.
+    const { result } = renderHook(() => useApartmentPager(3));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.total).toBe(3);
+    expect(result.current.position).toBe(2);
+    expect(result.current.prevId).toBe(2);
+    expect(result.current.nextId).toBe(1);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("honors sort preference stored in localStorage", async () => {
+    // rentChf asc: Bergstrasse (1800, id 2), Sonnenweg (2200, id 1), Seeblick (null last, id 3).
+    localStorage.setItem("flatpare-apartments-sort-field", "rentChf");
+    localStorage.setItem("flatpare-apartments-sort-direction", "asc");
+    const { result } = renderHook(() => useApartmentPager(1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.position).toBe(2);
+    expect(result.current.prevId).toBe(2);
+    expect(result.current.nextId).toBe(3);
+  });
+
+  it("returns prevId null on the first apartment in order", async () => {
+    // Default order: Bergstrasse (2) is first.
+    const { result } = renderHook(() => useApartmentPager(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.position).toBe(1);
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBe(3);
+  });
+
+  it("returns nextId null on the last apartment in order", async () => {
+    // Default order: Sonnenweg (1) is last.
+    const { result } = renderHook(() => useApartmentPager(1));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.position).toBe(3);
+    expect(result.current.prevId).toBe(3);
+    expect(result.current.nextId).toBeNull();
+  });
+
+  it("returns null position and null ids when current id is not in the list", async () => {
+    const { result } = renderHook(() => useApartmentPager(9999));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.total).toBe(3);
+    expect(result.current.position).toBeNull();
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBeNull();
+  });
+
+  it("falls back to defaults when localStorage has invalid sort values", async () => {
+    localStorage.setItem("flatpare-apartments-sort-field", "bogus");
+    localStorage.setItem("flatpare-apartments-sort-direction", "sideways");
+    const { result } = renderHook(() => useApartmentPager(3));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    // Defaults → createdAt desc → Seeblick is position 2.
+    expect(result.current.position).toBe(2);
+    expect(result.current.prevId).toBe(2);
+    expect(result.current.nextId).toBe(1);
+  });
+
+  it("surfaces an error when the list fetch fails", async () => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      clone() {
+        return this;
+      },
+      text: () => Promise.resolve("boom"),
+      headers: new Headers(),
+    } as unknown as Response);
+
+    const { result } = renderHook(() => useApartmentPager(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.total).toBe(0);
+    expect(result.current.position).toBeNull();
+    expect(result.current.prevId).toBeNull();
+    expect(result.current.nextId).toBeNull();
+  });
+
+  // Silence unused-import warning without removing act.
+  void act;
+});

--- a/src/lib/__tests__/use-apartment-pager.test.tsx
+++ b/src/lib/__tests__/use-apartment-pager.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, waitFor, act } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 import { useApartmentPager } from "@/lib/use-apartment-pager";
 
 const LIST = [
@@ -148,6 +148,13 @@ describe("useApartmentPager", () => {
     expect(result.current.nextId).toBeNull();
   });
 
-  // Silence unused-import warning without removing act.
-  void act;
+  it("surfaces an error when fetch itself throws (network failure)", async () => {
+    vi.spyOn(global, "fetch").mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(() => useApartmentPager(2));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.total).toBe(0);
+    expect(result.current.position).toBeNull();
+  });
 });

--- a/src/lib/apartment-sort.ts
+++ b/src/lib/apartment-sort.ts
@@ -85,3 +85,17 @@ export function compareApartments(
   }
   return a.id - b.id;
 }
+
+export const SORT_FIELD_STORAGE_KEY = "flatpare-apartments-sort-field";
+export const SORT_DIRECTION_STORAGE_KEY = "flatpare-apartments-sort-direction";
+export const SORT_CHANGE_EVENT = "flatpare-apartments-sort-change";
+
+export const SORT_FIELD_IDS = Object.keys(SORT_FIELD_LABELS) as SortField[];
+
+export function isSortField(v: string): v is SortField {
+  return (SORT_FIELD_IDS as string[]).includes(v);
+}
+
+export function isSortDirection(v: string): v is SortDirection {
+  return v === "asc" || v === "desc";
+}

--- a/src/lib/use-apartment-pager.ts
+++ b/src/lib/use-apartment-pager.ts
@@ -1,0 +1,110 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  compareApartments,
+  isSortDirection,
+  isSortField,
+  SORT_DIRECTION_STORAGE_KEY,
+  SORT_FIELD_STORAGE_KEY,
+  type SortableApartment,
+  type SortDirection,
+  type SortField,
+} from "@/lib/apartment-sort";
+import {
+  type ErrorDetails,
+  fetchErrorFromException,
+  fetchErrorFromResponse,
+} from "@/lib/fetch-error";
+
+export interface ApartmentPagerResult {
+  loading: boolean;
+  error: ErrorDetails | null;
+  total: number;
+  position: number | null;
+  prevId: number | null;
+  nextId: number | null;
+}
+
+function readSortField(): SortField {
+  const raw = window.localStorage.getItem(SORT_FIELD_STORAGE_KEY);
+  return raw !== null && isSortField(raw) ? raw : "createdAt";
+}
+
+function readSortDirection(): SortDirection {
+  const raw = window.localStorage.getItem(SORT_DIRECTION_STORAGE_KEY);
+  return raw !== null && isSortDirection(raw) ? raw : "desc";
+}
+
+export function useApartmentPager(currentId: number): ApartmentPagerResult {
+  const [apartments, setApartments] = useState<SortableApartment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<ErrorDetails | null>(null);
+
+  // Read sort preference once on mount — detail page does not need same-tab
+  // sync because the user cannot change sort while on the detail page.
+  const [sortField] = useState<SortField>(() => readSortField());
+  const [sortDirection] = useState<SortDirection>(() => readSortDirection());
+
+  useEffect(() => {
+    let cancelled = false;
+    const url = "/api/apartments";
+    (async () => {
+      try {
+        const res = await fetch(url);
+        if (cancelled) return;
+        if (!res.ok) {
+          setError(await fetchErrorFromResponse(res, url));
+          setLoading(false);
+          return;
+        }
+        const data = (await res.json()) as SortableApartment[];
+        if (cancelled) return;
+        setApartments(data);
+        setLoading(false);
+      } catch (err) {
+        if (cancelled) return;
+        setError(fetchErrorFromException(err, url));
+        setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return useMemo(() => {
+    if (loading || error) {
+      return {
+        loading,
+        error,
+        total: apartments.length,
+        position: null,
+        prevId: null,
+        nextId: null,
+      };
+    }
+    const sorted = [...apartments].sort((a, b) =>
+      compareApartments(a, b, sortField, sortDirection)
+    );
+    const index = sorted.findIndex((a) => a.id === currentId);
+    if (index === -1) {
+      return {
+        loading: false,
+        error: null,
+        total: sorted.length,
+        position: null,
+        prevId: null,
+        nextId: null,
+      };
+    }
+    return {
+      loading: false,
+      error: null,
+      total: sorted.length,
+      position: index + 1,
+      prevId: index > 0 ? sorted[index - 1].id : null,
+      nextId: index < sorted.length - 1 ? sorted[index + 1].id : null,
+    };
+  }, [loading, error, apartments, sortField, sortDirection, currentId]);
+}


### PR DESCRIPTION
## Summary
- New `useApartmentPager` hook (9 unit tests) fetches the apartment list on mount, reads the user's sort preference from localStorage (keys shipped in #61), and derives `position`, `prevId`, `nextId` via `compareApartments`.
- Detail page `/apartments/[id]` gets a compact `[← Previous] N of M [Next →]` row above the header; buttons disabled at the edges, loading, error, or when the current id is not in the list.
- Refactor: moved sort localStorage constants and validators from `src/app/apartments/page.tsx` into `src/lib/apartment-sort.ts` so both the list and the hook import from one place.
- Bumped the timeout on `edit-flow.test.tsx`'s save test to 10s — the extra list fetch tightened the parallel-suite budget past the default 5s.

## Test plan
- [x] `npm test` (170/170)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] Vercel preview: change sort on the list page, click into any apartment, verify Previous/Next follow the same order; verify edges disable buttons and direct-URL navigation still shows the pager.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)