### PR TITLE
feat: parse and edit available-from date (#55)

### DIFF
--- a/docs/superpowers/plans/2026-04-25-available-from.md
+++ b/docs/superpowers/plans/2026-04-25-available-from.md
@@ -1,0 +1,668 @@
+# Apartment "Available From" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Parse and edit a per-apartment "available from" date — extracted from the listing PDF, stored as ISO `YYYY-MM-DD` text, displayed Swiss-style on the detail page, editable via the existing form.
+
+**Architecture:** New `text` column `available_from` on the apartments table. Tiny helper module `src/lib/iso-date.ts` exports `isIsoDate` (validation guard) and `formatSwissDate` (display). AI extraction adds `availableFrom` to its schema and prompt. The form's `ApartmentForm` type gains the field as a string; routes validate on POST/PATCH; the detail page renders one new line in its summary and `<input type="date">` in its edit form.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Drizzle (SQLite), Vitest, `ai` SDK with Google Gemini.
+
+**Spec:** [`docs/superpowers/specs/2026-04-25-available-from-design.md`](../specs/2026-04-25-available-from-design.md)
+**Issue:** [#55](https://github.com/brlauuu/flatpare/issues/55)
+
+---
+
+## File Structure
+
+### Files created
+
+- `src/lib/iso-date.ts` — `isIsoDate` and `formatSwissDate` helpers.
+- `src/lib/__tests__/iso-date.test.ts` — 5 unit tests.
+
+### Files modified
+
+- `src/lib/db/schema.ts` — add `availableFrom` column.
+- `drizzle/<new>_*.sql` — generated migration.
+- `src/lib/parse-pdf.ts` — extend the schema and prompt; passthrough only.
+- `src/lib/__tests__/parse-pdf.test.ts` — extend with 5 new tests.
+- `src/app/api/apartments/route.ts` — POST validates `availableFrom`; GET selects the column.
+- `src/app/api/apartments/[id]/route.ts` — PATCH validates `availableFrom`.
+- `src/components/apartment-form-fields.tsx` — extend `ApartmentForm` / helpers / form UI.
+- `src/app/apartments/[id]/page.tsx` — extend `ApartmentDetail` type and render the date.
+- `src/app/apartments/[id]/__tests__/edit-flow.test.tsx` — 2 new integration tests + fixture update.
+
+---
+
+## Task 1: `iso-date` helpers (TDD)
+
+**Files:**
+- Create: `src/lib/iso-date.ts`
+- Create: `src/lib/__tests__/iso-date.test.ts`
+
+### Step 1: Write the failing tests
+
+Create `src/lib/__tests__/iso-date.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { formatSwissDate, isIsoDate } from "@/lib/iso-date";
+
+describe("isIsoDate", () => {
+  it("accepts a well-formed ISO date", () => {
+    expect(isIsoDate("2026-05-01")).toBe(true);
+  });
+
+  it("rejects a Swiss-format date", () => {
+    expect(isIsoDate("01.05.2026")).toBe(false);
+  });
+
+  it("rejects free text like 'ab sofort'", () => {
+    expect(isIsoDate("ab sofort")).toBe(false);
+  });
+});
+
+describe("formatSwissDate", () => {
+  it("converts ISO YYYY-MM-DD to DD.MM.YYYY", () => {
+    expect(formatSwissDate("2026-05-01")).toBe("01.05.2026");
+  });
+
+  it("preserves the digits exactly", () => {
+    expect(formatSwissDate("2026-12-31")).toBe("31.12.2026");
+  });
+});
+```
+
+### Step 2: Run tests — should fail
+
+Run: `npm test -- src/lib/__tests__/iso-date.test.ts`
+Expected: 5 fail with `Cannot find module '@/lib/iso-date'`.
+
+### Step 3: Implement
+
+Create `src/lib/iso-date.ts`:
+
+```ts
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isIsoDate(value: string): boolean {
+  return ISO_DATE_PATTERN.test(value);
+}
+
+/**
+ * Convert an ISO `YYYY-MM-DD` date string to Swiss `DD.MM.YYYY` format.
+ * Caller must pass a string already validated with `isIsoDate`.
+ */
+export function formatSwissDate(iso: string): string {
+  return iso.split("-").reverse().join(".");
+}
+```
+
+### Step 4: Run tests — should pass
+
+Run: `npm test -- src/lib/__tests__/iso-date.test.ts`
+Expected: 5 pass.
+
+### Step 5: Full suite + lint
+
+Run: `npm test && npm run lint`
+Expected: 224/224 (prior 219 + 5), lint clean.
+
+### Step 6: Commit
+
+```bash
+git add src/lib/iso-date.ts src/lib/__tests__/iso-date.test.ts
+git commit -m "feat: add iso-date helpers"
+```
+
+---
+
+## Task 2: DB schema + migration
+
+**Files:**
+- Modify: `src/lib/db/schema.ts`
+- Create: `drizzle/<auto-named>.sql` (Drizzle generates)
+
+### Step 1: Add the column
+
+In `src/lib/db/schema.ts`, locate the `apartments` table definition. Add a new field BEFORE the `createdAt` line:
+
+```ts
+availableFrom: text("available_from"),
+```
+
+The full apartments table block (showing the new field in context) should look like:
+
+```ts
+export const apartments = sqliteTable("apartments", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  address: text("address"),
+  sizeM2: real("size_m2"),
+  numRooms: real("num_rooms"),
+  numBathrooms: integer("num_bathrooms"),
+  numBalconies: integer("num_balconies"),
+  hasWashingMachine: integer("has_washing_machine", { mode: "boolean" }),
+  rentChf: real("rent_chf"),
+  distanceBikeMin: integer("distance_bike_min"),
+  distanceTransitMin: integer("distance_transit_min"),
+  pdfUrl: text("pdf_url"),
+  listingUrl: text("listing_url"),
+  shortCode: text("short_code").unique(),
+  rawExtractedData: text("raw_extracted_data"),
+  availableFrom: text("available_from"),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(
+    sql`(unixepoch())`
+  ),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).default(
+    sql`(unixepoch())`
+  ),
+});
+```
+
+(Leave existing fields untouched — only the one new line above `createdAt`.)
+
+### Step 2: Generate the migration
+
+Run: `npm run db:generate`
+Expected: a new file appears under `drizzle/` named like `0001_*.sql` (or similar — Drizzle picks the next sequential number). The file contains an `ALTER TABLE apartments ADD COLUMN available_from TEXT;` statement.
+
+If Drizzle prompts for a migration name, accept the default.
+
+### Step 3: Apply the migration
+
+Run: `npm run db:push`
+Expected: confirms the schema is up to date or applies the column to the local SQLite DB.
+
+If `db:push` is interactive and asks "do you want to apply this change?", answer yes / accept.
+
+### Step 4: Verify nothing in the codebase still type-errors
+
+Run: `npm run build`
+Expected: build still succeeds. The TS type for the apartments table now includes `availableFrom`, but no consumer references it yet — fine.
+
+### Step 5: Run tests + lint
+
+Run: `npm test && npm run lint`
+Expected: 224/224 pass, lint clean. (The schema change doesn't affect test behavior — existing tests don't query the column.)
+
+### Step 6: Commit
+
+```bash
+git add src/lib/db/schema.ts drizzle/
+git commit -m "feat: add available_from column to apartments"
+```
+
+---
+
+## Task 3: AI extraction (TDD)
+
+**Files:**
+- Modify: `src/lib/parse-pdf.ts`
+- Modify: `src/lib/__tests__/parse-pdf.test.ts`
+
+### Step 1: Add failing tests
+
+Append to `src/lib/__tests__/parse-pdf.test.ts`:
+
+In the existing schema-validation `describe("apartmentExtractionSchema", ...)` block (near the top of the file), add three new test cases. These confirm the public schema accepts the new field:
+
+```ts
+  it("accepts a valid ISO availableFrom", () => {
+    const result = apartmentExtractionSchema.parse({
+      name: "X",
+      address: null,
+      sizeM2: null,
+      numRooms: null,
+      numBathrooms: null,
+      numBalconies: null,
+      hasWashingMachine: null,
+      rentChf: null,
+      listingUrl: null,
+      availableFrom: "2026-05-01",
+    });
+    expect(result.availableFrom).toBe("2026-05-01");
+  });
+
+  it("accepts null availableFrom", () => {
+    const result = apartmentExtractionSchema.parse({
+      name: "X",
+      address: null,
+      sizeM2: null,
+      numRooms: null,
+      numBathrooms: null,
+      numBalconies: null,
+      hasWashingMachine: null,
+      rentChf: null,
+      listingUrl: null,
+      availableFrom: null,
+    });
+    expect(result.availableFrom).toBeNull();
+  });
+
+  it("rejects a non-string availableFrom", () => {
+    expect(() =>
+      apartmentExtractionSchema.parse({
+        name: "X",
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        hasWashingMachine: null,
+        rentChf: null,
+        listingUrl: null,
+        availableFrom: 12345,
+      })
+    ).toThrow();
+  });
+```
+
+Add a new `describe` block at the end of the file:
+
+```ts
+describe("extractApartmentData — availableFrom passthrough", () => {
+  it("returns availableFrom from the AI output", async () => {
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-key";
+
+    mockedGenerateText.mockResolvedValue({
+      output: {
+        name: "x",
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        hasWashingMachine: null,
+        rentChf: null,
+        listingUrl: null,
+        availableFrom: "2026-05-01",
+        laundryEvidence: null,
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never);
+
+    const result = await extractApartmentData("base64pdf");
+    expect(result.availableFrom).toBe("2026-05-01");
+  });
+
+  it("returns null availableFrom from the AI output", async () => {
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-key";
+
+    mockedGenerateText.mockResolvedValue({
+      output: {
+        name: "x",
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        hasWashingMachine: null,
+        rentChf: null,
+        listingUrl: null,
+        availableFrom: null,
+        laundryEvidence: null,
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never);
+
+    const result = await extractApartmentData("base64pdf");
+    expect(result.availableFrom).toBeNull();
+  });
+});
+```
+
+### Step 2: Run tests to confirm they fail
+
+Run: `npm test -- src/lib/__tests__/parse-pdf.test.ts`
+Expected: 5 new tests fail (3 schema-level: `availableFrom` not in schema; 2 passthrough: result doesn't have the field). Existing 14 tests still pass.
+
+### Step 3: Update the schema and prompt in `src/lib/parse-pdf.ts`
+
+In `apartmentExtractionSchema` (the public schema), add the new field after `listingUrl`:
+
+```ts
+  listingUrl: z
+    .string()
+    .nullable()
+    .describe(
+      "Original listing URL from the document (e.g. immobilienscout24, wg-gesucht, homegate, etc.)"
+    ),
+  availableFrom: z
+    .string()
+    .nullable()
+    .describe(
+      "Move-in / availability date in ISO format YYYY-MM-DD if a specific date is given " +
+        "(e.g. 'Bezugstermin: 01.05.2026' → '2026-05-01', '1. Mai 2026' → '2026-05-01'). " +
+        "null if not mentioned, or if the listing says 'ab sofort' / 'per sofort' / 'immediately'."
+    ),
+});
+```
+
+Find the prompt text (the `text:` field inside the user message). Append a new line right before `Return null for any field you cannot determine from the document.`:
+
+```
+For availableFrom: parse Swiss / German / English availability phrases like "Bezugstermin: 01.05.2026", "verfügbar ab 1. Mai 2026", "available from May 1, 2026" into ISO format YYYY-MM-DD. If the listing says "ab sofort", "per sofort", "immediately", or similar (meaning available now without a specific date), return null. If no availability info is mentioned, return null.
+```
+
+### Step 4: Run tests to confirm they pass
+
+Run: `npm test -- src/lib/__tests__/parse-pdf.test.ts`
+Expected: 19 tests pass (14 existing + 5 new).
+
+### Step 5: Full suite + lint
+
+Run: `npm test && npm run lint`
+Expected: 229/229 (224 + 5), lint clean.
+
+### Step 6: Commit
+
+```bash
+git add src/lib/parse-pdf.ts src/lib/__tests__/parse-pdf.test.ts
+git commit -m "feat: extract availableFrom from listing PDFs"
+```
+
+---
+
+## Task 4: API routes
+
+**Files:**
+- Modify: `src/app/api/apartments/route.ts`
+- Modify: `src/app/api/apartments/[id]/route.ts`
+
+### Step 1: GET list — add `availableFrom` to the explicit field list
+
+In `src/app/api/apartments/route.ts`, find the `db.select({...})` call inside the `GET` handler. Add `availableFrom` after `listingUrl`:
+
+```ts
+  pdfUrl: apartments.pdfUrl,
+  listingUrl: apartments.listingUrl,
+  availableFrom: apartments.availableFrom,
+  shortCode: apartments.shortCode,
+```
+
+### Step 2: POST — validate and insert `availableFrom`
+
+In `src/app/api/apartments/route.ts`, add an import:
+
+```ts
+import { isIsoDate } from "@/lib/iso-date";
+```
+
+Inside the `POST` handler, just before the `for (let attempt = ...)` loop (so the validation runs once, before any DB attempt), add:
+
+```ts
+const availableFrom: string | null =
+  typeof body.availableFrom === "string" && isIsoDate(body.availableFrom)
+    ? body.availableFrom
+    : null;
+```
+
+Inside the `db.insert(apartments).values({...})` call, add `availableFrom` after `listingUrl`:
+
+```ts
+  listingUrl: body.listingUrl || null,
+  availableFrom,
+  shortCode,
+```
+
+### Step 3: PATCH — validate and update `availableFrom`
+
+In `src/app/api/apartments/[id]/route.ts`, add an import:
+
+```ts
+import { isIsoDate } from "@/lib/iso-date";
+```
+
+Inside the `PATCH` handler, after `const body = await request.json();`, add:
+
+```ts
+const availableFrom: string | null =
+  typeof body.availableFrom === "string" && isIsoDate(body.availableFrom)
+    ? body.availableFrom
+    : null;
+```
+
+Inside the `db.update(apartments).set({...})` call, add `availableFrom` after `listingUrl`:
+
+```ts
+  listingUrl: body.listingUrl,
+  availableFrom,
+})
+```
+
+### Step 4: Run tests + lint + build
+
+Run: `npm test && npm run lint && npm run build`
+Expected: 229 pass, lint clean, build clean. No tests directly cover these routes; the existing parse-pdf retry test mocks `/api/apartments` and `/api/apartments/{id}` requests at the page level.
+
+### Step 5: Commit
+
+```bash
+git add src/app/api/apartments/route.ts src/app/api/apartments/[id]/route.ts
+git commit -m "feat: API routes accept and return availableFrom"
+```
+
+---
+
+## Task 5: Form types + UI + detail page + integration tests
+
+**Files:**
+- Modify: `src/components/apartment-form-fields.tsx`
+- Modify: `src/app/apartments/[id]/page.tsx`
+- Modify: `src/app/apartments/[id]/__tests__/edit-flow.test.tsx`
+
+### Step 1: Extend `ApartmentForm` and helpers in `src/components/apartment-form-fields.tsx`
+
+Add `availableFrom: string` to:
+
+- `ApartmentForm` type (after `listingUrl`).
+- `emptyApartmentForm` literal: `availableFrom: ""`.
+
+In `formFromExtracted`, add (after `listingUrl`):
+
+```ts
+availableFrom:
+  typeof extracted.availableFrom === "string" ? extracted.availableFrom : "",
+```
+
+Add `availableFrom: string | null` to the `ApartmentLike` type (after `listingUrl`).
+
+In `formFromApartment`, add (after `listingUrl`):
+
+```ts
+availableFrom: apt.availableFrom ?? "",
+```
+
+In `formToPayload`, add (after `listingUrl`):
+
+```ts
+availableFrom: form.availableFrom || null,
+```
+
+### Step 2: Add the date input to `ApartmentFormFields`
+
+Inside the `ApartmentFormFields` JSX, find the existing rent (CHF) input. Add a new field below it (or wherever the existing form layout fits — keep it near the other "primary listing facts" fields):
+
+```tsx
+<div className="space-y-1.5">
+  <Label htmlFor={`${idPrefix}-availableFrom`}>Available from</Label>
+  <Input
+    id={`${idPrefix}-availableFrom`}
+    type="date"
+    value={form.availableFrom}
+    onChange={(e) => onChange("availableFrom", e.target.value)}
+  />
+</div>
+```
+
+If the existing fields are arranged in a grid, add this one in the same grid; otherwise stack vertically. Match the existing field's wrapper structure.
+
+### Step 3: Update `ApartmentDetail` type and render in `src/app/apartments/[id]/page.tsx`
+
+Find the `interface ApartmentDetail { ... }` declaration. Add `availableFrom: string | null;` (after `listingUrl`).
+
+Add an import at the top:
+
+```tsx
+import { formatSwissDate } from "@/lib/iso-date";
+```
+
+Find the read-only summary block on the detail page (the muted-text rows showing distance / size etc.). Add a new line that renders only when set:
+
+```tsx
+{apartment.availableFrom && (
+  <div className="text-sm text-muted-foreground">
+    Available from: {formatSwissDate(apartment.availableFrom)}
+  </div>
+)}
+```
+
+(Place it next to the other muted-text summary rows. Locate them by searching for `text-muted-foreground` near the apartment header.)
+
+### Step 4: Update integration test fixture and add 2 new tests
+
+In `src/app/apartments/[id]/__tests__/edit-flow.test.tsx`, find `APARTMENT_V1` and `APARTMENT_V2` constants. Add `availableFrom: "2026-05-01"` to V1 and `availableFrom: "2026-07-15"` to V2 (after `listingUrl` or at the end of each object).
+
+After the existing 3 tests, before the closing `});` of the `describe("Apartment detail edit flow", ...)` block, add:
+
+```tsx
+it("displays availableFrom in Swiss format on the read-only view", async () => {
+  render(<ApartmentDetailPage />);
+  await waitFor(() => {
+    expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+  });
+  expect(screen.getByText(/01\.05\.2026/)).toBeInTheDocument();
+});
+
+it("round-trips the availableFrom date through the edit form", async () => {
+  const user = userEvent.setup();
+  render(<ApartmentDetailPage />);
+  await waitFor(() => {
+    expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+  });
+
+  await user.click(screen.getByRole("button", { name: /^Edit$/ }));
+
+  const dateInput = screen.getByLabelText(/Available from/i) as HTMLInputElement;
+  expect(dateInput.value).toBe("2026-05-01");
+
+  await user.clear(dateInput);
+  await user.type(dateInput, "2026-07-15");
+
+  await user.click(screen.getByRole("button", { name: /^Save$/ }));
+
+  await waitFor(() => {
+    const patchCall = fetchCalls.find(
+      (c) => c.url.endsWith("/api/apartments/42") && c.init.method === "PATCH"
+    );
+    expect(patchCall).toBeDefined();
+    const body = JSON.parse((patchCall!.init.body as string) ?? "{}");
+    expect(body.availableFrom).toBe("2026-07-15");
+  });
+});
+```
+
+Note: the 2nd new test ("round-trips") does multiple `userEvent` operations and may need the same `10000ms` timeout already applied to the existing "save flips name + rent + washing" test. Add the timeout in the same way:
+
+```tsx
+it(
+  "round-trips the availableFrom date through the edit form",
+  async () => {
+    // body
+  },
+  10000
+);
+```
+
+### Step 5: Run all tests
+
+Run: `npm test`
+Expected: 231 pass (229 + 2 new). The fixture update doesn't break the existing tests because they don't assert on `availableFrom`.
+
+### Step 6: Run lint and build
+
+Run: `npm run lint && npm run build`
+Expected: clean.
+
+### Step 7: Manual smoke-check
+
+Skip — the user has explicitly opted into "merge on green local tests". The browser preview check is theirs to do.
+
+### Step 8: Commit
+
+```bash
+git add src/components/apartment-form-fields.tsx \
+        src/app/apartments/[id]/page.tsx \
+        src/app/apartments/[id]/__tests__/edit-flow.test.tsx
+git commit -m "feat: edit and display availableFrom on apartment detail (#55)"
+```
+
+---
+
+## Task 6: Open PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin 55-available-from`
+Expected: branch published.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat: parse and edit available-from date (#55)" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `available_from` text column (ISO `YYYY-MM-DD`) on the apartments table; migration generated and applied via Drizzle.
+- AI extraction adds `availableFrom` to its schema and prompt — handles "Bezugstermin: 01.05.2026", "1. Mai 2026", "available from May 1, 2026", etc. "ab sofort" / "per sofort" return null.
+- POST and PATCH routes validate the input via a tiny `isIsoDate` helper; bad strings drop to null instead of poisoning the DB.
+- Detail page shows `Available from: 01.05.2026` (Swiss format) when set; native `<input type="date">` in the edit form.
+- List card and compare view unchanged.
+
+## Test plan
+- [x] `npm test` passes (5 helper tests + 5 schema/passthrough tests + 2 integration tests, 231 total)
+- [x] `npm run lint` clean
+- [x] `npm run build` succeeds
+- [ ] Vercel preview: upload a listing with a date phrase, confirm extracted; edit on detail page; reload to confirm persistence.
+
+Closes #55
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Hand back to controller.**
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- DB column `available_from` text nullable: Task 2 ✓
+- Drizzle migration generated and applied: Task 2 Steps 2–3 ✓
+- `isIsoDate` validator + `formatSwissDate` formatter in `src/lib/iso-date.ts`: Task 1 ✓
+- Schema accepts `availableFrom: string | null` in public schema: Task 3 Step 3 ✓
+- AI prompt parses date phrases: Task 3 Step 3 ✓
+- POST and PATCH routes validate: Task 4 Steps 2–3 ✓
+- GET list explicitly selects the column: Task 4 Step 1 ✓
+- GET detail auto-includes (uses `select()`): Task 2 (schema change) ✓
+- `ApartmentForm` / `formFromExtracted` / `ApartmentLike` / `formFromApartment` / `formToPayload` updated: Task 5 Step 1 ✓
+- `<input type="date">` in form UI: Task 5 Step 2 ✓
+- `ApartmentDetail` type + Swiss-format display: Task 5 Step 3 ✓
+- 5 helper tests: Task 1 ✓
+- 5 parse-pdf tests: Task 3 Step 1 ✓
+- 2 integration tests: Task 5 Step 4 ✓
+- List card / compare view UNTOUCHED: confirmed by absence of changes to `src/app/apartments/page.tsx`, `src/app/compare/page.tsx`, `src/lib/apartment-sort.ts` ✓
+
+**Placeholder scan:** no TBDs, no generic phrases. Every code step shows complete code.
+
+**Type consistency:**
+- `availableFrom: string` on the form, `string | null` on the API and detail types. Consistent with existing nullable-DB-field pattern (e.g. `address`, `listingUrl`).
+- `isIsoDate` and `formatSwissDate` both live in `src/lib/iso-date.ts`, both consumed by Tasks 4 and 5 respectively.
+- The integration test fixture format (`"2026-05-01"`) matches what the form input produces and what the API stores.
+
+No gaps.

--- a/docs/superpowers/specs/2026-04-25-available-from-design.md
+++ b/docs/superpowers/specs/2026-04-25-available-from-design.md
@@ -1,0 +1,173 @@
+# Apartment "available from" date — design
+
+**Issue:** [#55 — Add parsing of "available from date" if available. Make it editable field.](https://github.com/brlauuu/flatpare/issues/55)
+**Date:** 2026-04-25
+
+## Problem
+
+Listings often state when the apartment is available (e.g. "Bezugstermin: 01.05.2026", "verfügbar ab 1. Mai 2026"). Today the parser ignores this and there's no field for it on the apartment detail. The user wants the date extracted automatically AND editable in case the AI gets it wrong or the listing didn't include one.
+
+## Scope
+
+- DB column `available_from` (`text`, nullable, ISO `YYYY-MM-DD`).
+- Migration generated and applied via Drizzle.
+- AI extraction reads availability phrases and returns ISO format. "ab sofort" / "per sofort" / "immediately" → `null`.
+- Detail page shows the date in Swiss format below the existing summary rows; editable via the existing edit form.
+- List card and compare view are unchanged (per the user's choice).
+
+## Storage
+
+`text` column over a timestamp because:
+
+- The data is a calendar date, not an instant. `<input type="date">` produces ISO `YYYY-MM-DD`. Storing the same string roundtrips trivially.
+- SQLite + Drizzle's `integer({ mode: "timestamp" })` stores epoch seconds, which loses the "no time" intent and introduces UTC-vs-local confusion.
+- No date arithmetic happens server-side. Comparisons (sort by available date later, if needed) work fine on ISO strings.
+
+```ts
+// src/lib/db/schema.ts
+availableFrom: text("available_from"),
+```
+
+Migrations:
+
+- `npm run db:generate` — Drizzle creates a new SQL file under `drizzle/`.
+- `npm run db:push` — applies the schema to the local SQLite DB. (Production runs the same.)
+
+## Server-side validation
+
+AI returns whatever it produces. The route's PATCH and POST handlers run a tiny `isIsoDate(s: string): boolean` check (`/^\d{4}-\d{2}-\d{2}$/`) and drop the value to `null` if it doesn't match. We accept the string verbatim (no `Date` object roundtrip) once it passes the regex.
+
+```ts
+function isIsoDate(s: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(s);
+}
+```
+
+Defense-in-depth: protects against AI hallucinations like `"ab sofort"`, `"01.05.2026"`, or empty strings being accepted as dates.
+
+## AI extraction
+
+Schema addition (in BOTH `apartmentExtractionSchema` and `internalApartmentExtractionSchema`):
+
+```ts
+availableFrom: z
+  .string()
+  .nullable()
+  .describe(
+    "Move-in / availability date in ISO format YYYY-MM-DD if a specific date is given " +
+    "(e.g. 'Bezugstermin: 01.05.2026' → '2026-05-01', '1. Mai 2026' → '2026-05-01'). " +
+    "null if not mentioned, or if the listing says 'ab sofort' / 'per sofort' / 'immediately'."
+  ),
+```
+
+Prompt addition (appended to the existing extraction prompt):
+
+> For `availableFrom`: parse Swiss / German / English availability phrases like "Bezugstermin: 01.05.2026", "verfügbar ab 1. Mai 2026", "available from May 1, 2026" into ISO format `YYYY-MM-DD`. If the listing says "ab sofort", "per sofort", "immediately", or similar (meaning available now without a specific date), return null. If no availability info is mentioned, return null.
+
+The AI handles the date-string variety. We don't add a server-side date parser — the formats (`DD.MM.YYYY`, `1. Mai 2026`, `May 1, 2026`, `5/1/2026`) are exactly what an LLM does well, and a regex would miss half of them.
+
+## API & form types
+
+Touch every type that mirrors the apartment shape:
+
+- `ApartmentForm` (in `src/components/apartment-form-fields.tsx`): add `availableFrom: string` (empty string when not set).
+- `emptyApartmentForm`: `availableFrom: ""`.
+- `formFromExtracted`: copy `availableFrom`, defaulting to `""`.
+- `ApartmentLike`: add `availableFrom: string | null`.
+- `formFromApartment`: copy `availableFrom`, defaulting to `""`.
+- `formToPayload`: emit `availableFrom: form.availableFrom || null`.
+- `ApartmentDetail` (in `src/app/apartments/[id]/page.tsx`): add `availableFrom: string | null`.
+- `ApartmentSummary` (in `src/app/apartments/page.tsx`): NOT needed — list card doesn't show it (per Q1).
+- `ApartmentWithRatings` (in `src/app/compare/page.tsx`): NOT needed — compare view doesn't show it.
+
+API routes:
+
+- `src/app/api/apartments/route.ts` (POST): accept `availableFrom` from request body, validate with `isIsoDate`, insert into the apartments row.
+- `src/app/api/apartments/route.ts` (GET): explicitly select `availableFrom` (the existing list query enumerates fields).
+- `src/app/api/apartments/[id]/route.ts` (PATCH): accept `availableFrom`, validate, update.
+- `src/app/api/apartments/[id]/route.ts` (GET): already uses `select()` (full row) — once the schema column exists, the value flows through automatically.
+
+`isIsoDate` lives in a tiny helper module — `src/lib/iso-date.ts` — so both the POST and PATCH routes can import it.
+
+## UI
+
+### Detail page read-only summary
+
+Add one row below the existing distance rows:
+
+```tsx
+{apartment.availableFrom && (
+  <div className="text-sm text-muted-foreground">
+    Available from: {formatSwissDate(apartment.availableFrom)}
+  </div>
+)}
+```
+
+`formatSwissDate(iso)` is a tiny helper: `iso.split("-").reverse().join(".")` — guarantees `2026-05-01` → `01.05.2026`. Lives in `src/lib/iso-date.ts` next to `isIsoDate`. Hidden when `availableFrom` is null.
+
+### Edit form (`ApartmentFormFields`)
+
+New field rendered between the existing rent and the bike/transit fields (or wherever fits the visual order):
+
+```tsx
+<div className="space-y-1.5">
+  <Label htmlFor={`${idPrefix}-availableFrom`}>Available from</Label>
+  <Input
+    id={`${idPrefix}-availableFrom`}
+    type="date"
+    value={form.availableFrom}
+    onChange={(e) => onChange("availableFrom", e.target.value)}
+  />
+</div>
+```
+
+Native `<input type="date">` works on desktop and mobile. Value format is ISO `YYYY-MM-DD`, matching storage and AI output.
+
+### List card and compare view
+
+Unchanged.
+
+## Testing
+
+### Unit tests
+
+`src/lib/__tests__/iso-date.test.ts` (new, 5 tests):
+
+1. `isIsoDate("2026-05-01")` → `true`.
+2. `isIsoDate("01.05.2026")` → `false`.
+3. `isIsoDate("ab sofort")` → `false`.
+4. `formatSwissDate("2026-05-01")` → `"01.05.2026"`.
+5. `formatSwissDate("2026-12-31")` → `"31.12.2026"`.
+
+`src/lib/__tests__/parse-pdf.test.ts` (extend, 5 new tests):
+
+6. Schema accepts `availableFrom: "2026-05-01"`.
+7. Schema accepts `availableFrom: null`.
+8. Schema rejects `availableFrom: 12345` (non-string).
+9. AI returns `availableFrom: "2026-05-01"` → result has the same value.
+10. AI returns `availableFrom: null` → result has `null`.
+
+### Integration tests
+
+Extend `src/app/apartments/[id]/__tests__/edit-flow.test.tsx` with 2 tests:
+
+11. **Read-only display when set** — fixture with `availableFrom: "2026-05-01"`; assert `01.05.2026` text appears.
+12. **Edit round-trips the date** — open the edit form, change the date input to `2026-07-15`, save; assert the PATCH body has `availableFrom: "2026-07-15"`.
+
+The existing edit-flow fixture currently uses `id: 42` and various null fields; adding `availableFrom: "2026-05-01"` to the V1 fixture and `availableFrom: "2026-07-15"` to V2 lines up the existing "save flips name + rent + washing" test with one more field.
+
+### No new upload-page test
+
+The upload flow already mocks the parse-pdf response and tests retry/status transitions. Adding a `availableFrom` assertion would be low-value; the `formFromExtracted` field copy is covered by the parse-pdf tests indirectly.
+
+### Existing tests
+
+All unchanged. No fixture updates outside `edit-flow.test.tsx`. The list, compare, pager, retry, search tests don't touch `availableFrom`.
+
+## Out of scope
+
+- Sortable / filterable on availability date (could be a future enhancement).
+- Showing the date on the list card or compare view (rejected per Q1).
+- Calendar UI components beyond native `<input type="date">`.
+- Localized date format toggling (Swiss `DD.MM.YYYY` is hardcoded — matches the listings).
+- Auto-set "ab sofort" → today's date (deliberately left null for the user to fill in).

--- a/drizzle/0004_colossal_jackal.sql
+++ b/drizzle/0004_colossal_jackal.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `apartments` ADD `available_from` text;

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,360 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "380a29a5-5006-482f-bbb3-82ea000f3299",
+  "prevId": "1ea24975-5207-4373-b36d-dc39d41e7613",
+  "tables": {
+    "apartments": {
+      "name": "apartments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_m2": {
+          "name": "size_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_rooms": {
+          "name": "num_rooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_bathrooms": {
+          "name": "num_bathrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_balconies": {
+          "name": "num_balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_washing_machine": {
+          "name": "has_washing_machine",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rent_chf": {
+          "name": "rent_chf",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_bike_min": {
+          "name": "distance_bike_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_transit_min": {
+          "name": "distance_transit_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_url": {
+          "name": "listing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_extracted_data": {
+          "name": "raw_extracted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "apartments_short_code_unique": {
+          "name": "apartments_short_code_unique",
+          "columns": [
+            "short_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_usage": {
+      "name": "api_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ratings": {
+      "name": "ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kitchen": {
+          "name": "kitchen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "balconies": {
+          "name": "balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "location": {
+          "name": "location",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "floorplan": {
+          "name": "floorplan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "overall_feeling": {
+          "name": "overall_feeling",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "ratings_apartment_user_idx": {
+          "name": "ratings_apartment_user_idx",
+          "columns": [
+            "apartment_id",
+            "user_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ratings_apartment_id_apartments_id_fk": {
+          "name": "ratings_apartment_id_apartments_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1776851029322,
       "tag": "0003_short_code",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1777096955218,
+      "tag": "0004_colossal_jackal",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
+++ b/src/app/apartments/[id]/__tests__/edit-flow.test.tsx
@@ -25,6 +25,7 @@ const APARTMENT_V1 = {
   distanceTransitMin: 25,
   pdfUrl: null,
   listingUrl: null,
+  availableFrom: "2026-05-01",
   ratings: [],
 };
 
@@ -33,6 +34,7 @@ const APARTMENT_V2 = {
   name: "Sonnenweg 3b",
   rentChf: 2400,
   hasWashingMachine: true,
+  availableFrom: "2026-07-15",
 };
 
 type FetchCall = { url: string; init: RequestInit };
@@ -195,4 +197,43 @@ describe("Apartment detail edit flow", () => {
     // "within" import just to keep the import list stable.
     void within;
   });
+
+  it("displays availableFrom in Swiss format on the read-only view", async () => {
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/01\.05\.2026/)).toBeInTheDocument();
+  });
+
+  it(
+    "round-trips the availableFrom date through the edit form",
+    async () => {
+      const user = userEvent.setup();
+      render(<ApartmentDetailPage />);
+      await waitFor(() => {
+        expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /^Edit$/ }));
+
+      const dateInput = screen.getByLabelText(/Available from/i) as HTMLInputElement;
+      expect(dateInput.value).toBe("2026-05-01");
+
+      await user.clear(dateInput);
+      await user.type(dateInput, "2026-07-15");
+
+      await user.click(screen.getByRole("button", { name: /^Save$/ }));
+
+      await waitFor(() => {
+        const patchCall = fetchCalls.find(
+          (c) => c.url.endsWith("/api/apartments/42") && c.init.method === "PATCH"
+        );
+        expect(patchCall).toBeDefined();
+        const body = JSON.parse((patchCall!.init.body as string) ?? "{}");
+        expect(body.availableFrom).toBe("2026-07-15");
+      });
+    },
+    10000
+  );
 });

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/lib/fetch-error";
 import { useApartmentPager } from "@/lib/use-apartment-pager";
 import { setUnsavedRating } from "@/lib/unsaved-changes";
+import { formatSwissDate } from "@/lib/iso-date";
 
 interface ErrorState {
   headline: string;
@@ -58,6 +59,7 @@ interface ApartmentDetail {
   distanceTransitMin: number | null;
   pdfUrl: string | null;
   listingUrl: string | null;
+  availableFrom: string | null;
   shortCode: string | null;
   mapEmbedUrl: string | null;
   ratings: Rating[];
@@ -507,6 +509,12 @@ export default function ApartmentDetailPage() {
               {apartment.distanceTransitMin} min transit
             </Badge>
           )}
+        </div>
+      )}
+
+      {apartment.availableFrom && (
+        <div className="text-sm text-muted-foreground">
+          Available from: {formatSwissDate(apartment.availableFrom)}
         </div>
       )}
 

--- a/src/app/api/apartments/[id]/route.ts
+++ b/src/app/api/apartments/[id]/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db";
 import { apartments, ratings } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { buildMapEmbedUrl } from "@/lib/map-embed";
+import { isIsoDate } from "@/lib/iso-date";
 
 export async function GET(
   _request: Request,
@@ -50,6 +51,11 @@ export async function PATCH(
     const apartmentId = parseInt(id);
     const body = await request.json();
 
+    const availableFrom: string | null =
+      typeof body.availableFrom === "string" && isIsoDate(body.availableFrom)
+        ? body.availableFrom
+        : null;
+
     const result = await db
       .update(apartments)
       .set({
@@ -64,6 +70,7 @@ export async function PATCH(
         distanceBikeMin: body.distanceBikeMin,
         distanceTransitMin: body.distanceTransitMin,
         listingUrl: body.listingUrl,
+        availableFrom,
       })
       .where(eq(apartments.id, apartmentId))
       .returning();

--- a/src/app/api/apartments/route.ts
+++ b/src/app/api/apartments/route.ts
@@ -8,6 +8,7 @@ import {
   computeShortCodeParts,
   pickLetters,
 } from "@/lib/short-code";
+import { isIsoDate } from "@/lib/iso-date";
 
 const MAX_SHORT_CODE_ATTEMPTS = 5;
 
@@ -35,6 +36,7 @@ export async function GET() {
         distanceTransitMin: apartments.distanceTransitMin,
         pdfUrl: apartments.pdfUrl,
         listingUrl: apartments.listingUrl,
+        availableFrom: apartments.availableFrom,
         shortCode: apartments.shortCode,
         createdAt: apartments.createdAt,
         avgKitchen: avg(ratings.kitchen),
@@ -84,6 +86,11 @@ export async function POST(request: Request) {
   try {
     const body = await request.json();
 
+    const availableFrom: string | null =
+      typeof body.availableFrom === "string" && isIsoDate(body.availableFrom)
+        ? body.availableFrom
+        : null;
+
     // Compute derived parts once (postcode extraction can hit an API);
     // only the random letters change on unique-constraint retries.
     const parts = await computeShortCodeParts({
@@ -111,6 +118,7 @@ export async function POST(request: Request) {
             distanceTransitMin: body.distanceTransitMin,
             pdfUrl: body.pdfUrl,
             listingUrl: body.listingUrl || null,
+            availableFrom,
             shortCode,
             rawExtractedData: body.rawExtractedData
               ? JSON.stringify(body.rawExtractedData)

--- a/src/components/apartment-form-fields.tsx
+++ b/src/components/apartment-form-fields.tsx
@@ -17,6 +17,7 @@ export type ApartmentForm = {
   distanceTransitMin: string;
   pdfUrl: string;
   listingUrl: string;
+  availableFrom: string;
   rawExtractedData: Record<string, unknown> | null;
 };
 
@@ -33,6 +34,7 @@ export const emptyApartmentForm: ApartmentForm = {
   distanceTransitMin: "",
   pdfUrl: "",
   listingUrl: "",
+  availableFrom: "",
   rawExtractedData: null,
 };
 
@@ -58,6 +60,8 @@ export function formFromExtracted(
     distanceTransitMin: "",
     pdfUrl,
     listingUrl: (extracted.listingUrl as string) || "",
+    availableFrom:
+      typeof extracted.availableFrom === "string" ? extracted.availableFrom : "",
     rawExtractedData: extracted,
   };
 }
@@ -75,6 +79,7 @@ export type ApartmentLike = {
   distanceTransitMin: number | null;
   pdfUrl: string | null;
   listingUrl: string | null;
+  availableFrom: string | null;
 };
 
 export function formFromApartment(apt: ApartmentLike): ApartmentForm {
@@ -93,6 +98,7 @@ export function formFromApartment(apt: ApartmentLike): ApartmentForm {
     distanceTransitMin: numOrEmpty(apt.distanceTransitMin),
     pdfUrl: apt.pdfUrl ?? "",
     listingUrl: apt.listingUrl ?? "",
+    availableFrom: apt.availableFrom ?? "",
     rawExtractedData: null,
   };
 }
@@ -115,6 +121,7 @@ export function formToPayload(form: ApartmentForm) {
       : null,
     pdfUrl: form.pdfUrl || null,
     listingUrl: form.listingUrl || null,
+    availableFrom: form.availableFrom || null,
     rawExtractedData: form.rawExtractedData,
   };
 }
@@ -170,6 +177,15 @@ export function ApartmentFormFields({
             onChange={(e) => onChange("sizeM2", e.target.value)}
           />
         </div>
+      </div>
+      <div className="space-y-1.5">
+        <Label htmlFor={`${idPrefix}-availableFrom`}>Available from</Label>
+        <Input
+          id={`${idPrefix}-availableFrom`}
+          type="date"
+          value={form.availableFrom}
+          onChange={(e) => onChange("availableFrom", e.target.value)}
+        />
       </div>
       <div className="grid grid-cols-3 gap-4">
         <div className="space-y-2">

--- a/src/lib/__tests__/iso-date.test.ts
+++ b/src/lib/__tests__/iso-date.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { formatSwissDate, isIsoDate } from "@/lib/iso-date";
+
+describe("isIsoDate", () => {
+  it("accepts a well-formed ISO date", () => {
+    expect(isIsoDate("2026-05-01")).toBe(true);
+  });
+
+  it("rejects a Swiss-format date", () => {
+    expect(isIsoDate("01.05.2026")).toBe(false);
+  });
+
+  it("rejects free text like 'ab sofort'", () => {
+    expect(isIsoDate("ab sofort")).toBe(false);
+  });
+});
+
+describe("formatSwissDate", () => {
+  it("converts ISO YYYY-MM-DD to DD.MM.YYYY", () => {
+    expect(formatSwissDate("2026-05-01")).toBe("01.05.2026");
+  });
+
+  it("preserves the digits exactly", () => {
+    expect(formatSwissDate("2026-12-31")).toBe("31.12.2026");
+  });
+});

--- a/src/lib/__tests__/parse-pdf.test.ts
+++ b/src/lib/__tests__/parse-pdf.test.ts
@@ -49,6 +49,7 @@ describe("apartmentExtractionSchema", () => {
       hasWashingMachine: true,
       rentChf: 1800,
       listingUrl: "https://www.immobilienscout24.ch/listing/123",
+      availableFrom: null,
     };
     const result = apartmentExtractionSchema.parse(data);
     expect(result).toEqual(data);
@@ -65,6 +66,7 @@ describe("apartmentExtractionSchema", () => {
       hasWashingMachine: null,
       rentChf: null,
       listingUrl: null,
+      availableFrom: null,
     };
     const result = apartmentExtractionSchema.parse(data);
     expect(result).toEqual(data);
@@ -81,6 +83,7 @@ describe("apartmentExtractionSchema", () => {
       hasWashingMachine: false,
       rentChf: null,
       listingUrl: null,
+      availableFrom: null,
     };
     const result = apartmentExtractionSchema.parse(data);
     expect(result.hasWashingMachine).toBe(false);
@@ -105,6 +108,55 @@ describe("apartmentExtractionSchema", () => {
   it("rejects missing name", () => {
     expect(() =>
       apartmentExtractionSchema.parse({ address: null })
+    ).toThrow();
+  });
+
+  it("accepts a valid ISO availableFrom", () => {
+    const result = apartmentExtractionSchema.parse({
+      name: "X",
+      address: null,
+      sizeM2: null,
+      numRooms: null,
+      numBathrooms: null,
+      numBalconies: null,
+      hasWashingMachine: null,
+      rentChf: null,
+      listingUrl: null,
+      availableFrom: "2026-05-01",
+    });
+    expect(result.availableFrom).toBe("2026-05-01");
+  });
+
+  it("accepts null availableFrom", () => {
+    const result = apartmentExtractionSchema.parse({
+      name: "X",
+      address: null,
+      sizeM2: null,
+      numRooms: null,
+      numBathrooms: null,
+      numBalconies: null,
+      hasWashingMachine: null,
+      rentChf: null,
+      listingUrl: null,
+      availableFrom: null,
+    });
+    expect(result.availableFrom).toBeNull();
+  });
+
+  it("rejects a non-string availableFrom", () => {
+    expect(() =>
+      apartmentExtractionSchema.parse({
+        name: "X",
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        hasWashingMachine: null,
+        rentChf: null,
+        listingUrl: null,
+        availableFrom: 12345,
+      })
     ).toThrow();
   });
 });
@@ -305,5 +357,55 @@ describe("extractApartmentData — laundry evidence override", () => {
     const result = await extractApartmentData("base64pdf");
     expect(result.hasWashingMachine).toBe(true);
     expect("laundryEvidence" in result).toBe(false);
+  });
+});
+
+describe("extractApartmentData — availableFrom passthrough", () => {
+  it("returns availableFrom from the AI output", async () => {
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-key";
+
+    mockedGenerateText.mockResolvedValue({
+      output: {
+        name: "x",
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        hasWashingMachine: null,
+        rentChf: null,
+        listingUrl: null,
+        availableFrom: "2026-05-01",
+        laundryEvidence: null,
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never);
+
+    const result = await extractApartmentData("base64pdf");
+    expect(result.availableFrom).toBe("2026-05-01");
+  });
+
+  it("returns null availableFrom from the AI output", async () => {
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "test-key";
+
+    mockedGenerateText.mockResolvedValue({
+      output: {
+        name: "x",
+        address: null,
+        sizeM2: null,
+        numRooms: null,
+        numBathrooms: null,
+        numBalconies: null,
+        hasWashingMachine: null,
+        rentChf: null,
+        listingUrl: null,
+        availableFrom: null,
+        laundryEvidence: null,
+      },
+      usage: { inputTokens: 1, outputTokens: 1 },
+    } as never);
+
+    const result = await extractApartmentData("base64pdf");
+    expect(result.availableFrom).toBeNull();
   });
 });

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -34,7 +34,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(4);
+    expect(migrations.rows).toHaveLength(5);
   });
 
   it("adds listing_url to a legacy database missing the column", async () => {
@@ -66,7 +66,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(4);
+    expect(migrations.rows).toHaveLength(5);
   });
 
   it("reconciles a DB that already has has_washing_machine but no 0002 marker", async () => {
@@ -129,13 +129,13 @@ describe("applyMigrations", () => {
     // try to re-add has_washing_machine).
     await applyMigrations(client);
 
-    // 0002 recorded via reconcile + 0003 run normally = 4 total
-    // (0000/0001 were seeded, 0002 stamped by reconcile, 0003 by migrator).
+    // 0002 recorded via reconcile + 0003 and 0004 run normally = 5 total
+    // (0000/0001 were seeded, 0002 stamped by reconcile, 0003+0004 by migrator).
     const rows = await client.execute({
       sql: "SELECT COUNT(*) as n FROM __drizzle_migrations",
       args: [],
     });
-    expect(Number(rows.rows[0].n)).toBe(4);
+    expect(Number(rows.rows[0].n)).toBe(5);
   });
 
   it("backfills the users table from distinct rating user_names", async () => {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -17,6 +17,7 @@ export const apartments = sqliteTable("apartments", {
   listingUrl: text("listing_url"),
   shortCode: text("short_code").unique(),
   rawExtractedData: text("raw_extracted_data"),
+  availableFrom: text("available_from"),
   createdAt: integer("created_at", { mode: "timestamp" }).default(
     sql`(unixepoch())`
   ),

--- a/src/lib/iso-date.ts
+++ b/src/lib/iso-date.ts
@@ -1,0 +1,13 @@
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+export function isIsoDate(value: string): boolean {
+  return ISO_DATE_PATTERN.test(value);
+}
+
+/**
+ * Convert an ISO `YYYY-MM-DD` date string to Swiss `DD.MM.YYYY` format.
+ * Caller must pass a string already validated with `isIsoDate`.
+ */
+export function formatSwissDate(iso: string): string {
+  return iso.split("-").reverse().join(".");
+}

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -42,6 +42,14 @@ export const apartmentExtractionSchema = z.object({
     .describe(
       "Original listing URL from the document (e.g. immobilienscout24, wg-gesucht, homegate, etc.)"
     ),
+  availableFrom: z
+    .string()
+    .nullable()
+    .describe(
+      "Move-in / availability date in ISO format YYYY-MM-DD if a specific date is given " +
+        "(e.g. 'Bezugstermin: 01.05.2026' → '2026-05-01', '1. Mai 2026' → '2026-05-01'). " +
+        "null if not mentioned, or if the listing says 'ab sofort' / 'per sofort' / 'immediately'."
+    ),
 });
 
 export type ApartmentExtraction = z.infer<typeof apartmentExtractionSchema>;
@@ -105,6 +113,7 @@ For rent, prefer the gross/brutto rent (Bruttomiete) if both net and gross are s
 For rooms, use the Swiss convention (e.g. 3.5 Zimmer = 3.5 rooms).
 For hasWashingMachine: true if the listing says the apartment has its own washing machine ("Waschmaschine in der Wohnung", "eigene Waschmaschine", "Waschturm", "own washing machine"). false if the listing describes shared / communal laundry — especially phrases like "zur Mitbenutzung", "zur Mitnutzung", "Gemeinschaftswaschküche", "Gemeinschaftswaschraum", "shared laundry", or "communal laundry". null if not mentioned.
 Always populate laundryEvidence with the exact short snippet (max ~120 characters) you used to decide, or null if no laundry information was found.
+For availableFrom: parse Swiss / German / English availability phrases like "Bezugstermin: 01.05.2026", "verfügbar ab 1. Mai 2026", "available from May 1, 2026" into ISO format YYYY-MM-DD. If the listing says "ab sofort", "per sofort", "immediately", or similar (meaning available now without a specific date), return null. If no availability info is mentioned, return null.
 Return null for any field you cannot determine from the document.`,
           },
           {


### PR DESCRIPTION
## Summary
- New `available_from` text column (ISO `YYYY-MM-DD`) on the apartments table; Drizzle migration generated and applied.
- AI extraction handles "Bezugstermin: 01.05.2026", "1. Mai 2026", "available from May 1, 2026". "ab sofort" / "per sofort" return null (let the user fill it in).
- POST and PATCH routes validate via a tiny `isIsoDate` helper; bad strings drop to null.
- Detail page shows "Available from: 01.05.2026" (Swiss format) when set; native `<input type="date">` in the edit form.
- List card and compare view unchanged.

## Test plan
- [x] `npm test` passes (5 helper + 5 schema/passthrough + 2 integration tests, 231 total)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] Vercel preview: upload a listing with a date phrase and confirm extracted; edit on detail page; reload to confirm persistence.

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)