### PR TITLE
feat: link apartment names, PDFs, and listings in compare view (#64)

### DIFF
--- a/docs/superpowers/plans/2026-04-24-compare-column-links.md
+++ b/docs/superpowers/plans/2026-04-24-compare-column-links.md
@@ -1,0 +1,315 @@
+# Compare Column Header Links Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the apartment name in each compare-view column header into a link to the detail page and add small PDF / Listing icon links alongside it. All three open in a new tab so the compare view stays intact.
+
+**Architecture:** Edit one render block in `src/app/compare/page.tsx`. Widen `ApartmentWithRatings` by two optional-valued URL fields. Extend the existing `compare-page.test.tsx` with a new `describe` block for link behavior and update the fixture to populate the URLs on two of three apartments.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Vitest + React Testing Library, Tailwind, `lucide-react` icons.
+
+**Spec:** [`docs/superpowers/specs/2026-04-24-compare-column-links-design.md`](../specs/2026-04-24-compare-column-links-design.md)
+**Issue:** [#64](https://github.com/brlauuu/flatpare/issues/64)
+
+---
+
+## File Structure
+
+### Files modified
+
+- `src/app/compare/page.tsx` — widen `ApartmentWithRatings` with `pdfUrl` / `listingUrl`; extend the `lucide-react` import; replace the name `<div>` with a three-element flex row (anchor for name, optional anchor for PDF, optional anchor for listing).
+- `src/app/compare/__tests__/compare-page.test.tsx` — populate `pdfUrl` / `listingUrl` on Sonnenweg and Bergstrasse fixtures; append a new `describe("Compare page — column header links", ...)` block with 5 tests.
+
+### No new files. No API or schema changes.
+
+---
+
+## Task 1: Ship column header links (single-task plan)
+
+One coherent change: one source file + one test file. TDD ordering — tests first, implementation second.
+
+**Files:**
+- Modify: `src/app/compare/page.tsx`
+- Modify: `src/app/compare/__tests__/compare-page.test.tsx`
+
+### Step 1: Update fixture URLs in `compare-page.test.tsx`
+
+In `src/app/compare/__tests__/compare-page.test.tsx`, locate the `DETAILS` constant (near the top of the file). Each fixture object currently omits `pdfUrl` and `listingUrl`. Add them as follows, keeping every other field intact:
+
+- `id: 1` (Sonnenweg 3) — add `pdfUrl: "https://example.com/sonnenweg.pdf"`, `listingUrl: null`.
+- `id: 2` (Bergstrasse 12) — add `pdfUrl: null`, `listingUrl: "https://example.com/bergstrasse-listing"`.
+- `id: 3` (Seeblick 7) — add `pdfUrl: null`, `listingUrl: null`.
+
+Add both keys to every object (even null) so the TypeScript structural type stays consistent.
+
+- [ ] **Step 2: Append the failing tests**
+
+In `src/app/compare/__tests__/compare-page.test.tsx`, after the existing `describe("Compare page — sort", ...)` block closes, append:
+
+```tsx
+describe("Compare page — column header links", () => {
+  it("renders the apartment name as a link to its detail page in a new tab", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    const link = screen.getByRole("link", { name: "Sonnenweg 3" });
+    expect(link).toHaveAttribute("href", "/apartments/1");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders a PDF icon link when pdfUrl is present", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    const pdfLink = screen.getByRole("link", {
+      name: /View PDF for Sonnenweg 3/i,
+    });
+    expect(pdfLink).toHaveAttribute(
+      "href",
+      "https://example.com/sonnenweg.pdf"
+    );
+    expect(pdfLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("hides the PDF icon link when pdfUrl is null", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Bergstrasse 12")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("link", { name: /View PDF for Bergstrasse 12/i })
+    ).toBeNull();
+  });
+
+  it("renders an Original listing icon link when listingUrl is present", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Bergstrasse 12")).toBeInTheDocument();
+    });
+    const listingLink = screen.getByRole("link", {
+      name: /Original listing for Bergstrasse 12/i,
+    });
+    expect(listingLink).toHaveAttribute(
+      "href",
+      "https://example.com/bergstrasse-listing"
+    );
+    expect(listingLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("hides the Original listing icon link when listingUrl is null", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Seeblick 7")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("link", { name: /Original listing for Seeblick 7/i })
+    ).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+Run: `npm test -- src/app/compare/__tests__/compare-page.test.tsx`
+Expected: 5 new tests fail — no anchors exist yet for name / PDF / listing. Existing 6 sort/hidden tests still pass (they only assert on text content and the close button, which are unchanged).
+
+- [ ] **Step 4: Widen `ApartmentWithRatings` in `src/app/compare/page.tsx`**
+
+Find the interface (around line 43). Add two fields:
+
+```tsx
+interface ApartmentWithRatings {
+  id: number;
+  name: string;
+  address: string | null;
+  sizeM2: number | null;
+  numRooms: number | null;
+  numBathrooms: number | null;
+  numBalconies: number | null;
+  hasWashingMachine: boolean | null;
+  rentChf: number | null;
+  distanceBikeMin: number | null;
+  distanceTransitMin: number | null;
+  pdfUrl: string | null;
+  listingUrl: string | null;
+  shortCode: string | null;
+  ratings: {
+    userName: string;
+    kitchen: number;
+    balconies: number;
+    location: number;
+    floorplan: number;
+    overallFeeling: number;
+    comment: string;
+  }[];
+}
+```
+
+(Only `pdfUrl` and `listingUrl` are new; keep other fields as they are.)
+
+- [ ] **Step 5: Extend the `lucide-react` import**
+
+Current import at the top of `src/app/compare/page.tsx`:
+
+```tsx
+import { ArrowDown, ArrowUp, BarChart3 } from "lucide-react";
+```
+
+Replace with:
+
+```tsx
+import {
+  ArrowDown,
+  ArrowUp,
+  BarChart3,
+  ExternalLink,
+  FileText,
+} from "lucide-react";
+```
+
+- [ ] **Step 6: Replace the column-header name block**
+
+Find the column-header content — inside `thead` > `tr` > the `sortedVisible.map((apt) => ...)` block — there is a `<div className="space-y-1">` containing:
+
+```tsx
+<div className="space-y-1">
+  <div className="font-semibold">{apt.name}</div>
+  <ShortCode code={apt.shortCode} />
+  {apt.address && (
+    <AddressLink
+      address={apt.address}
+      className="text-xs font-normal text-muted-foreground"
+    />
+  )}
+</div>
+```
+
+Replace the inner `<div className="font-semibold">{apt.name}</div>` with a new flex row holding the name anchor plus the two optional icon anchors. The resulting block:
+
+```tsx
+<div className="space-y-1">
+  <div className="flex items-center gap-1.5">
+    <a
+      href={`/apartments/${apt.id}`}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="font-semibold hover:underline"
+    >
+      {apt.name}
+    </a>
+    {apt.pdfUrl && (
+      <a
+        href={apt.pdfUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`View PDF for ${apt.name}`}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <FileText className="h-3.5 w-3.5" />
+      </a>
+    )}
+    {apt.listingUrl && (
+      <a
+        href={apt.listingUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label={`Original listing for ${apt.name}`}
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <ExternalLink className="h-3.5 w-3.5" />
+      </a>
+    )}
+  </div>
+  <ShortCode code={apt.shortCode} />
+  {apt.address && (
+    <AddressLink
+      address={apt.address}
+      className="text-xs font-normal text-muted-foreground"
+    />
+  )}
+</div>
+```
+
+- [ ] **Step 7: Run the compare-page tests — should pass**
+
+Run: `npm test -- src/app/compare/__tests__/compare-page.test.tsx`
+Expected: 11 tests pass (6 existing + 5 new).
+
+- [ ] **Step 8: Run the full test suite and lint**
+
+Run: `npm test && npm run lint`
+Expected: all tests pass (186 total = prior 181 + 5 new), lint clean.
+
+- [ ] **Step 9: Run the build**
+
+Run: `npm run build`
+Expected: build succeeds, no TS errors.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/app/compare/page.tsx src/app/compare/__tests__/compare-page.test.tsx
+git commit -m "feat: link apartment names, PDFs, and listings in compare view (#64)"
+```
+
+---
+
+## Task 2: Open PR
+
+**Files:** none — workflow only.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin 64-compare-column-links`
+Expected: branch published.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat: link apartment names, PDFs, and listings in compare view (#64)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Compare view column headers: apartment name is now a link to the detail page; small PDF and Listing icons appear next to it when those URLs are set; all three open in a new tab so the compare view (sort + hidden columns) stays intact.
+- Widened the compare page's \`ApartmentWithRatings\` type with \`pdfUrl\` / \`listingUrl\` (both already returned by the detail API).
+
+## Test plan
+- [x] \`npm test\` passes (5 new tests, 186 total)
+- [x] \`npm run lint\` clean
+- [x] \`npm run build\` succeeds
+- [ ] Vercel preview: open \`/compare\`, verify each name is a link that opens the detail page in a new tab; verify PDF/Listing icons appear only when the underlying URL is set; confirm hidden columns and sort order survive across clicks.
+
+Closes #64
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Hand back to the controller** — merge decision belongs to the user.
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- Name → detail page (new tab): Task 1 Step 6 ✓
+- PDF icon (new tab, hidden when null): Task 1 Step 6 + tests 2, 3 ✓
+- Listing icon (new tab, hidden when null): Task 1 Step 6 + tests 4, 5 ✓
+- All three use `target="_blank"` + `rel="noopener noreferrer"`: Task 1 Step 6 ✓
+- `ApartmentWithRatings` widened with `pdfUrl` / `listingUrl`: Task 1 Step 4 ✓
+- Close button stays where it is: unchanged (Task 1 Step 6 only touches the inner content block) ✓
+- Fixture exercises all 4 URL states (pdfUrl only, listingUrl only, neither — both provides only needed coverage per spec): Task 1 Step 1 ✓
+- Existing 6 sort / hidden tests remain green: verified in Task 1 Step 3 ("existing tests still pass") and Task 1 Step 7 (11 pass after) ✓
+
+**Placeholder scan:** no TBDs, no generic "handle edge case" phrases. Each code step shows full code.
+
+**Type consistency:**
+- `apt.pdfUrl` / `apt.listingUrl` are accessed in Task 1 Step 6; the interface gains them in Task 1 Step 4 (same file, earlier step).
+- `FileText` and `ExternalLink` are imported in Task 1 Step 5 before use in Step 6.
+- Fixture keys (`pdfUrl`, `listingUrl`) match the interface exactly.
+
+No gaps.

--- a/docs/superpowers/specs/2026-04-24-compare-column-links-design.md
+++ b/docs/superpowers/specs/2026-04-24-compare-column-links-design.md
@@ -1,0 +1,84 @@
+# Compare view column header links — design
+
+**Issue:** [#64 — In the compare tab, apartment names should be links](https://github.com/brlauuu/flatpare/issues/64)
+**Date:** 2026-04-24
+
+## Problem
+
+The compare view at `/compare` shows each apartment as a column; the column header currently renders the apartment name as plain text. Users want to navigate to the apartment detail page, its PDF, or its original listing from the compare view without losing the compare state (hidden columns, sort).
+
+## Scope
+
+Make the apartment name a link to the detail page and add two small icon links for PDF and the original listing. All three open in a new tab. Icons hide when their underlying URL is null. One render block in `src/app/compare/page.tsx` changes; no new component extraction.
+
+## UI
+
+Column header layout changes only inside the left-hand content block (the close "✕" button stays as-is):
+
+```
+Before:
+  <div className="font-semibold">{apt.name}</div>
+  <ShortCode code={apt.shortCode} />
+  {address && <AddressLink ... />}
+
+After:
+  <div className="flex items-center gap-1.5">
+    <a href="/apartments/{id}" target="_blank" rel="noopener noreferrer"
+       className="font-semibold hover:underline">{apt.name}</a>
+    {pdfUrl && <a href={pdfUrl} target="_blank" ...><FileText .../></a>}
+    {listingUrl && <a href={listingUrl} target="_blank" ...><ExternalLink .../></a>}
+  </div>
+  <ShortCode code={apt.shortCode} />
+  {address && <AddressLink ... />}
+```
+
+### Details
+
+- **Name anchor.** Plain `<a>`, not Next.js `<Link>`, because `target="_blank"` cross-origin-safe opens a fresh browser tab and bypasses client-side navigation — which is exactly what preserves the compare state. `className="font-semibold hover:underline"`. Default text color (no blue); hover-underline signals interactivity without visual noise.
+- **PDF icon.** `<FileText>` from `lucide-react`, `className="h-3.5 w-3.5"`. Wrapped in `<a target="_blank" rel="noopener noreferrer" aria-label={`View PDF for ${apt.name}`} className="text-muted-foreground hover:text-foreground">`. Renders only when `apt.pdfUrl` is truthy.
+- **Listing icon.** Same structure with `<ExternalLink>` and `aria-label={`Original listing for ${apt.name}`}`. Renders only when `apt.listingUrl` is truthy.
+- **All three links** use `target="_blank"` and `rel="noopener noreferrer"` (the standard security hygiene for new-tab external links).
+
+### Placements considered and rejected
+
+- **Dropdown/popover on the name** — overkill for three links.
+- **Single link target (pick one)** — user wants access to all three from compare without losing state.
+- **Add links inside the row sections instead of the header** — dilutes the "this column is apartment X" signal.
+
+## Data shape change
+
+`ApartmentWithRatings` in `src/app/compare/page.tsx` currently omits `pdfUrl` and `listingUrl`. The detail API (`GET /api/apartments/[id]`) returns the entire DB row via `...apartment[0]` spread, so these fields are already in the payload — the TypeScript interface just hasn't declared them. Add both as `string | null` to the interface. No schema, migration, or API change needed.
+
+## Testing
+
+Add a new `describe("Compare page — column header links", ...)` block to `src/app/compare/__tests__/compare-page.test.tsx`. Update the existing fixture to populate `pdfUrl` on one apartment and `listingUrl` on another (and neither on the third) so all branches are exercised:
+
+- Sonnenweg (id 1) → `pdfUrl: "https://example.com/sonnenweg.pdf"`, `listingUrl: null`.
+- Bergstrasse (id 2) → `pdfUrl: null`, `listingUrl: "https://example.com/bergstrasse-listing"`.
+- Seeblick (id 3) → both null.
+
+### New tests
+
+1. Apartment name renders as an anchor to `/apartments/{id}` with `target="_blank"`.
+2. PDF icon link appears when `pdfUrl` is present; href matches; new tab.
+3. PDF icon link is absent when `pdfUrl` is null.
+4. Listing icon link appears when `listingUrl` is present; href matches; new tab.
+5. Listing icon link is absent when `listingUrl` is null.
+
+Queries use `getByRole("link", { name: ... })` and `queryByRole` for the absence cases. `aria-label` on the icon links gives them an accessible name the role query can match.
+
+### Existing tests
+
+The existing 6 compare-page tests (sort + hidden columns) rely on `getByText("Sonnenweg 3")`, `columnOrder()` (which queries `thead th .font-semibold`), and the "Hide {name}" close-button aria-label. All continue to work because:
+
+- The name text still renders inside an element with `font-semibold` (just now an `<a>` instead of a `<div>`).
+- `columnOrder` queries `.font-semibold` and will match the anchor's `textContent`.
+- `getByText` matches text content regardless of wrapping tag.
+
+## Out of scope
+
+- No changes to the detail page's existing "View PDF" / "Original Listing" buttons.
+- No visual redesign of the "URL missing" badge that shows on the detail page when `listingUrl` is null — that UI is specific to the detail view.
+- No keyboard shortcut for jumping between linked columns.
+- No preview / hover card for the destinations.
+- No changes to the compare view's `ApartmentWithRatings` beyond adding `pdfUrl` and `listingUrl`.

--- a/src/app/compare/__tests__/compare-page.test.tsx
+++ b/src/app/compare/__tests__/compare-page.test.tsx
@@ -23,6 +23,8 @@ const DETAILS = [
     distanceTransitMin: 25,
     shortCode: "ABC-2.5B-WY-4057",
     createdAt: "2026-01-15T10:00:00Z",
+    pdfUrl: "https://example.com/sonnenweg.pdf",
+    listingUrl: null,
     ratings: [],
   },
   {
@@ -39,6 +41,8 @@ const DETAILS = [
     distanceTransitMin: 15,
     shortCode: "DEF-2B-W-4058",
     createdAt: "2026-03-20T10:00:00Z",
+    pdfUrl: null,
+    listingUrl: "https://example.com/bergstrasse-listing",
     ratings: [],
   },
   {
@@ -55,6 +59,8 @@ const DETAILS = [
     distanceTransitMin: 30,
     shortCode: "GHI-3.5B-WY-4059",
     createdAt: "2026-02-10T10:00:00Z",
+    pdfUrl: null,
+    listingUrl: null,
     ratings: [],
   },
 ];
@@ -188,5 +194,68 @@ describe("Compare page — sort", () => {
     await waitFor(() => {
       expect(columnOrder()).toEqual(["Sonnenweg 3", "Seeblick 7"]);
     });
+  });
+});
+
+describe("Compare page — column header links", () => {
+  it("renders the apartment name as a link to its detail page in a new tab", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    const link = screen.getByRole("link", { name: "Sonnenweg 3" });
+    expect(link).toHaveAttribute("href", "/apartments/1");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders a PDF icon link when pdfUrl is present", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    const pdfLink = screen.getByRole("link", {
+      name: /View PDF for Sonnenweg 3/i,
+    });
+    expect(pdfLink).toHaveAttribute(
+      "href",
+      "https://example.com/sonnenweg.pdf"
+    );
+    expect(pdfLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("hides the PDF icon link when pdfUrl is null", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Bergstrasse 12")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("link", { name: /View PDF for Bergstrasse 12/i })
+    ).toBeNull();
+  });
+
+  it("renders an Original listing icon link when listingUrl is present", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Bergstrasse 12")).toBeInTheDocument();
+    });
+    const listingLink = screen.getByRole("link", {
+      name: /Original listing for Bergstrasse 12/i,
+    });
+    expect(listingLink).toHaveAttribute(
+      "href",
+      "https://example.com/bergstrasse-listing"
+    );
+    expect(listingLink).toHaveAttribute("target", "_blank");
+  });
+
+  it("hides the Original listing icon link when listingUrl is null", async () => {
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Seeblick 7")).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByRole("link", { name: /Original listing for Seeblick 7/i })
+    ).toBeNull();
   });
 });

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -7,7 +7,13 @@ import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
 import { AddressLink } from "@/components/address-link";
 import { cn } from "@/lib/utils";
-import { ArrowDown, ArrowUp, BarChart3 } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  BarChart3,
+  ExternalLink,
+  FileText,
+} from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
   type ErrorDetails,
@@ -52,6 +58,8 @@ interface ApartmentWithRatings {
   rentChf: number | null;
   distanceBikeMin: number | null;
   distanceTransitMin: number | null;
+  pdfUrl: string | null;
+  listingUrl: string | null;
   shortCode: string | null;
   createdAt: string | null;
   avgOverall: string | null;
@@ -264,7 +272,38 @@ export default function ComparePage() {
                 >
                   <div className="flex items-start justify-between gap-2">
                     <div className="space-y-1">
-                      <div className="font-semibold">{apt.name}</div>
+                      <div className="flex items-center gap-1.5">
+                        <a
+                          href={`/apartments/${apt.id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="font-semibold hover:underline"
+                        >
+                          {apt.name}
+                        </a>
+                        {apt.pdfUrl && (
+                          <a
+                            href={apt.pdfUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`View PDF for ${apt.name}`}
+                            className="text-muted-foreground hover:text-foreground"
+                          >
+                            <FileText className="h-3.5 w-3.5" />
+                          </a>
+                        )}
+                        {apt.listingUrl && (
+                          <a
+                            href={apt.listingUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label={`Original listing for ${apt.name}`}
+                            className="text-muted-foreground hover:text-foreground"
+                          >
+                            <ExternalLink className="h-3.5 w-3.5" />
+                          </a>
+                        )}
+                      </div>
                       <ShortCode code={apt.shortCode} />
                       {apt.address && (
                         <AddressLink


### PR DESCRIPTION
## Summary
- Compare view column headers: apartment name is now a link to the detail page; small PDF and Listing icons appear next to it when those URLs are set; all three open in a new tab so the compare view (sort + hidden columns) stays intact.
- Widened the compare page's `ApartmentWithRatings` type with `pdfUrl` / `listingUrl` (both already returned by the detail API via `...apartment[0]` spread).

## Test plan
- [x] `npm test` passes (5 new tests, 186 total)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] Vercel preview: open `/compare`, click each name and verify it opens the detail page in a new tab; verify PDF/Listing icons appear only when their URL is set; confirm hidden columns and sort order survive across clicks.

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)