### PR TITLE
feat: recompute distances on reprocess when address changes

### DIFF
--- a/src/app/api/apartments/[id]/reprocess/route.ts
+++ b/src/app/api/apartments/[id]/reprocess/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db";
-import { apartments } from "@/lib/db/schema";
+import { apartments, apartmentDistances } from "@/lib/db/schema";
 import { extractApartmentData } from "@/lib/parse-pdf";
 import { classifyParsePdfError } from "@/lib/parse-pdf-error";
 import { INFERABLE_FIELDS } from "@/lib/edited-fields";
 import { readStoredFile } from "@/lib/storage";
+import { listLocations } from "@/lib/locations";
+import { calculateDistance } from "@/lib/distance";
 
 export async function POST(
   _request: Request,
@@ -94,7 +96,40 @@ export async function POST(
       .where(eq(apartments.id, apartmentId))
       .returning();
 
-    return NextResponse.json(result[0]);
+    const updated = result[0];
+
+    // Re-compute distances when the address actually changed. Delete then
+    // re-insert per location, mirroring the POST /apartments flow.
+    const addressChanged =
+      "address" in updates && updates.address !== apt.address;
+    if (addressChanged && updated.address) {
+      await db
+        .delete(apartmentDistances)
+        .where(eq(apartmentDistances.apartmentId, apartmentId));
+
+      const locations = await listLocations();
+      for (const loc of locations) {
+        try {
+          const { bikeMinutes, transitMinutes } = await calculateDistance(
+            loc.address,
+            updated.address
+          );
+          await db.insert(apartmentDistances).values({
+            apartmentId,
+            locationId: loc.id,
+            bikeMin: bikeMinutes,
+            transitMin: transitMinutes,
+          });
+        } catch (err) {
+          console.error(
+            `[reprocess] distance calc failed apt=${apartmentId} loc=${loc.id}:`,
+            err
+          );
+        }
+      }
+    }
+
+    return NextResponse.json(updated);
   } catch (error) {
     console.error("[apartments/id/reprocess:POST] Error:", error);
     return NextResponse.json(


### PR DESCRIPTION
## Summary
- Reprocess already updates parsed inferable fields including \`address\`. Until now, \`apartment_distances\` rows were left untouched, so a corrected address left stale bike/transit times against every location of interest.
- After the update, if the address actually changed, this PR deletes the apartment's distance rows and recomputes them against every location, mirroring the POST /apartments flow.
- No-op if the address didn't change or the new address is null.

## Test plan
- [x] \`npm test\` — 258 passing
- [x] \`npm run lint\` — clean
- [ ] Reprocess an apartment whose PDF address was misparsed → distances refresh
- [ ] Reprocess an apartment with no address change → distances unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)