### PR TITLE
feat: reprocess apartment, keeping user-edited fields (#83)

### DIFF
--- a/docs/superpowers/plans/2026-04-25-reprocess.md
+++ b/docs/superpowers/plans/2026-04-25-reprocess.md
@@ -1,0 +1,836 @@
+# Apartment Reprocess Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Reprocess" button on the apartment detail page that re-runs the AI extraction on the existing PDF, refreshing only the AI-inferable fields the user hasn't edited.
+
+**Architecture:** New `user_edited_fields` JSON-array column on apartments. The PATCH route diffs the incoming body against the current row and unions changed AI-inferable fields into the column. A new POST `/api/apartments/[id]/reprocess` endpoint fetches the stored PDF, re-runs `extractApartmentData`, and only writes back fields not in the edited set. The detail page gets a Reprocess button that calls the endpoint after a confirm dialog.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, Drizzle (SQLite), Vitest, `ai` SDK with Google Gemini, shadcn/ui Button.
+
+**Spec:** [`docs/superpowers/specs/2026-04-25-reprocess-design.md`](../specs/2026-04-25-reprocess-design.md)
+**Issue:** [#83](https://github.com/brlauuu/flatpare/issues/83)
+
+---
+
+## File Structure
+
+### Files created
+
+- `src/lib/edited-fields.ts` — `INFERABLE_FIELDS`, `InferableField` type, `diffInferableFields`.
+- `src/lib/__tests__/edited-fields.test.ts` — 4 unit tests.
+- `src/app/api/apartments/[id]/reprocess/route.ts` — POST handler.
+- `src/app/apartments/[id]/__tests__/reprocess.test.tsx` — 3 integration tests.
+
+### Files modified
+
+- `src/lib/db/schema.ts` — add `userEditedFields` column.
+- `drizzle/<auto-named>.sql` — generated migration.
+- `src/app/api/apartments/[id]/route.ts` — PATCH diffs and updates the edited set.
+- `src/app/apartments/[id]/page.tsx` — Reprocess button + handler.
+- `src/app/apartments/[id]/__tests__/edit-flow.test.tsx` — extend fixture + 2 new tests.
+
+---
+
+## Task 1: DB schema + migration
+
+**Files:**
+- Modify: `src/lib/db/schema.ts`
+- Create: `drizzle/<auto-named>.sql`
+
+### Step 1: Add the column
+
+In `src/lib/db/schema.ts`, locate the `apartments` table. Insert `userEditedFields: text("user_edited_fields"),` BEFORE the `summary` line:
+
+```ts
+  rawExtractedData: text("raw_extracted_data"),
+  userEditedFields: text("user_edited_fields"),
+  summary: text("summary"),
+  availableFrom: text("available_from"),
+```
+
+(Preserve all other fields exactly as-is.)
+
+### Step 2: Generate the migration
+
+Run: `npm run db:generate`
+Expected: a new file appears under `drizzle/` (sequentially numbered, e.g. `0007_*.sql`) with `ALTER TABLE apartments ADD COLUMN user_edited_fields TEXT;`. Accept the default migration name.
+
+### Step 3: Apply the migration
+
+Run: `npm run db:push`
+Expected: applies the column to the local SQLite DB.
+
+### Step 4: Verify build
+
+Run: `npm run build`
+Expected: succeeds.
+
+### Step 5: Run tests + lint
+
+Run: `npm test && npm run lint`
+Expected: 246 pass. Bump the migration count in `migrate.test.ts` by 1 (likely from `7` to `8`).
+
+### Step 6: Commit
+
+```bash
+git add src/lib/db/schema.ts drizzle/
+git add src/lib/__tests__/migrate.test.ts 2>/dev/null || true
+git commit -m "feat: add user_edited_fields column to apartments"
+```
+
+---
+
+## Task 2: `edited-fields` helper (TDD)
+
+**Files:**
+- Create: `src/lib/edited-fields.ts`
+- Create: `src/lib/__tests__/edited-fields.test.ts`
+
+### Step 1: Write the failing tests
+
+Create `src/lib/__tests__/edited-fields.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import {
+  INFERABLE_FIELDS,
+  diffInferableFields,
+} from "@/lib/edited-fields";
+
+describe("INFERABLE_FIELDS", () => {
+  it("contains the expected AI-inferable apartment fields", () => {
+    expect(INFERABLE_FIELDS).toEqual([
+      "name",
+      "address",
+      "sizeM2",
+      "numRooms",
+      "numBathrooms",
+      "numBalconies",
+      "hasWashingMachine",
+      "rentChf",
+      "listingUrl",
+      "summary",
+      "availableFrom",
+    ]);
+  });
+});
+
+describe("diffInferableFields", () => {
+  it("returns an empty array when all values match", () => {
+    const current = { name: "X", rentChf: 1500, sizeM2: 50 };
+    const incoming = { name: "X", rentChf: 1500, sizeM2: 50 };
+    expect(diffInferableFields(current, incoming)).toEqual([]);
+  });
+
+  it("returns the names of changed inferable fields", () => {
+    const current = { name: "X", rentChf: 1500 };
+    const incoming = { name: "Y", rentChf: 2000 };
+    const result = diffInferableFields(current, incoming);
+    expect(result.sort()).toEqual(["name", "rentChf"]);
+  });
+
+  it("ignores changes to fields outside the inferable list", () => {
+    const current = { name: "X", distanceBikeMin: 5 };
+    const incoming = { name: "X", distanceBikeMin: 10 };
+    expect(diffInferableFields(current, incoming)).toEqual([]);
+  });
+
+  it("treats null vs non-null as a change", () => {
+    const current = { rentChf: null };
+    const incoming = { rentChf: 1500 };
+    expect(diffInferableFields(current, incoming)).toEqual(["rentChf"]);
+  });
+});
+```
+
+### Step 2: Run tests — should fail
+
+Run: `npm test -- src/lib/__tests__/edited-fields.test.ts`
+Expected: tests fail with `Cannot find module '@/lib/edited-fields'`.
+
+### Step 3: Implement
+
+Create `src/lib/edited-fields.ts`:
+
+```ts
+export const INFERABLE_FIELDS = [
+  "name",
+  "address",
+  "sizeM2",
+  "numRooms",
+  "numBathrooms",
+  "numBalconies",
+  "hasWashingMachine",
+  "rentChf",
+  "listingUrl",
+  "summary",
+  "availableFrom",
+] as const;
+
+export type InferableField = (typeof INFERABLE_FIELDS)[number];
+
+export function diffInferableFields(
+  current: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): InferableField[] {
+  const changed: InferableField[] = [];
+  for (const field of INFERABLE_FIELDS) {
+    if (current[field] !== incoming[field]) changed.push(field);
+  }
+  return changed;
+}
+```
+
+### Step 4: Run tests — should pass
+
+Run: `npm test -- src/lib/__tests__/edited-fields.test.ts`
+Expected: 4 tests pass.
+
+### Step 5: Full suite + lint
+
+Run: `npm test && npm run lint`
+Expected: 250 pass (246 + 4 new), lint clean.
+
+### Step 6: Commit
+
+```bash
+git add src/lib/edited-fields.ts src/lib/__tests__/edited-fields.test.ts
+git commit -m "feat: add edited-fields helper for tracking AI vs user data"
+```
+
+---
+
+## Task 3: PATCH route diffs and merges
+
+**Files:**
+- Modify: `src/app/api/apartments/[id]/route.ts`
+- Modify: `src/app/apartments/[id]/__tests__/edit-flow.test.tsx`
+
+### Step 1: Add 2 failing tests
+
+In `src/app/apartments/[id]/__tests__/edit-flow.test.tsx`, append these tests inside the existing `describe("Apartment detail edit flow", ...)` block (before its closing `});`):
+
+```tsx
+it("PATCH response after editing fields includes userEditedFields with the changed names", async () => {
+  // Mock the PATCH response so we can assert what the server "would" return.
+  // The server-side merge logic is what's under test in this file's PATCH.
+  vi.spyOn(global, "fetch").mockImplementationOnce(((
+    input: RequestInfo,
+    init?: RequestInit
+  ) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url.endsWith("/api/apartments/42") && init?.method === "PATCH") {
+      const sent = JSON.parse((init.body as string) ?? "{}");
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            ...APARTMENT_V1,
+            ...sent,
+            userEditedFields: JSON.stringify(["name", "rentChf"]),
+          }),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  }) as typeof fetch);
+
+  const user = userEvent.setup();
+  render(<ApartmentDetailPage />);
+  await waitFor(() => {
+    expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+  });
+  await user.click(screen.getByRole("button", { name: /^Edit$/ }));
+  // Edit the name and rent. The actual mutation behaviour comes from the mock above.
+  // The point of this test is just to confirm the body is sent — the server handles diffing.
+  const nameInput = screen.getByLabelText(/Name/i) as HTMLInputElement;
+  await user.clear(nameInput);
+  await user.type(nameInput, "Sonnenweg 3b");
+  await user.click(screen.getByRole("button", { name: /^Save$/ }));
+
+  await waitFor(() => {
+    const patchCall = fetchCalls.find(
+      (c) => c.url.endsWith("/api/apartments/42") && c.init.method === "PATCH"
+    );
+    expect(patchCall).toBeDefined();
+  });
+}, 10000);
+
+it("server-side: PATCH that doesn't change values keeps userEditedFields empty", () => {
+  // This test asserts a contract about server behaviour. The real coverage is
+  // in the unit test for diffInferableFields plus manual inspection of the
+  // route. We document the contract here for future readers.
+  expect(true).toBe(true);
+});
+```
+
+NOTE: Test 5 is intentionally lightweight — it confirms the client sends the PATCH; the diff/merge logic itself is exercised by the unit tests in Task 2 plus the route code in Step 3 below. Test 6 is a placeholder that documents the contract; consider replacing later if a true server-side route harness is added.
+
+### Step 2: Run tests — Test 5 should pass already (existing client behavior); Test 6 trivially passes
+
+Run: `npm test -- src/app/apartments/\[id\]/__tests__/edit-flow.test.tsx`
+Expected: tests pass. The point of Step 1 is to ensure these tests exist BEFORE the route changes; the actual server-side diff logic is verified by Task 2's unit tests.
+
+### Step 3: Update the PATCH route
+
+Open `src/app/api/apartments/[id]/route.ts`. Add the import:
+
+```ts
+import { diffInferableFields, INFERABLE_FIELDS } from "@/lib/edited-fields";
+```
+
+Replace the body of the `PATCH` handler. The current code:
+
+```ts
+const result = await db
+  .update(apartments)
+  .set({ /* fields */ })
+  .where(eq(apartments.id, apartmentId))
+  .returning();
+```
+
+becomes:
+
+```ts
+const current = await db
+  .select()
+  .from(apartments)
+  .where(eq(apartments.id, apartmentId))
+  .limit(1);
+
+if (current.length === 0) {
+  return NextResponse.json({ error: "Not found" }, { status: 404 });
+}
+
+const previousEdited: string[] = (() => {
+  const raw = current[0].userEditedFields;
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((v): v is string => typeof v === "string")
+      : [];
+  } catch {
+    return [];
+  }
+})();
+
+const newlyChanged = diffInferableFields(
+  current[0],
+  body as Record<string, unknown>
+);
+
+const merged = Array.from(new Set([...previousEdited, ...newlyChanged]));
+
+const availableFrom: string | null =
+  typeof body.availableFrom === "string" && isIsoDate(body.availableFrom)
+    ? body.availableFrom
+    : null;
+
+const result = await db
+  .update(apartments)
+  .set({
+    name: body.name,
+    address: body.address,
+    sizeM2: body.sizeM2,
+    numRooms: body.numRooms,
+    numBathrooms: body.numBathrooms,
+    numBalconies: body.numBalconies,
+    hasWashingMachine: body.hasWashingMachine ?? null,
+    rentChf: body.rentChf,
+    distanceBikeMin: body.distanceBikeMin,
+    distanceTransitMin: body.distanceTransitMin,
+    listingUrl: body.listingUrl,
+    summary: body.summary ?? null,
+    availableFrom,
+    userEditedFields:
+      merged.length > 0 ? JSON.stringify(merged) : null,
+  })
+  .where(eq(apartments.id, apartmentId))
+  .returning();
+```
+
+(Preserve any existing field assignments — only `userEditedFields` is new in the `set` block. The `availableFrom` and `summary` lines should already be present from #54/#55.)
+
+### Step 4: Test + lint + build
+
+Run: `npm test && npm run lint && npm run build`
+Expected: 250 pass, lint clean, build clean.
+
+### Step 5: Commit
+
+```bash
+git add src/app/api/apartments/[id]/route.ts \
+        src/app/apartments/[id]/__tests__/edit-flow.test.tsx
+git commit -m "feat: PATCH tracks user-edited fields"
+```
+
+---
+
+## Task 4: Reprocess endpoint
+
+**Files:**
+- Create: `src/app/api/apartments/[id]/reprocess/route.ts`
+
+### Step 1: Create the route
+
+Create `src/app/api/apartments/[id]/reprocess/route.ts`:
+
+```ts
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { apartments } from "@/lib/db/schema";
+import { extractApartmentData } from "@/lib/parse-pdf";
+import { classifyParsePdfError } from "@/lib/parse-pdf-error";
+import { INFERABLE_FIELDS } from "@/lib/edited-fields";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const apartmentId = parseInt(id);
+
+    const rows = await db
+      .select()
+      .from(apartments)
+      .where(eq(apartments.id, apartmentId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const apt = rows[0];
+
+    if (!apt.pdfUrl) {
+      return NextResponse.json(
+        { error: "No PDF on file for this apartment" },
+        { status: 400 }
+      );
+    }
+
+    let pdfBase64: string;
+    try {
+      const pdfRes = await fetch(apt.pdfUrl);
+      if (!pdfRes.ok) throw new Error(`Failed to fetch PDF (${pdfRes.status})`);
+      const buf = Buffer.from(await pdfRes.arrayBuffer());
+      pdfBase64 = buf.toString("base64");
+    } catch (err) {
+      console.error("[reprocess] PDF fetch failed:", err);
+      return NextResponse.json(
+        {
+          error: err instanceof Error ? err.message : "Failed to fetch PDF",
+        },
+        { status: 500 }
+      );
+    }
+
+    let extraction: Awaited<ReturnType<typeof extractApartmentData>>;
+    try {
+      extraction = await extractApartmentData(pdfBase64);
+    } catch (err) {
+      const classified = classifyParsePdfError(err);
+      return NextResponse.json(
+        {
+          error: classified.message,
+          reason: classified.reason,
+          retryAfterSeconds: classified.retryAfterSeconds,
+        },
+        { status: classified.status }
+      );
+    }
+
+    const editedSet = new Set<string>(
+      (() => {
+        const raw = apt.userEditedFields;
+        if (!raw) return [];
+        try {
+          const parsed = JSON.parse(raw);
+          return Array.isArray(parsed)
+            ? parsed.filter((v): v is string => typeof v === "string")
+            : [];
+        } catch {
+          return [];
+        }
+      })()
+    );
+
+    const updates: Record<string, unknown> = {};
+    for (const field of INFERABLE_FIELDS) {
+      if (editedSet.has(field)) continue;
+      updates[field] = (extraction as Record<string, unknown>)[field] ?? null;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json(apt);
+    }
+
+    const result = await db
+      .update(apartments)
+      .set(updates)
+      .where(eq(apartments.id, apartmentId))
+      .returning();
+
+    return NextResponse.json(result[0]);
+  } catch (error) {
+    console.error("[apartments/id/reprocess:POST] Error:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to reprocess",
+      },
+      { status: 500 }
+    );
+  }
+}
+```
+
+### Step 2: Test + lint + build
+
+Run: `npm test && npm run lint && npm run build`
+Expected: 250 pass, lint clean, build clean. The new route has no direct test yet (Task 5's integration tests cover it via the page).
+
+### Step 3: Commit
+
+```bash
+git add src/app/api/apartments/[id]/reprocess/
+git commit -m "feat: reprocess endpoint refreshes AI-inferable fields"
+```
+
+---
+
+## Task 5: Detail page UI + integration tests
+
+**Files:**
+- Modify: `src/app/apartments/[id]/page.tsx`
+- Create: `src/app/apartments/[id]/__tests__/reprocess.test.tsx`
+
+### Step 1: Write the failing integration tests
+
+Create `src/app/apartments/[id]/__tests__/reprocess.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "42" }),
+  useRouter: () => ({ push, refresh }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const APT_WITH_PDF = {
+  id: 42,
+  name: "Sonnenweg 3",
+  address: "Sonnenweg 3, 8001 Zürich",
+  sizeM2: 60,
+  numRooms: 2.5,
+  numBathrooms: 1,
+  numBalconies: 1,
+  hasWashingMachine: false,
+  rentChf: 2200,
+  distanceBikeMin: 12,
+  distanceTransitMin: 25,
+  pdfUrl: "https://blob.example/sonnenweg.pdf",
+  listingUrl: null,
+  shortCode: "ABC-2.5B-WY-4057",
+  summary: "Original AI summary.",
+  availableFrom: null,
+  userEditedFields: null,
+  ratings: [],
+};
+
+const APT_WITH_PDF_REFRESHED = {
+  ...APT_WITH_PDF,
+  summary: "Refreshed summary after reprocess.",
+};
+
+const APT_NO_PDF = { ...APT_WITH_PDF, pdfUrl: null };
+
+let fetchCalls: { url: string; init: RequestInit }[] = [];
+let detailResponse: typeof APT_WITH_PDF = APT_WITH_PDF;
+let reprocessResponse: { ok: boolean; status: number; body: unknown } = {
+  ok: true,
+  status: 200,
+  body: APT_WITH_PDF_REFRESHED,
+};
+
+beforeEach(() => {
+  push.mockReset();
+  refresh.mockReset();
+  fetchCalls = [];
+  detailResponse = APT_WITH_PDF;
+  reprocessResponse = {
+    ok: true,
+    status: 200,
+    body: APT_WITH_PDF_REFRESHED,
+  };
+
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    get: () => "flatpare-name=Alice",
+    set: () => {},
+  });
+
+  vi.spyOn(global, "fetch").mockImplementation(((
+    input: RequestInfo,
+    init?: RequestInit
+  ) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    fetchCalls.push({ url, init: init ?? {} });
+    const method = init?.method ?? "GET";
+
+    if (url === "/api/apartments" && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }
+    if (url.endsWith("/api/apartments/42/reprocess") && method === "POST") {
+      const body = reprocessResponse.body;
+      return Promise.resolve({
+        ok: reprocessResponse.ok,
+        status: reprocessResponse.status,
+        json: () => Promise.resolve(body),
+      } as Response);
+    }
+    if (url.endsWith("/api/apartments/42") && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(detailResponse),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  }) as typeof fetch);
+
+  vi.stubGlobal("confirm", () => true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Apartment detail — reprocess", () => {
+  it("clicking Reprocess calls the endpoint and reloads the apartment", async () => {
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Original AI summary.")).toBeInTheDocument();
+
+    // After reprocess, the second GET should return the refreshed apartment.
+    detailResponse = APT_WITH_PDF_REFRESHED;
+
+    await user.click(screen.getByRole("button", { name: /Reprocess/i }));
+
+    await waitFor(() => {
+      const reprocessCall = fetchCalls.find((c) =>
+        c.url.endsWith("/api/apartments/42/reprocess")
+      );
+      expect(reprocessCall).toBeDefined();
+      expect(reprocessCall!.init.method).toBe("POST");
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText("Refreshed summary after reprocess.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("Reprocess button is disabled when the apartment has no pdfUrl", async () => {
+    detailResponse = APT_NO_PDF;
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Reprocess/i })).toBeDisabled();
+  });
+
+  it("renders an error when reprocess returns a quota error", async () => {
+    reprocessResponse = {
+      ok: false,
+      status: 429,
+      body: {
+        error: "AI quota exceeded — try again in 34s.",
+        reason: "quota",
+        retryAfterSeconds: 34,
+      },
+    };
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Reprocess/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't reprocess apartment/i)
+      ).toBeInTheDocument();
+    });
+  });
+});
+```
+
+### Step 2: Run tests to confirm they fail
+
+Run: `npm test -- src/app/apartments/\[id\]/__tests__/reprocess.test.tsx`
+Expected: all 3 fail — no Reprocess button yet.
+
+### Step 3: Add the button + handler to `src/app/apartments/[id]/page.tsx`
+
+In the component body, alongside the other useState calls, add:
+
+```tsx
+const [reprocessing, setReprocessing] = useState(false);
+```
+
+Add the handler. Place it next to other detail-page handlers like `handleDelete`:
+
+```tsx
+async function handleReprocess() {
+  if (!apartment?.pdfUrl) return;
+  const ok = window.confirm(
+    "Reprocess this apartment? Fields you haven't edited will be refreshed from the PDF. Fields you've edited will stay."
+  );
+  if (!ok) return;
+  setReprocessing(true);
+  const url = `/api/apartments/${params.id}/reprocess`;
+  try {
+    const res = await fetch(url, { method: "POST" });
+    if (!res.ok) {
+      setError({
+        headline: "Couldn't reprocess apartment",
+        details: await fetchErrorFromResponse(res, url),
+      });
+      setReprocessing(false);
+      return;
+    }
+    await reloadApartment();
+  } catch (err) {
+    setError({
+      headline: "Couldn't reprocess apartment",
+      details: fetchErrorFromException(err, url),
+    });
+  } finally {
+    setReprocessing(false);
+  }
+}
+```
+
+In the JSX action button row (the column with View PDF / Listing / Edit / Delete), insert the Reprocess button BEFORE the Delete button:
+
+```tsx
+<Button
+  variant="outline"
+  size="sm"
+  disabled={reprocessing || editing || !apartment.pdfUrl}
+  onClick={handleReprocess}
+  className="w-full sm:w-auto"
+>
+  {reprocessing ? "Reprocessing..." : "Reprocess"}
+</Button>
+```
+
+### Step 4: Update `ApartmentDetail` interface
+
+Add `userEditedFields: string | null;` to the `ApartmentDetail` interface (after `availableFrom: string | null;`). Existing pages that consume `ApartmentDetail` won't break — none of them read this field.
+
+### Step 5: Run all tests
+
+Run: `npm test`
+Expected: 253 pass (250 + 3 new).
+
+### Step 6: Lint and build
+
+Run: `npm run lint && npm run build`
+Expected: clean.
+
+### Step 7: Commit
+
+```bash
+git add src/app/apartments/[id]/page.tsx \
+        src/app/apartments/[id]/__tests__/reprocess.test.tsx
+git commit -m "feat: add reprocess button to apartment detail (#83)"
+```
+
+---
+
+## Task 6: Open PR
+
+**Files:** none.
+
+- [ ] **Step 1: Push the branch**
+
+Run: `git push -u origin 83-reprocess`
+Expected: branch published.
+
+- [ ] **Step 2: Open the PR**
+
+```bash
+gh pr create \
+  --title "feat: reprocess apartment, keeping user-edited fields (#83)" \
+  --body "$(cat <<'EOF'
+## Summary
+- New `user_edited_fields` JSON-array column on apartments. PATCH diffs the body against the current row and unions changed AI-inferable fields into the column. Editing the form sets the bit; the AI is no longer allowed to overwrite that field on subsequent reprocesses.
+- New `POST /api/apartments/[id]/reprocess` endpoint fetches the stored PDF, re-runs `extractApartmentData`, and only writes back fields not in the edited set.
+- Detail page gets a "Reprocess" button (next to Edit/Delete) with a confirm dialog. Disabled when there's no PDF on file.
+- Errors from the AI go through the same `classifyParsePdfError` flow as the upload route — quota / invalid-pdf / unknown branches are preserved.
+
+## Test plan
+- [x] `npm test` passes (4 helper unit tests + 2 edit-flow tests + 3 integration tests, 253 total)
+- [x] `npm run lint` clean
+- [x] `npm run build` succeeds
+- [ ] Vercel preview: edit an apartment field, click Reprocess, confirm the edited field stays while other AI fields refresh.
+
+Closes #83
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Hand back to controller.**
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- DB column `user_edited_fields` (text, nullable, JSON array): Task 1 ✓
+- `INFERABLE_FIELDS` list and `diffInferableFields` helper: Task 2 ✓
+- PATCH diff + merge + persist: Task 3 ✓
+- POST `/api/apartments/[id]/reprocess` endpoint: Task 4 ✓
+- PDF fetch + base64 + AI re-extraction: Task 4 Step 1 ✓
+- Skip fields in the edited set: Task 4 Step 1 ✓
+- Empty-payload no-op: Task 4 Step 1 (early return when `Object.keys(updates).length === 0`) ✓
+- Error classification via `classifyParsePdfError`: Task 4 Step 1 ✓
+- Reprocess button on detail page: Task 5 Step 3 ✓
+- Disabled when no `pdfUrl`: Task 5 Step 3 + test 8 ✓
+- Confirm dialog: Task 5 Step 3 ✓
+- Reload on success: Task 5 Step 3 (`await reloadApartment()`) ✓
+- 4 helper unit tests: Task 2 ✓
+- 2 edit-flow tests: Task 3 Step 1 ✓
+- 3 reprocess integration tests: Task 5 Step 1 ✓
+- No distance recomputation in reprocess: confirmed — endpoint only updates inferable fields ✓
+- POST does NOT initialize `userEditedFields`: spec says null on insert; the existing POST `db.insert(apartments).values({...})` doesn't set the field, so it defaults to null ✓
+
+**Placeholder scan:** no TBDs, no generic phrases. Every code step shows complete code.
+
+**Type consistency:**
+- `INFERABLE_FIELDS` defined in Task 2, used in Tasks 3 and 4.
+- `diffInferableFields` signature `(current, incoming) => InferableField[]` — same in Task 2 (definition) and Task 3 (PATCH route).
+- `userEditedFields` column declared in Task 1, written by Task 3 (PATCH), read by Task 4 (reprocess), and exposed on `ApartmentDetail` in Task 5.
+- API response shape from reprocess (the apartment row OR `{ error, reason, retryAfterSeconds? }`) matches `ApartmentDetail` and the existing `fetchErrorFromResponse` consumer.
+
+No gaps.

--- a/docs/superpowers/specs/2026-04-25-reprocess-design.md
+++ b/docs/superpowers/specs/2026-04-25-reprocess-design.md
@@ -1,0 +1,192 @@
+# Apartment reprocess — design
+
+**Issue:** [#83 — There should be a reprocess button on the apartment page that refreshes all inferred data but keeps all user provided data as is](https://github.com/brlauuu/flatpare/issues/83)
+**Date:** 2026-04-25
+
+## Problem
+
+After uploading a PDF and saving an apartment, the AI-extracted fields are frozen. If the user later updates the prompt logic, picks a better model, or re-uploads a clearer PDF as the same listing, there's no way to refresh the inferred data without losing whatever fields the user manually edited along the way.
+
+## Scope
+
+- Track which fields the user has edited via the form, persistently.
+- New "Reprocess" button on the apartment detail page that re-runs `extractApartmentData` on the existing PDF.
+- Reprocess updates only the AI-inferable fields that the user HAS NOT edited.
+- Distance recomputation is NOT triggered by reprocess (the user can use the existing settings-page button).
+- Out: "un-mark field as edited" UI, per-field reprocess, showing inferred-vs-edited badges next to fields.
+
+## Edit tracking
+
+### Storage
+
+New nullable column on the apartments table:
+
+```ts
+// src/lib/db/schema.ts
+userEditedFields: text("user_edited_fields"),
+```
+
+JSON-encoded array of field names, e.g. `'["rentChf","sizeM2"]'`. `null` and `'[]'` are equivalent (no edits tracked). Existing apartments default to `null`.
+
+### Inferable-fields list
+
+Extracted into `src/lib/edited-fields.ts`:
+
+```ts
+export const INFERABLE_FIELDS = [
+  "name",
+  "address",
+  "sizeM2",
+  "numRooms",
+  "numBathrooms",
+  "numBalconies",
+  "hasWashingMachine",
+  "rentChf",
+  "listingUrl",
+  "summary",
+  "availableFrom",
+] as const satisfies readonly string[];
+
+export type InferableField = (typeof INFERABLE_FIELDS)[number];
+
+export function diffInferableFields(
+  current: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): InferableField[] {
+  const changed: InferableField[] = [];
+  for (const field of INFERABLE_FIELDS) {
+    if (current[field] !== incoming[field]) changed.push(field);
+  }
+  return changed;
+}
+```
+
+The list intentionally excludes `pdfUrl`, `shortCode`, `distanceBikeMin`, `distanceTransitMin`, `rawExtractedData`, `createdAt`, `updatedAt` — those are computed or set on upload, never AI-inferred.
+
+### PATCH route changes
+
+`src/app/api/apartments/[id]/route.ts` PATCH handler grows a "diff and merge" step:
+
+1. Fetch the current apartment row.
+2. Compute `changed = diffInferableFields(current, body)`.
+3. Parse the existing `userEditedFields` (`null` or invalid JSON → empty set).
+4. Compute `merged = unique union of current set + changed`.
+5. Update the row with all fields PLUS `userEditedFields: JSON.stringify(merged)`.
+
+The response body now includes `userEditedFields` (parsed back to an array, or `[]`).
+
+Saving the form unchanged → no fields added (correct). Editing rent → `"rentChf"` joins the set. Re-editing back to the AI's original value → still tracked as edited (the user touched it).
+
+### POST route
+
+POST does NOT initialize `userEditedFields`. A freshly-uploaded apartment has `null`, meaning "no edits yet — everything is AI-inferred". Reprocess at this point would happily refresh every AI field.
+
+## Reprocess endpoint
+
+`POST /api/apartments/[id]/reprocess`:
+
+1. Fetch the apartment row, including `pdfUrl` and `userEditedFields`.
+2. If `pdfUrl` is null, return `400 { error: "No PDF on file for this apartment" }`.
+3. Server-side `fetch(pdfUrl)` → `arrayBuffer` → `Buffer.from(...).toString("base64")`.
+4. Call `extractApartmentData(base64)`. Wrapped in a try/catch that runs the result through `classifyParsePdfError` on failure, returning the same `{ error, reason, retryAfterSeconds? }` shape as `/api/parse-pdf`.
+5. Parse `userEditedFields` to a Set (empty if null/invalid).
+6. Build the update payload: for each `field of INFERABLE_FIELDS`, if `field in extraction && !editedSet.has(field)`, copy `extraction[field]` to the payload.
+7. If the payload is empty (every inferable field was edited), return the unchanged apartment with HTTP 200 — successful no-op.
+8. Otherwise run `db.update(apartments).set(payload).where(eq(...))`.
+9. Return the full updated apartment row.
+
+The endpoint is idempotent — calling it twice in a row produces the same result (same PDF + same edit set + same model = same payload).
+
+## UI
+
+`src/app/apartments/[id]/page.tsx` action button row gets a new "Reprocess" button between Edit and Delete:
+
+```tsx
+<Button
+  variant="outline"
+  size="sm"
+  disabled={reprocessing || editing || !apartment.pdfUrl}
+  onClick={handleReprocess}
+  className="w-full sm:w-auto"
+>
+  {reprocessing ? "Reprocessing..." : "Reprocess"}
+</Button>
+```
+
+Disabled when there's no PDF on file (legacy single-entry apartments) and during edit mode.
+
+`handleReprocess`:
+
+```tsx
+async function handleReprocess() {
+  const ok = window.confirm(
+    "Reprocess this apartment? Fields you haven't edited will be refreshed from the PDF. Fields you've edited will stay."
+  );
+  if (!ok) return;
+  setReprocessing(true);
+  const url = `/api/apartments/${params.id}/reprocess`;
+  try {
+    const res = await fetch(url, { method: "POST" });
+    if (!res.ok) {
+      setError({
+        headline: "Couldn't reprocess apartment",
+        details: await fetchErrorFromResponse(res, url),
+      });
+      return;
+    }
+    await reloadApartment();
+  } catch (err) {
+    setError({
+      headline: "Couldn't reprocess apartment",
+      details: fetchErrorFromException(err, url),
+    });
+  } finally {
+    setReprocessing(false);
+  }
+}
+```
+
+`reloadApartment` is already in the page (used by the user-switch effect). It re-fetches and re-derives state. After reprocess, the user sees the refreshed fields immediately.
+
+## Migration
+
+`npm run db:generate` adds the `user_edited_fields` column (nullable, no default). `npm run db:push` applies it. Non-destructive.
+
+## Testing
+
+### Unit tests — `src/lib/__tests__/edited-fields.test.ts` (new, 4 tests)
+
+1. Empty diff when all values match.
+2. One changed field → set contains that field name.
+3. Multiple changed fields → set contains all of them.
+4. Fields outside `INFERABLE_FIELDS` (e.g. `distanceBikeMin`) are ignored even when changed.
+
+### Integration tests — extend `edit-flow.test.tsx` (2 new tests)
+
+5. After saving an edit that changes `name` and `rentChf`, the second `GET /api/apartments/42` (the post-save reload) returns `userEditedFields: ["name","rentChf"]` (or some order). Assert the field appears in the apartment state. (Doesn't need a UI assertion — the field tracking is server-side.)
+6. Saving without changing any field results in PATCH being called but `userEditedFields` stays empty.
+
+### Integration tests — `src/app/apartments/[id]/__tests__/reprocess.test.tsx` (new, 3 tests)
+
+7. Click Reprocess → confirm → POST `/api/apartments/{id}/reprocess` is called → page reloads with the new fields rendered.
+8. Reprocess button is disabled when `apartment.pdfUrl` is null.
+9. Server returns a 429 quota error → message renders in `ErrorDisplay`.
+
+### Existing tests
+
+Unchanged. The PATCH route still accepts and returns the same fields; the new `userEditedFields` is additive in both directions.
+
+## Out of scope
+
+- "Reset edits" button to un-mark a field as edited.
+- Distance recomputation as part of reprocess.
+- Per-field reprocess.
+- Inferred-vs-edited badges in the UI.
+- Reprocessing in the upload flow (upload is already a fresh process).
+- Migration to backfill `userEditedFields` for existing apartments — they default to null, meaning everything is AI-inferred, which is the correct interpretation: existing apartments will have all AI fields refreshed on first reprocess unless the user has edited them since this PR ships.
+
+## Security & cost
+
+- Reprocess re-runs the AI on a server-fetched PDF — same cost profile as upload, just triggered manually.
+- The endpoint is gated by the existing app-wide password (the proxy guards `/api/*`). No additional auth is needed.
+- `pdfUrl` may be a Vercel Blob signed URL or a public URL; the server `fetch` handles both.

--- a/drizzle/0007_narrow_cannonball.sql
+++ b/drizzle/0007_narrow_cannonball.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `apartments` ADD `user_edited_fields` text;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,406 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "ad62c510-d623-43bc-a501-ecde745d7111",
+  "prevId": "6de441a3-eb3d-4adb-995f-39975efca88d",
+  "tables": {
+    "apartments": {
+      "name": "apartments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_m2": {
+          "name": "size_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_rooms": {
+          "name": "num_rooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_bathrooms": {
+          "name": "num_bathrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_balconies": {
+          "name": "num_balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_washing_machine": {
+          "name": "has_washing_machine",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rent_chf": {
+          "name": "rent_chf",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_bike_min": {
+          "name": "distance_bike_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "distance_transit_min": {
+          "name": "distance_transit_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_url": {
+          "name": "listing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_extracted_data": {
+          "name": "raw_extracted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_edited_fields": {
+          "name": "user_edited_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "apartments_short_code_unique": {
+          "name": "apartments_short_code_unique",
+          "columns": [
+            "short_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_usage": {
+      "name": "api_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ratings": {
+      "name": "ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kitchen": {
+          "name": "kitchen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "balconies": {
+          "name": "balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "location": {
+          "name": "location",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "floorplan": {
+          "name": "floorplan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "overall_feeling": {
+          "name": "overall_feeling",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "ratings_apartment_user_idx": {
+          "name": "ratings_apartment_user_idx",
+          "columns": [
+            "apartment_id",
+            "user_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ratings_apartment_id_apartments_id_fk": {
+          "name": "ratings_apartment_id_apartments_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1777101441771,
       "tag": "0006_giant_metal_master",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1777146956276,
+      "tag": "0007_narrow_cannonball",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/apartments/[id]/__tests__/reprocess.test.tsx
+++ b/src/app/apartments/[id]/__tests__/reprocess.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const push = vi.fn();
+const refresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "42" }),
+  useRouter: () => ({ push, refresh }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const APT_WITH_PDF = {
+  id: 42,
+  name: "Sonnenweg 3",
+  address: "Sonnenweg 3, 8001 Zürich",
+  sizeM2: 60,
+  numRooms: 2.5,
+  numBathrooms: 1,
+  numBalconies: 1,
+  hasWashingMachine: false,
+  rentChf: 2200,
+  distanceBikeMin: 12,
+  distanceTransitMin: 25,
+  pdfUrl: "https://blob.example/sonnenweg.pdf",
+  listingUrl: null,
+  shortCode: "ABC-2.5B-WY-4057",
+  summary: "Original AI summary.",
+  availableFrom: null,
+  userEditedFields: null,
+  ratings: [],
+};
+
+const APT_WITH_PDF_REFRESHED = {
+  ...APT_WITH_PDF,
+  summary: "Refreshed summary after reprocess.",
+};
+
+const APT_NO_PDF = { ...APT_WITH_PDF, pdfUrl: null };
+
+let fetchCalls: { url: string; init: RequestInit }[] = [];
+let detailResponse: typeof APT_WITH_PDF = APT_WITH_PDF;
+let reprocessResponse: { ok: boolean; status: number; body: unknown } = {
+  ok: true,
+  status: 200,
+  body: APT_WITH_PDF_REFRESHED,
+};
+
+beforeEach(() => {
+  push.mockReset();
+  refresh.mockReset();
+  fetchCalls = [];
+  detailResponse = APT_WITH_PDF;
+  reprocessResponse = {
+    ok: true,
+    status: 200,
+    body: APT_WITH_PDF_REFRESHED,
+  };
+
+  Object.defineProperty(document, "cookie", {
+    configurable: true,
+    get: () => "flatpare-name=Alice",
+    set: () => {},
+  });
+
+  vi.spyOn(global, "fetch").mockImplementation(((
+    input: RequestInfo,
+    init?: RequestInit
+  ) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    fetchCalls.push({ url, init: init ?? {} });
+    const method = init?.method ?? "GET";
+
+    if (url === "/api/apartments" && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }
+    if (url.endsWith("/api/apartments/42/reprocess") && method === "POST") {
+      const body = reprocessResponse.body;
+      return Promise.resolve({
+        ok: reprocessResponse.ok,
+        status: reprocessResponse.status,
+        json: () => Promise.resolve(body),
+      } as Response);
+    }
+    if (url.endsWith("/api/apartments/42") && method === "GET") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(detailResponse),
+      } as Response);
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) } as Response);
+  }) as typeof fetch);
+
+  vi.stubGlobal("confirm", () => true);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("Apartment detail — reprocess", () => {
+  it("clicking Reprocess calls the endpoint and reloads the apartment", async () => {
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Original AI summary.")).toBeInTheDocument();
+
+    detailResponse = APT_WITH_PDF_REFRESHED;
+
+    await user.click(screen.getByRole("button", { name: /Reprocess/i }));
+
+    await waitFor(() => {
+      const reprocessCall = fetchCalls.find((c) =>
+        c.url.endsWith("/api/apartments/42/reprocess")
+      );
+      expect(reprocessCall).toBeDefined();
+      expect(reprocessCall!.init.method).toBe("POST");
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByText("Refreshed summary after reprocess.")
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("Reprocess button is disabled when the apartment has no pdfUrl", async () => {
+    detailResponse = APT_NO_PDF;
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Reprocess/i })).toBeDisabled();
+  });
+
+  it("renders an error when reprocess returns a quota error", async () => {
+    reprocessResponse = {
+      ok: false,
+      status: 429,
+      body: {
+        error: "AI quota exceeded — try again in 34s.",
+        reason: "quota",
+        retryAfterSeconds: 34,
+      },
+    };
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Reprocess/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't reprocess apartment/i)
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -62,6 +62,7 @@ interface ApartmentDetail {
   listingUrl: string | null;
   summary: string | null;
   availableFrom: string | null;
+  userEditedFields: string | null;
   shortCode: string | null;
   mapEmbedUrl: string | null;
   ratings: Rating[];
@@ -103,6 +104,7 @@ export default function ApartmentDetailPage() {
   const [editing, setEditing] = useState(false);
   const [editForm, setEditForm] = useState<ApartmentForm | null>(null);
   const [savingEdit, setSavingEdit] = useState(false);
+  const [reprocessing, setReprocessing] = useState(false);
 
   // Shared applier so both the initial effect and event-driven reloads
   // converge on the same state updates.
@@ -224,6 +226,35 @@ export default function ApartmentDetailPage() {
         details: fetchErrorFromException(err, url),
       });
       setDeleting(false);
+    }
+  }
+
+  async function handleReprocess() {
+    if (!apartment?.pdfUrl) return;
+    const ok = window.confirm(
+      "Reprocess this apartment? Fields you haven't edited will be refreshed from the PDF. Fields you've edited will stay."
+    );
+    if (!ok) return;
+    setReprocessing(true);
+    const url = `/api/apartments/${params.id}/reprocess`;
+    try {
+      const res = await fetch(url, { method: "POST" });
+      if (!res.ok) {
+        setError({
+          headline: "Couldn't reprocess apartment",
+          details: await fetchErrorFromResponse(res, url),
+        });
+        setReprocessing(false);
+        return;
+      }
+      await reloadApartment();
+    } catch (err) {
+      setError({
+        headline: "Couldn't reprocess apartment",
+        details: fetchErrorFromException(err, url),
+      });
+    } finally {
+      setReprocessing(false);
     }
   }
 
@@ -425,6 +456,15 @@ export default function ApartmentDetailPage() {
               Edit
             </Button>
           )}
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={reprocessing || editing || !apartment.pdfUrl}
+            onClick={handleReprocess}
+            className="w-full sm:w-auto"
+          >
+            {reprocessing ? "Reprocessing..." : "Reprocess"}
+          </Button>
           <Button
             variant="destructive"
             size="sm"

--- a/src/app/api/__tests__/apartments.test.ts
+++ b/src/app/api/__tests__/apartments.test.ts
@@ -217,7 +217,16 @@ describe("GET /api/apartments/[id]", () => {
 
 describe("PATCH /api/apartments/[id]", () => {
   it("updates an apartment", async () => {
+    const current = { id: 1, name: "Old Name", userEditedFields: null };
     const updated = { id: 1, name: "Updated" };
+
+    mockSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          limit: vi.fn().mockResolvedValue([current]),
+        }),
+      }),
+    });
 
     mockUpdate.mockReturnValue({
       set: vi.fn().mockReturnValue({
@@ -239,10 +248,10 @@ describe("PATCH /api/apartments/[id]", () => {
   });
 
   it("returns 404 when apartment not found", async () => {
-    mockUpdate.mockReturnValue({
-      set: vi.fn().mockReturnValue({
+    mockSelect.mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
         where: vi.fn().mockReturnValue({
-          returning: vi.fn().mockResolvedValue([]),
+          limit: vi.fn().mockResolvedValue([]),
         }),
       }),
     });

--- a/src/app/api/apartments/[id]/reprocess/route.ts
+++ b/src/app/api/apartments/[id]/reprocess/route.ts
@@ -1,0 +1,109 @@
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { apartments } from "@/lib/db/schema";
+import { extractApartmentData } from "@/lib/parse-pdf";
+import { classifyParsePdfError } from "@/lib/parse-pdf-error";
+import { INFERABLE_FIELDS } from "@/lib/edited-fields";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params;
+    const apartmentId = parseInt(id);
+
+    const rows = await db
+      .select()
+      .from(apartments)
+      .where(eq(apartments.id, apartmentId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const apt = rows[0];
+
+    if (!apt.pdfUrl) {
+      return NextResponse.json(
+        { error: "No PDF on file for this apartment" },
+        { status: 400 }
+      );
+    }
+
+    let pdfBase64: string;
+    try {
+      const pdfRes = await fetch(apt.pdfUrl);
+      if (!pdfRes.ok) throw new Error(`Failed to fetch PDF (${pdfRes.status})`);
+      const buf = Buffer.from(await pdfRes.arrayBuffer());
+      pdfBase64 = buf.toString("base64");
+    } catch (err) {
+      console.error("[reprocess] PDF fetch failed:", err);
+      return NextResponse.json(
+        {
+          error: err instanceof Error ? err.message : "Failed to fetch PDF",
+        },
+        { status: 500 }
+      );
+    }
+
+    let extraction: Awaited<ReturnType<typeof extractApartmentData>>;
+    try {
+      extraction = await extractApartmentData(pdfBase64);
+    } catch (err) {
+      const classified = classifyParsePdfError(err);
+      return NextResponse.json(
+        {
+          error: classified.message,
+          reason: classified.reason,
+          retryAfterSeconds: classified.retryAfterSeconds,
+        },
+        { status: classified.status }
+      );
+    }
+
+    const editedSet = new Set<string>(
+      (() => {
+        const raw = apt.userEditedFields;
+        if (!raw) return [];
+        try {
+          const parsed = JSON.parse(raw);
+          return Array.isArray(parsed)
+            ? parsed.filter((v): v is string => typeof v === "string")
+            : [];
+        } catch {
+          return [];
+        }
+      })()
+    );
+
+    const updates: Record<string, unknown> = {};
+    for (const field of INFERABLE_FIELDS) {
+      if (editedSet.has(field)) continue;
+      updates[field] = (extraction as Record<string, unknown>)[field] ?? null;
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json(apt);
+    }
+
+    const result = await db
+      .update(apartments)
+      .set(updates)
+      .where(eq(apartments.id, apartmentId))
+      .returning();
+
+    return NextResponse.json(result[0]);
+  } catch (error) {
+    console.error("[apartments/id/reprocess:POST] Error:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to reprocess",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/apartments/[id]/route.ts
+++ b/src/app/api/apartments/[id]/route.ts
@@ -4,6 +4,7 @@ import { apartments, ratings } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { buildMapEmbedUrl } from "@/lib/map-embed";
 import { isIsoDate } from "@/lib/iso-date";
+import { diffInferableFields } from "@/lib/edited-fields";
 
 export async function GET(
   _request: Request,
@@ -56,6 +57,36 @@ export async function PATCH(
         ? body.availableFrom
         : null;
 
+    const currentRows = await db
+      .select()
+      .from(apartments)
+      .where(eq(apartments.id, apartmentId))
+      .limit(1);
+
+    if (currentRows.length === 0) {
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+    }
+
+    const previousEdited: string[] = (() => {
+      const raw = currentRows[0].userEditedFields;
+      if (!raw) return [];
+      try {
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed)
+          ? parsed.filter((v): v is string => typeof v === "string")
+          : [];
+      } catch {
+        return [];
+      }
+    })();
+
+    const newlyChanged = diffInferableFields(
+      currentRows[0] as Record<string, unknown>,
+      body as Record<string, unknown>
+    );
+
+    const merged = Array.from(new Set([...previousEdited, ...newlyChanged]));
+
     const result = await db
       .update(apartments)
       .set({
@@ -72,6 +103,7 @@ export async function PATCH(
         listingUrl: body.listingUrl,
         summary: body.summary ?? null,
         availableFrom,
+        userEditedFields: merged.length > 0 ? JSON.stringify(merged) : null,
       })
       .where(eq(apartments.id, apartmentId))
       .returning();

--- a/src/lib/__tests__/edited-fields.test.ts
+++ b/src/lib/__tests__/edited-fields.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  INFERABLE_FIELDS,
+  diffInferableFields,
+} from "@/lib/edited-fields";
+
+describe("INFERABLE_FIELDS", () => {
+  it("contains the expected AI-inferable apartment fields", () => {
+    expect(INFERABLE_FIELDS).toEqual([
+      "name",
+      "address",
+      "sizeM2",
+      "numRooms",
+      "numBathrooms",
+      "numBalconies",
+      "hasWashingMachine",
+      "rentChf",
+      "listingUrl",
+      "summary",
+      "availableFrom",
+    ]);
+  });
+});
+
+describe("diffInferableFields", () => {
+  it("returns an empty array when all values match", () => {
+    const current = { name: "X", rentChf: 1500, sizeM2: 50 };
+    const incoming = { name: "X", rentChf: 1500, sizeM2: 50 };
+    expect(diffInferableFields(current, incoming)).toEqual([]);
+  });
+
+  it("returns the names of changed inferable fields", () => {
+    const current = { name: "X", rentChf: 1500 };
+    const incoming = { name: "Y", rentChf: 2000 };
+    const result = diffInferableFields(current, incoming);
+    expect(result.sort()).toEqual(["name", "rentChf"]);
+  });
+
+  it("ignores changes to fields outside the inferable list", () => {
+    const current = { name: "X", distanceBikeMin: 5 };
+    const incoming = { name: "X", distanceBikeMin: 10 };
+    expect(diffInferableFields(current, incoming)).toEqual([]);
+  });
+
+  it("treats null vs non-null as a change", () => {
+    const current = { rentChf: null };
+    const incoming = { rentChf: 1500 };
+    expect(diffInferableFields(current, incoming)).toEqual(["rentChf"]);
+  });
+});

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -34,7 +34,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(7);
+    expect(migrations.rows).toHaveLength(8);
   });
 
   it("adds listing_url to a legacy database missing the column", async () => {
@@ -66,7 +66,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(7);
+    expect(migrations.rows).toHaveLength(8);
   });
 
   it("reconciles a DB that already has has_washing_machine but no 0002 marker", async () => {
@@ -129,13 +129,13 @@ describe("applyMigrations", () => {
     // try to re-add has_washing_machine).
     await applyMigrations(client);
 
-    // 0002 recorded via reconcile + 0003, 0004, 0005, and 0006 run normally = 7 total
-    // (0000/0001 were seeded, 0002 stamped by reconcile, 0003+0004+0005+0006 by migrator).
+    // 0002 recorded via reconcile + 0003, 0004, 0005, 0006, and 0007 run normally = 8 total
+    // (0000/0001 were seeded, 0002 stamped by reconcile, 0003+0004+0005+0006+0007 by migrator).
     const rows = await client.execute({
       sql: "SELECT COUNT(*) as n FROM __drizzle_migrations",
       args: [],
     });
-    expect(Number(rows.rows[0].n)).toBe(7);
+    expect(Number(rows.rows[0].n)).toBe(8);
   });
 
   it("backfills the users table from distinct rating user_names", async () => {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -17,6 +17,7 @@ export const apartments = sqliteTable("apartments", {
   listingUrl: text("listing_url"),
   shortCode: text("short_code").unique(),
   rawExtractedData: text("raw_extracted_data"),
+  userEditedFields: text("user_edited_fields"),
   summary: text("summary"),
   availableFrom: text("available_from"),
   createdAt: integer("created_at", { mode: "timestamp" }).default(

--- a/src/lib/edited-fields.ts
+++ b/src/lib/edited-fields.ts
@@ -1,0 +1,26 @@
+export const INFERABLE_FIELDS = [
+  "name",
+  "address",
+  "sizeM2",
+  "numRooms",
+  "numBathrooms",
+  "numBalconies",
+  "hasWashingMachine",
+  "rentChf",
+  "listingUrl",
+  "summary",
+  "availableFrom",
+] as const;
+
+export type InferableField = (typeof INFERABLE_FIELDS)[number];
+
+export function diffInferableFields(
+  current: Record<string, unknown>,
+  incoming: Record<string, unknown>
+): InferableField[] {
+  const changed: InferableField[] = [];
+  for (const field of INFERABLE_FIELDS) {
+    if (current[field] !== incoming[field]) changed.push(field);
+  }
+  return changed;
+}


### PR DESCRIPTION
## Summary
- New `user_edited_fields` JSON-array column on apartments. PATCH diffs the body against the current row and unions changed AI-inferable fields into the column. Editing the form sets the bit; the AI is no longer allowed to overwrite that field on subsequent reprocesses.
- New `POST /api/apartments/[id]/reprocess` endpoint fetches the stored PDF, re-runs `extractApartmentData`, and only writes back fields not in the edited set.
- Detail page gets a "Reprocess" button (between Edit and Delete) with a confirm dialog. Disabled when there's no PDF on file.
- Errors from the AI flow through the same `classifyParsePdfError` route as the upload — quota / invalid-pdf / unknown branches are preserved.

## Test plan
- [x] `npm test` passes (5 helper tests + 3 integration tests, 254 total)
- [x] `npm run lint` clean
- [x] `npm run build` succeeds
- [ ] Vercel preview: edit one field on an apartment, click Reprocess, confirm the edited field stays while other AI fields refresh.

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)