### PR TITLE
fix: apply schema migrations on Vercel + reprocess relative-URL crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 3002",
     "build": "next build",
-    "vercel-build": "drizzle-kit migrate && next build",
+    "vercel-build": "node scripts/vercel-build.mjs",
     "start": "next start -p 3002",
     "lint": "eslint",
     "test": "vitest run",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,13 @@
   "scripts": {
     "dev": "next dev -p 3002",
     "build": "next build",
+    "vercel-build": "drizzle-kit migrate && next build",
     "start": "next start -p 3002",
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
     "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio"
   },

--- a/scripts/vercel-build.mjs
+++ b/scripts/vercel-build.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process";
+
+function run(cmd, args) {
+  const res = spawnSync(cmd, args, { stdio: "inherit", shell: false });
+  if (res.status !== 0) process.exit(res.status ?? 1);
+}
+
+if (process.env.TURSO_DATABASE_URL) {
+  console.log("[vercel-build] applying drizzle migrations to Turso");
+  run("npx", ["drizzle-kit", "migrate"]);
+} else {
+  console.log(
+    "[vercel-build] TURSO_DATABASE_URL not set; skipping drizzle migrations"
+  );
+}
+
+run("npx", ["next", "build"]);

--- a/src/app/api/apartments/[id]/reprocess/route.ts
+++ b/src/app/api/apartments/[id]/reprocess/route.ts
@@ -5,6 +5,7 @@ import { apartments } from "@/lib/db/schema";
 import { extractApartmentData } from "@/lib/parse-pdf";
 import { classifyParsePdfError } from "@/lib/parse-pdf-error";
 import { INFERABLE_FIELDS } from "@/lib/edited-fields";
+import { readStoredFile } from "@/lib/storage";
 
 export async function POST(
   _request: Request,
@@ -35,15 +36,13 @@ export async function POST(
 
     let pdfBase64: string;
     try {
-      const pdfRes = await fetch(apt.pdfUrl);
-      if (!pdfRes.ok) throw new Error(`Failed to fetch PDF (${pdfRes.status})`);
-      const buf = Buffer.from(await pdfRes.arrayBuffer());
+      const buf = await readStoredFile(apt.pdfUrl);
       pdfBase64 = buf.toString("base64");
     } catch (err) {
-      console.error("[reprocess] PDF fetch failed:", err);
+      console.error("[reprocess] PDF read failed:", err);
       return NextResponse.json(
         {
-          error: err instanceof Error ? err.message : "Failed to fetch PDF",
+          error: err instanceof Error ? err.message : "Failed to read PDF",
         },
         { status: 500 }
       );

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,5 +2,12 @@ export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
 
   const { runMigrations } = await import("@/lib/db/migrate");
-  await runMigrations();
+  try {
+    await runMigrations();
+  } catch (err) {
+    // Don't swallow — Next.js will otherwise log this only at debug level and
+    // we'd be flying blind, the way 0008 was missed in prod.
+    console.error("[instrumentation] runMigrations failed:", err);
+    throw err;
+  }
 }

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -235,8 +235,15 @@ async function migrateLocationsOfInterestBackfill(client: Client): Promise<void>
 export async function applyMigrations(client: Client): Promise<void> {
   await ensureListingUrlColumn(client);
   await reconcileHasWashingMachine(client);
-  const db = drizzle(client, { schema });
-  await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+  // On Vercel the `drizzle/` folder isn't reliably present in the serverless
+  // file trace, so SQL migrations are applied at build time via `drizzle-kit
+  // migrate` (see package.json `vercel-build`). Skip the runtime drizzle
+  // migrator when the folder is absent — the backfills below are idempotent
+  // and only need libsql, no fs.
+  if (fs.existsSync(path.join(MIGRATIONS_FOLDER, "meta", "_journal.json"))) {
+    const db = drizzle(client, { schema });
+    await migrate(db, { migrationsFolder: MIGRATIONS_FOLDER });
+  }
   await backfillShortCodes(client);
   await migrateLocationsOfInterestBackfill(client);
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -36,11 +36,7 @@ export async function readStoredFile(storedUrl: string): Promise<Buffer> {
     if (!result || result.statusCode !== 200) {
       throw new Error(`Blob not found: ${pathname}`);
     }
-    const chunks: Uint8Array[] = [];
-    for await (const chunk of result.stream as AsyncIterable<Uint8Array>) {
-      chunks.push(chunk);
-    }
-    return Buffer.concat(chunks);
+    return Buffer.from(await new Response(result.stream).arrayBuffer());
   }
 
   if (storedUrl.startsWith("/api/uploads/")) {

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,5 +1,5 @@
-import { put } from "@vercel/blob";
-import { writeFile, mkdir } from "fs/promises";
+import { put, get } from "@vercel/blob";
+import { writeFile, mkdir, readFile } from "fs/promises";
 import path from "path";
 
 const UPLOADS_DIR = path.join(process.cwd(), "uploads");
@@ -24,4 +24,31 @@ export async function uploadFile(
   const filePath = path.join(UPLOADS_DIR, filename);
   await writeFile(filePath, buffer);
   return `/api/uploads/${encodeURIComponent(filename)}`;
+}
+
+// Read a stored PDF back from the URL produced by `uploadFile`. Goes directly
+// to blob/disk — server-side fetch() can't resolve the relative `/api/...`
+// URLs we hand to clients.
+export async function readStoredFile(storedUrl: string): Promise<Buffer> {
+  if (storedUrl.startsWith("/api/pdf/")) {
+    const pathname = storedUrl.slice("/api/pdf/".length);
+    const result = await get(pathname, { access: "private" });
+    if (!result || result.statusCode !== 200) {
+      throw new Error(`Blob not found: ${pathname}`);
+    }
+    const chunks: Uint8Array[] = [];
+    for await (const chunk of result.stream as AsyncIterable<Uint8Array>) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks);
+  }
+
+  if (storedUrl.startsWith("/api/uploads/")) {
+    const filename = decodeURIComponent(
+      storedUrl.slice("/api/uploads/".length)
+    );
+    return readFile(path.join(UPLOADS_DIR, filename));
+  }
+
+  throw new Error(`Unrecognized stored URL: ${storedUrl}`);
 }


### PR DESCRIPTION
## Summary
- Move SQL migrations to a `vercel-build` step (`drizzle-kit migrate && next build`) so schema changes reach Turso before new function code goes live. Migration 0008 didn't apply on the previous deploy because the runtime file trace on Vercel doesn't reliably include `drizzle/`, and the instrumentation-hook drizzle migrator silently failed — `locations_of_interest` and `apartment_distances` were missing in prod.
- Make the runtime migrator tolerate a missing `drizzle/` folder. Custom backfills still run (they only need libsql, no fs).
- Log instrumentation failures loudly so the next regression isn't silent.
- Fix `/api/apartments/[id]/reprocess` — it was calling `fetch(apt.pdfUrl)` with a relative `/api/pdf/...` URL, which Node fetch can't resolve. Added `readStoredFile()` in `src/lib/storage.ts` that reads directly from Vercel Blob (cloud) or disk (local), and switched the route to use it.

## Verification needed
- Confirm `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` are enabled for the **Build** environment in Vercel (not just Runtime), otherwise `drizzle-kit migrate` will fall back to the local sqlite path in `drizzle.config.ts` and migrate nothing.

## Test plan
- [x] `npm test` — 258 passing
- [x] `npm run lint` — clean
- [ ] Verify next deploy logs show `drizzle-kit migrate` running during build
- [ ] Settings page loads without 500
- [ ] Reprocess action on an apartment with a stored PDF succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)