### PR TITLE
feat: user-switch during rating reloads form for new user (#50)

### DIFF
--- a/docs/superpowers/plans/2026-04-24-user-switch-rating.md
+++ b/docs/superpowers/plans/2026-04-24-user-switch-rating.md
@@ -1,0 +1,506 @@
+# User-Switch Rating Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the user switches identity via the NavBar while rating an apartment, confirm if there are unsaved changes, then reload the rating form for the new user so the right person's preferences are saved.
+
+**Architecture:** A tiny module-level `unsaved-changes` singleton tracks dirty state. The detail page writes to it in an effect and listens for a new `flatpare-user-changed` window event to reload its data. NavBar reads the flag synchronously to gate switches behind `window.confirm`, then dispatches the event after a successful cookie change.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Vitest + React Testing Library, native `window.confirm`, custom window events.
+
+**Spec:** [`docs/superpowers/specs/2026-04-24-user-switch-rating-design.md`](../specs/2026-04-24-user-switch-rating-design.md)
+**Issue:** [#50](https://github.com/brlauuu/flatpare/issues/50)
+
+---
+
+## File Structure
+
+### Files created
+
+- `src/lib/unsaved-changes.ts` — 3-function singleton (`setUnsavedRating`, `getUnsavedRating`, internal flag).
+- `src/lib/__tests__/unsaved-changes.test.ts` — 3 unit tests.
+- `src/app/apartments/[id]/__tests__/user-switch.test.tsx` — 3 integration tests.
+
+### Files modified
+
+- `src/app/apartments/[id]/page.tsx` — import `setUnsavedRating`; add two effects (dirty-tracker + user-change listener).
+- `src/components/nav-bar.tsx` — import `getUnsavedRating`; add `window.confirm` gates to `switchUser` / `deleteUser`; dispatch `flatpare-user-changed` after cookie mutations.
+
+### No API, DB, schema, or env changes.
+
+---
+
+## Task 1: Unsaved-changes singleton (TDD)
+
+**Files:**
+- Create: `src/lib/unsaved-changes.ts`
+- Create: `src/lib/__tests__/unsaved-changes.test.ts`
+
+### Step 1: Write the failing tests
+
+Create `src/lib/__tests__/unsaved-changes.test.ts`:
+
+```ts
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getUnsavedRating,
+  setUnsavedRating,
+} from "@/lib/unsaved-changes";
+
+afterEach(() => {
+  // Reset between tests so order doesn't matter.
+  setUnsavedRating(false);
+});
+
+describe("unsaved-changes", () => {
+  it("defaults to false", () => {
+    expect(getUnsavedRating()).toBe(false);
+  });
+
+  it("setUnsavedRating(true) flips the flag to true", () => {
+    setUnsavedRating(true);
+    expect(getUnsavedRating()).toBe(true);
+  });
+
+  it("setUnsavedRating(false) flips the flag back to false", () => {
+    setUnsavedRating(true);
+    setUnsavedRating(false);
+    expect(getUnsavedRating()).toBe(false);
+  });
+});
+```
+
+### Step 2: Run tests to confirm they fail
+
+Run: `npm test -- src/lib/__tests__/unsaved-changes.test.ts`
+Expected: 3 fail — `Cannot find module '@/lib/unsaved-changes'`.
+
+### Step 3: Implement the singleton
+
+Create `src/lib/unsaved-changes.ts`:
+
+```ts
+let hasUnsavedRating = false;
+
+export function setUnsavedRating(value: boolean): void {
+  hasUnsavedRating = value;
+}
+
+export function getUnsavedRating(): boolean {
+  return hasUnsavedRating;
+}
+```
+
+### Step 4: Run tests — should pass
+
+Run: `npm test -- src/lib/__tests__/unsaved-changes.test.ts`
+Expected: 3 pass.
+
+### Step 5: Full suite + lint
+
+Run: `npm test && npm run lint`
+Expected: 211/211 tests pass (prior 208 + 3 new), lint clean.
+
+### Step 6: Commit
+
+```bash
+git add src/lib/unsaved-changes.ts src/lib/__tests__/unsaved-changes.test.ts
+git commit -m "feat: add unsaved-rating singleton"
+```
+
+---
+
+## Task 2: Detail-page effects + integration tests (TDD)
+
+Wire the detail page to write the dirty flag and to re-load apartment data when a user-change event fires.
+
+**Files:**
+- Modify: `src/app/apartments/[id]/page.tsx`
+- Create: `src/app/apartments/[id]/__tests__/user-switch.test.tsx`
+
+### Step 1: Write the failing integration tests
+
+Create `src/app/apartments/[id]/__tests__/user-switch.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "42" }),
+  useRouter: () => ({ push, refresh }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const APARTMENT_WITH_TWO_RATINGS = {
+  id: 42,
+  name: "Test Flat",
+  address: null,
+  sizeM2: null,
+  numRooms: null,
+  numBathrooms: null,
+  numBalconies: null,
+  hasWashingMachine: null,
+  rentChf: null,
+  distanceBikeMin: null,
+  distanceTransitMin: null,
+  pdfUrl: null,
+  listingUrl: null,
+  shortCode: "ABC-?B-?b-W?-?",
+  ratings: [
+    {
+      id: 1,
+      userName: "Alice",
+      kitchen: 5,
+      balconies: 5,
+      location: 5,
+      floorplan: 5,
+      overallFeeling: 5,
+      comment: "alice comment",
+    },
+    {
+      id: 2,
+      userName: "Bob",
+      kitchen: 2,
+      balconies: 2,
+      location: 2,
+      floorplan: 2,
+      overallFeeling: 2,
+      comment: "bob comment",
+    },
+  ],
+};
+
+let currentCookie = "flatpare-name=Alice";
+
+beforeEach(() => {
+  push.mockReset();
+  refresh.mockReset();
+  currentCookie = "flatpare-name=Alice";
+
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    get: () => currentCookie,
+    set: () => {},
+  });
+
+  vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url === "/api/apartments") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }
+    if (url.endsWith("/api/apartments/42")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(APARTMENT_WITH_TWO_RATINGS),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  }) as typeof fetch);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Apartment detail — user switch", () => {
+  it("shows the current user's rating on mount", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+    expect(
+      (screen.getByLabelText(/Comment/i) as HTMLTextAreaElement).value
+    ).toBe("alice comment");
+  });
+
+  it("reloads the form for the new user when a user-change event fires", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+
+    // Simulate NavBar flipping the cookie and announcing the change.
+    currentCookie = "flatpare-name=Bob";
+    window.dispatchEvent(new Event("flatpare-user-changed"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Bob\)/)).toBeInTheDocument();
+    });
+    expect(
+      (screen.getByLabelText(/Comment/i) as HTMLTextAreaElement).value
+    ).toBe("bob comment");
+  });
+
+  it("reloads to an empty rating when the new user has none", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+
+    currentCookie = "flatpare-name=Charlie";
+    window.dispatchEvent(new Event("flatpare-user-changed"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Charlie\)/)).toBeInTheDocument();
+    });
+    expect(
+      (screen.getByLabelText(/Comment/i) as HTMLTextAreaElement).value
+    ).toBe("");
+  });
+});
+```
+
+### Step 2: Run tests to confirm they fail
+
+Run: `npm test -- src/app/apartments/\[id\]/__tests__/user-switch.test.tsx`
+Expected: test 1 passes (existing behavior works on mount). Tests 2 and 3 fail — the event has no listener yet; `Your Rating (Alice)` is still shown because the page never reloads.
+
+### Step 3: Add imports to `src/app/apartments/[id]/page.tsx`
+
+Near the existing `@/lib/fetch-error` import at the top of the file, add:
+
+```tsx
+import { setUnsavedRating } from "@/lib/unsaved-changes";
+```
+
+### Step 4: Add the dirty-tracker effect
+
+Inside `ApartmentDetailPage()`, below the existing `useEffect` that fetches the apartment on mount (`return () => { cancelled = true; };` at around line 174), add:
+
+```tsx
+useEffect(() => {
+  const dirty =
+    myRating.kitchen !== cleanRating.kitchen ||
+    myRating.balconies !== cleanRating.balconies ||
+    myRating.location !== cleanRating.location ||
+    myRating.floorplan !== cleanRating.floorplan ||
+    myRating.overallFeeling !== cleanRating.overallFeeling ||
+    myRating.comment !== cleanRating.comment;
+  setUnsavedRating(dirty);
+  return () => setUnsavedRating(false);
+}, [myRating, cleanRating]);
+```
+
+### Step 5: Add the user-change listener effect
+
+Directly after the dirty-tracker effect, add:
+
+```tsx
+useEffect(() => {
+  function handler() {
+    reloadApartment();
+  }
+  window.addEventListener("flatpare-user-changed", handler);
+  return () => window.removeEventListener("flatpare-user-changed", handler);
+  // reloadApartment is defined in this component scope; React hooks eslint may
+  // want it in deps — it's stable within this render and the ref-like usage is
+  // intentional. Using an inline closure keeps the effect body concise.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+}, []);
+```
+
+### Step 6: Run the new tests — should pass
+
+Run: `npm test -- src/app/apartments/\[id\]/__tests__/user-switch.test.tsx`
+Expected: 3 tests pass.
+
+### Step 7: Run the full suite and lint
+
+Run: `npm test && npm run lint`
+Expected: all tests pass (214 total = prior 208 + 3 unit + 3 integration = 214), lint clean.
+
+### Step 8: Commit
+
+```bash
+git add src/app/apartments/[id]/page.tsx src/app/apartments/[id]/__tests__/user-switch.test.tsx
+git commit -m "feat: detail page reloads rating on user change"
+```
+
+---
+
+## Task 3: NavBar confirm + event dispatch
+
+**Files:**
+- Modify: `src/components/nav-bar.tsx`
+
+No new tests — per spec, NavBar's flow is simple and the existing integration tests for other pages don't interact with user switching.
+
+### Step 1: Import the tracker
+
+At the top of `src/components/nav-bar.tsx`, add:
+
+```tsx
+import { getUnsavedRating } from "@/lib/unsaved-changes";
+```
+
+### Step 2: Update `switchUser`
+
+Find the existing `switchUser` function (around line 40):
+
+```ts
+async function switchUser(name: string) {
+  if (name === userName) return;
+  await fetch("/api/auth/name", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ displayName: name }),
+  });
+  router.refresh();
+}
+```
+
+Replace with:
+
+```ts
+async function switchUser(name: string) {
+  if (name === userName) return;
+  if (getUnsavedRating()) {
+    const ok = window.confirm(
+      "You have unsaved rating changes. Switch user anyway? Your input will be discarded."
+    );
+    if (!ok) return;
+  }
+  await fetch("/api/auth/name", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ displayName: name }),
+  });
+  window.dispatchEvent(new Event("flatpare-user-changed"));
+  router.refresh();
+}
+```
+
+### Step 3: Update `deleteUser`
+
+Find the existing `deleteUser` function (around line 50):
+
+```ts
+async function deleteUser(name: string) {
+  const res = await fetch(
+    `/api/auth/users/${encodeURIComponent(name)}`,
+    { method: "DELETE" }
+  );
+  if (!res.ok) return;
+  const data = (await res.json()) as { switchedTo?: string | null };
+  if (data.switchedTo === null) {
+    router.push("/");
+  } else {
+    router.refresh();
+  }
+}
+```
+
+Replace with:
+
+```ts
+async function deleteUser(name: string) {
+  if (name === userName && getUnsavedRating()) {
+    const ok = window.confirm(
+      "You have unsaved rating changes. Delete yourself anyway? Your input will be discarded."
+    );
+    if (!ok) return;
+  }
+  const res = await fetch(
+    `/api/auth/users/${encodeURIComponent(name)}`,
+    { method: "DELETE" }
+  );
+  if (!res.ok) return;
+  const data = (await res.json()) as { switchedTo?: string | null };
+  if (data.switchedTo !== undefined) {
+    window.dispatchEvent(new Event("flatpare-user-changed"));
+  }
+  if (data.switchedTo === null) {
+    router.push("/");
+  } else {
+    router.refresh();
+  }
+}
+```
+
+### Step 4: Run the full suite and lint
+
+Run: `npm test && npm run lint`
+Expected: 214/214 tests pass, lint clean.
+
+### Step 5: Run the build
+
+Run: `npm run build`
+Expected: build succeeds.
+
+### Step 6: Commit
+
+```bash
+git add src/components/nav-bar.tsx
+git commit -m "feat: NavBar confirms unsaved rating before user switch (#50)"
+```
+
+---
+
+## Task 4: Open PR
+
+**Files:** none — workflow only.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin 50-user-switch-rating`
+Expected: branch published.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat: user-switch during rating reloads form for new user (#50)" \
+  --body "$(cat <<'EOF'
+## Summary
+- Tracks "unsaved rating changes" in a tiny singleton (\`src/lib/unsaved-changes.ts\`).
+- Detail page reads the flag via an effect and listens for a new \`flatpare-user-changed\` window event; on fire, it reloads the apartment and re-derives the rating form from the new cookie.
+- NavBar's \`switchUser\` and \`deleteUser\` show a \`window.confirm\` when there are unsaved changes; on proceed, they dispatch the event so the detail page updates without the user having to navigate away.
+
+## Test plan
+- [x] \`npm test\` passes (3 singleton tests + 3 integration tests, 214 total)
+- [x] \`npm run lint\` clean
+- [x] \`npm run build\` succeeds
+- [ ] Vercel preview: rate an apartment partially, switch users via the NavBar dropdown — confirm dialog appears; cancel keeps you on the old user; confirm loads the new user's rating form.
+
+Closes #50
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Hand back to the controller.**
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- `src/lib/unsaved-changes.ts` singleton with `getUnsavedRating` / `setUnsavedRating`: Task 1 ✓
+- 3 unit tests for the singleton: Task 1 Step 1 ✓
+- Detail page writes the flag via effect on `myRating`/`cleanRating`: Task 2 Step 4 ✓
+- Effect cleanup clears flag on unmount: Task 2 Step 4 (return function) ✓
+- Detail page listens for `flatpare-user-changed` and calls `reloadApartment`: Task 2 Step 5 ✓
+- 3 integration tests: Task 2 Step 1 ✓
+- NavBar `switchUser` gate via `window.confirm` when flag is set: Task 3 Step 2 ✓
+- NavBar dispatches `flatpare-user-changed` after cookie mutations: Task 3 Step 2 (switchUser) + Step 3 (deleteUser) ✓
+- NavBar `deleteUser` confirms only when self-deleting: Task 3 Step 3 (`if (name === userName && getUnsavedRating())`) ✓
+- NavBar `deleteUser` dispatches only when `switchedTo !== undefined`: Task 3 Step 3 ✓
+
+**Placeholder scan:** no TBDs, no "implement later". Every code step shows complete code.
+
+**Type consistency:**
+- `setUnsavedRating` / `getUnsavedRating` signatures match between Task 1 definition and Tasks 2/3 imports.
+- Custom event name `"flatpare-user-changed"` used identically in Tasks 2 (listener) and 3 (dispatcher).
+- Test Step 1 mocks in `user-switch.test.tsx` match the route/fetch contract used elsewhere.
+
+No gaps.

--- a/docs/superpowers/specs/2026-04-24-user-switch-rating-design.md
+++ b/docs/superpowers/specs/2026-04-24-user-switch-rating-design.md
@@ -1,0 +1,165 @@
+# User-switch during rating — design
+
+**Issue:** [#50 — If the user changes in the middle of rating the apartment, the rating should be updated so that the right user's preferences are saved](https://github.com/brlauuu/flatpare/issues/50)
+**Date:** 2026-04-24
+
+## Problem
+
+On the apartment detail page, the rating form loads its data (existing stars + comment) for the current user identified by the `flatpare-name` cookie. The page reads the cookie ONCE — during the initial apartment fetch (`applyApartmentData`). If the user then switches their identity via the NavBar user switcher mid-editing, two failure modes occur:
+
+1. The rating form still shows the previous user's input (or their saved rating, if any).
+2. Saving the form writes those inputs to the DB under the NEW user's name — overwriting or creating the new user's rating with data the previous user entered.
+
+## Scope
+
+- Detect user switches (NavBar's `switchUser` and self-deletion in `deleteUser`) and notify the detail page.
+- When a switch happens with unsaved rating changes, ask for confirmation first. On cancel, don't switch. On confirm, discard the in-progress input and reload the form for the new user.
+- Module-level "unsaved rating" flag so NavBar can check synchronously without re-rendering on every keystroke.
+- No change to the server or database.
+
+## "Unsaved rating" tracker
+
+New module: `src/lib/unsaved-changes.ts` — a minimal singleton.
+
+```ts
+let hasUnsavedRating = false;
+export function setUnsavedRating(v: boolean) { hasUnsavedRating = v; }
+export function getUnsavedRating(): boolean { return hasUnsavedRating; }
+```
+
+- **Detail page writes to it** in an effect whose dependencies are `myRating` and `cleanRating`. The effect computes dirty-ness (same 6-field comparison that already gates the Save button) and calls `setUnsavedRating(dirty)`. Effect cleanup clears the flag when the page unmounts.
+- **NavBar reads from it** synchronously in `switchUser` / `deleteUser` click handlers.
+- Not exposed via React context. A plain module variable is correct for this shape — one reader (NavBar), one writer (detail page), no re-renders needed on changes.
+
+## Detail page (`src/app/apartments/[id]/page.tsx`) changes
+
+### New effect: dirty tracker
+
+```tsx
+useEffect(() => {
+  const dirty =
+    myRating.kitchen !== cleanRating.kitchen ||
+    myRating.balconies !== cleanRating.balconies ||
+    myRating.location !== cleanRating.location ||
+    myRating.floorplan !== cleanRating.floorplan ||
+    myRating.overallFeeling !== cleanRating.overallFeeling ||
+    myRating.comment !== cleanRating.comment;
+  setUnsavedRating(dirty);
+  return () => setUnsavedRating(false);
+}, [myRating, cleanRating]);
+```
+
+Cleanup fires on unmount AND between re-runs. Net effect: the flag is correct after every commit; on unmount (navigation away) it resets to `false` cleanly.
+
+### New effect: listen for `flatpare-user-changed`
+
+```tsx
+useEffect(() => {
+  function handler() {
+    reloadApartment();
+  }
+  window.addEventListener("flatpare-user-changed", handler);
+  return () => window.removeEventListener("flatpare-user-changed", handler);
+}, []);
+```
+
+`reloadApartment` is already defined in the page; it calls `applyApartmentData(fetch(/api/apartments/:id))`, which re-reads the cookie and derives `myRating`/`cleanRating` from the fresh user's existing rating (or `EMPTY_RATING`). Nothing new needed inside `applyApartmentData`.
+
+## NavBar (`src/components/nav-bar.tsx`) changes
+
+### Import the tracker
+
+```tsx
+import { getUnsavedRating } from "@/lib/unsaved-changes";
+```
+
+### `switchUser` confirmation + dispatch
+
+```ts
+async function switchUser(name: string) {
+  if (name === userName) return;
+  if (getUnsavedRating()) {
+    const ok = window.confirm(
+      "You have unsaved rating changes. Switch user anyway? Your input will be discarded."
+    );
+    if (!ok) return;
+  }
+  await fetch("/api/auth/name", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ displayName: name }),
+  });
+  window.dispatchEvent(new Event("flatpare-user-changed"));
+  router.refresh();
+}
+```
+
+### `deleteUser` confirmation + dispatch
+
+Confirmation gate fires only when the deleted user is the current user (deleting someone else doesn't change your identity). Dispatch fires only when the server actually changed your identity (`switchedTo !== undefined`):
+
+```ts
+async function deleteUser(name: string) {
+  if (name === userName && getUnsavedRating()) {
+    const ok = window.confirm(
+      "You have unsaved rating changes. Delete yourself anyway? Your input will be discarded."
+    );
+    if (!ok) return;
+  }
+  const res = await fetch(`/api/auth/users/${encodeURIComponent(name)}`, { method: "DELETE" });
+  if (!res.ok) return;
+  const data = (await res.json()) as { switchedTo?: string | null };
+  if (data.switchedTo !== undefined) {
+    window.dispatchEvent(new Event("flatpare-user-changed"));
+  }
+  if (data.switchedTo === null) {
+    router.push("/");
+  } else {
+    router.refresh();
+  }
+}
+```
+
+## Why custom event (not `router.refresh()` alone)
+
+`router.refresh()` re-fetches server components (the layout with its `userName` prop on the NavBar) but does NOT re-run the client page's `useEffect`s or reset its `useState`. The detail page's `myRating` / `userName` state stays as-is. A custom event is the explicit, minimal signal that tells the page "the cookie changed — re-read apartment data".
+
+The event name `flatpare-user-changed` joins the existing family of custom events the project uses for same-tab synchronization (`flatpare-apartments-sort-change`, `flatpare-apartments-view-change`, `flatpare-compare-sort-change`).
+
+## Testing
+
+### Unit tests — `src/lib/__tests__/unsaved-changes.test.ts` (new, 3 tests)
+
+1. Defaults to `false`.
+2. `setUnsavedRating(true)` → `getUnsavedRating()` is `true`.
+3. `setUnsavedRating(false)` after a true → `getUnsavedRating()` is `false`.
+
+### Integration tests — `src/app/apartments/[id]/__tests__/user-switch.test.tsx` (new, 3 tests)
+
+Fixture: an apartment with two ratings on it (Alice and Bob) plus no-rating-for-a-new-user case. Tests drive the custom event directly, not through NavBar — the event is the contract between the two components.
+
+1. **Initial load shows the current user's rating.** Cookie is `flatpare-name=Alice`. On mount, the form shows Alice's stars and comment.
+2. **Dispatching `flatpare-user-changed` with the cookie switched to Bob reloads the form.** Test updates `document.cookie` to Bob, dispatches the event, and asserts the form shows Bob's values.
+3. **Dispatching the event with the cookie switched to a new user (not in ratings) reloads to the empty state.** All sliders back to 0 stars, empty comment.
+
+### No NavBar-level integration test
+
+NavBar's flow (read flag → `window.confirm` → dispatch → refresh) is simple enough that mocking `window.confirm` + asserting the fetch and dispatch calls has low marginal value relative to the test scaffolding needed to mount NavBar in isolation (it depends on `useRouter`, `usePathname`, and a fetch to `/api/auth/users`). The unit tests and the two integration tests together cover the real behavior. If the team later adds a regression around the confirm flow, we can add a NavBar test then.
+
+### Existing tests
+
+Unchanged. `rating-cancel.test.tsx`, `edit-flow.test.tsx`, `pager.test.tsx`, `retry.test.tsx` don't interact with user switching.
+
+## Out of scope
+
+- Auto-save the previous user's input before switching (rejected).
+- A real modal for the confirm (native `window.confirm` is fine for this personal app).
+- Warning the user when they close the tab with unsaved rating input (`beforeunload`).
+- Syncing user identity across browser tabs (storage events / `BroadcastChannel`).
+- Any changes to `/api/auth/name` or `/api/auth/users/:name`.
+
+## Security notes
+
+- `window.confirm` is a passive gate — no data flows through it.
+- The singleton module is per-browser-tab. Two tabs can hold different "dirty" flags without interference.
+- No new inputs, no new endpoints, no new trust boundaries.

--- a/src/app/apartments/[id]/__tests__/user-switch.test.tsx
+++ b/src/app/apartments/[id]/__tests__/user-switch.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "42" }),
+  useRouter: () => ({ push, refresh }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const APARTMENT_WITH_TWO_RATINGS = {
+  id: 42,
+  name: "Test Flat",
+  address: null,
+  sizeM2: null,
+  numRooms: null,
+  numBathrooms: null,
+  numBalconies: null,
+  hasWashingMachine: null,
+  rentChf: null,
+  distanceBikeMin: null,
+  distanceTransitMin: null,
+  pdfUrl: null,
+  listingUrl: null,
+  shortCode: "ABC-?B-?b-W?-?",
+  ratings: [
+    {
+      id: 1,
+      userName: "Alice",
+      kitchen: 5,
+      balconies: 5,
+      location: 5,
+      floorplan: 5,
+      overallFeeling: 5,
+      comment: "alice comment",
+    },
+    {
+      id: 2,
+      userName: "Bob",
+      kitchen: 2,
+      balconies: 2,
+      location: 2,
+      floorplan: 2,
+      overallFeeling: 2,
+      comment: "bob comment",
+    },
+  ],
+};
+
+let currentCookie = "flatpare-name=Alice";
+
+beforeEach(() => {
+  push.mockReset();
+  refresh.mockReset();
+  currentCookie = "flatpare-name=Alice";
+
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    get: () => currentCookie,
+    set: () => {},
+  });
+
+  vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url === "/api/apartments") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }
+    if (url.endsWith("/api/apartments/42")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(APARTMENT_WITH_TWO_RATINGS),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  }) as typeof fetch);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Apartment detail — user switch", () => {
+  it("shows the current user's rating on mount", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+    expect(
+      (screen.getByLabelText(/Comment/i) as HTMLTextAreaElement).value
+    ).toBe("alice comment");
+  });
+
+  it("reloads the form for the new user when a user-change event fires", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+
+    currentCookie = "flatpare-name=Bob";
+    window.dispatchEvent(new Event("flatpare-user-changed"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Bob\)/)).toBeInTheDocument();
+    });
+    expect(
+      (screen.getByLabelText(/Comment/i) as HTMLTextAreaElement).value
+    ).toBe("bob comment");
+  });
+
+  it("reloads to an empty rating when the new user has none", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Alice\)/)).toBeInTheDocument();
+    });
+
+    currentCookie = "flatpare-name=Charlie";
+    window.dispatchEvent(new Event("flatpare-user-changed"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your Rating \(Charlie\)/)).toBeInTheDocument();
+    });
+    expect(
+      (screen.getByLabelText(/Comment/i) as HTMLTextAreaElement).value
+    ).toBe("");
+  });
+});

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -26,6 +26,7 @@ import {
   fetchErrorFromException,
 } from "@/lib/fetch-error";
 import { useApartmentPager } from "@/lib/use-apartment-pager";
+import { setUnsavedRating } from "@/lib/unsaved-changes";
 
 interface ErrorState {
   headline: string;
@@ -174,6 +175,29 @@ export default function ApartmentDetailPage() {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params.id]);
+
+  useEffect(() => {
+    const dirty =
+      myRating.kitchen !== cleanRating.kitchen ||
+      myRating.balconies !== cleanRating.balconies ||
+      myRating.location !== cleanRating.location ||
+      myRating.floorplan !== cleanRating.floorplan ||
+      myRating.overallFeeling !== cleanRating.overallFeeling ||
+      myRating.comment !== cleanRating.comment;
+    setUnsavedRating(dirty);
+    return () => setUnsavedRating(false);
+  }, [myRating, cleanRating]);
+
+  useEffect(() => {
+    function handler() {
+      reloadApartment();
+    }
+    window.addEventListener("flatpare-user-changed", handler);
+    return () => window.removeEventListener("flatpare-user-changed", handler);
+    // reloadApartment is defined in this component scope; keeping deps empty is
+    // intentional (inline closure picks up the latest definition per render).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   async function handleDelete() {
     if (!confirm("Delete this apartment? This cannot be undone.")) return;
@@ -508,8 +532,9 @@ export default function ApartmentDetailPage() {
             </div>
           ))}
           <div className="space-y-2">
-            <Label>Comment</Label>
+            <Label htmlFor="rating-comment">Comment</Label>
             <Textarea
+              id="rating-comment"
               value={myRating.comment}
               onChange={(e) =>
                 setMyRating((prev) => ({ ...prev, comment: e.target.value }))

--- a/src/components/nav-bar.tsx
+++ b/src/components/nav-bar.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import { useState, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import { getUnsavedRating } from "@/lib/unsaved-changes";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { ChevronDown, Plus, User, X } from "lucide-react";
 import {
@@ -39,21 +40,37 @@ export function NavBar({ userName }: { userName: string }) {
 
   async function switchUser(name: string) {
     if (name === userName) return;
+    if (getUnsavedRating()) {
+      const ok = window.confirm(
+        "You have unsaved rating changes. Switch user anyway? Your input will be discarded."
+      );
+      if (!ok) return;
+    }
     await fetch("/api/auth/name", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ displayName: name }),
     });
+    window.dispatchEvent(new Event("flatpare-user-changed"));
     router.refresh();
   }
 
   async function deleteUser(name: string) {
+    if (name === userName && getUnsavedRating()) {
+      const ok = window.confirm(
+        "You have unsaved rating changes. Delete yourself anyway? Your input will be discarded."
+      );
+      if (!ok) return;
+    }
     const res = await fetch(
       `/api/auth/users/${encodeURIComponent(name)}`,
       { method: "DELETE" }
     );
     if (!res.ok) return;
     const data = (await res.json()) as { switchedTo?: string | null };
+    if (data.switchedTo !== undefined) {
+      window.dispatchEvent(new Event("flatpare-user-changed"));
+    }
     if (data.switchedTo === null) {
       router.push("/");
     } else {

--- a/src/lib/__tests__/unsaved-changes.test.ts
+++ b/src/lib/__tests__/unsaved-changes.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  getUnsavedRating,
+  setUnsavedRating,
+} from "@/lib/unsaved-changes";
+
+afterEach(() => {
+  setUnsavedRating(false);
+});
+
+describe("unsaved-changes", () => {
+  it("defaults to false", () => {
+    expect(getUnsavedRating()).toBe(false);
+  });
+
+  it("setUnsavedRating(true) flips the flag to true", () => {
+    setUnsavedRating(true);
+    expect(getUnsavedRating()).toBe(true);
+  });
+
+  it("setUnsavedRating(false) flips the flag back to false", () => {
+    setUnsavedRating(true);
+    setUnsavedRating(false);
+    expect(getUnsavedRating()).toBe(false);
+  });
+});

--- a/src/lib/unsaved-changes.ts
+++ b/src/lib/unsaved-changes.ts
@@ -1,0 +1,9 @@
+let hasUnsavedRating = false;
+
+export function setUnsavedRating(value: boolean): void {
+  hasUnsavedRating = value;
+}
+
+export function getUnsavedRating(): boolean {
+  return hasUnsavedRating;
+}


### PR DESCRIPTION
## Summary
- Tracks "unsaved rating changes" via a small singleton (`src/lib/unsaved-changes.ts`) — written by the detail page in a `useEffect`, read by the NavBar synchronously at click time.
- Detail page listens for a new `flatpare-user-changed` window event and reloads the apartment when it fires, so `myRating` / `userName` re-derive from the new cookie.
- NavBar's `switchUser` and `deleteUser` show a `window.confirm` when unsaved changes exist; on proceed, they POST the change then dispatch the event.
- Also added `htmlFor` / `id` to the Comment label/textarea — minor a11y fix (required for `getByLabelText` queries).

## Test plan
- [x] `npm test` passes (3 singleton tests + 3 integration tests, 214 total)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] Vercel preview: rate an apartment partially; open the user menu and pick another user — confirm dialog appears; cancel keeps you put; confirm loads the other user's rating form (or empty state if they have none).

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)