### PR TITLE
feat: detect 404'd listings and label apartments as gone (#93)

### DIFF
--- a/drizzle/0009_violet_groot.sql
+++ b/drizzle/0009_violet_groot.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `apartments` ADD `listing_gone` integer DEFAULT false;--> statement-breakpoint
+ALTER TABLE `apartments` ADD `listing_checked_at` integer;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,517 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "0afce233-a06e-4460-841f-bd7bc4cae609",
+  "prevId": "f9d8b2c1-1ab4-4e3c-a5b9-9f8e3d7c1b2a",
+  "tables": {
+    "apartment_distances": {
+      "name": "apartment_distances",
+      "columns": {
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location_id": {
+          "name": "location_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "bike_min": {
+          "name": "bike_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "transit_min": {
+          "name": "transit_min",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "apartment_distances_apartment_id_apartments_id_fk": {
+          "name": "apartment_distances_apartment_id_apartments_id_fk",
+          "tableFrom": "apartment_distances",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "apartment_distances_location_id_locations_of_interest_id_fk": {
+          "name": "apartment_distances_location_id_locations_of_interest_id_fk",
+          "tableFrom": "apartment_distances",
+          "tableTo": "locations_of_interest",
+          "columnsFrom": [
+            "location_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "apartment_distances_apartment_id_location_id_pk": {
+          "columns": [
+            "apartment_id",
+            "location_id"
+          ],
+          "name": "apartment_distances_apartment_id_location_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "apartments": {
+      "name": "apartments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "size_m2": {
+          "name": "size_m2",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_rooms": {
+          "name": "num_rooms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_bathrooms": {
+          "name": "num_bathrooms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "num_balconies": {
+          "name": "num_balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "has_washing_machine": {
+          "name": "has_washing_machine",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rent_chf": {
+          "name": "rent_chf",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pdf_url": {
+          "name": "pdf_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_url": {
+          "name": "listing_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "short_code": {
+          "name": "short_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_extracted_data": {
+          "name": "raw_extracted_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_edited_fields": {
+          "name": "user_edited_fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "available_from": {
+          "name": "available_from",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listing_gone": {
+          "name": "listing_gone",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "listing_checked_at": {
+          "name": "listing_checked_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "apartments_short_code_unique": {
+          "name": "apartments_short_code_unique",
+          "columns": [
+            "short_code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "api_usage": {
+      "name": "api_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "locations_of_interest": {
+      "name": "locations_of_interest",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "address": {
+          "name": "address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ratings": {
+      "name": "ratings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "apartment_id": {
+          "name": "apartment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kitchen": {
+          "name": "kitchen",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "balconies": {
+          "name": "balconies",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "location": {
+          "name": "location",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "floorplan": {
+          "name": "floorplan",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "overall_feeling": {
+          "name": "overall_feeling",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "ratings_apartment_user_idx": {
+          "name": "ratings_apartment_user_idx",
+          "columns": [
+            "apartment_id",
+            "user_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "ratings_apartment_id_apartments_id_fk": {
+          "name": "ratings_apartment_id_apartments_id_fk",
+          "tableFrom": "ratings",
+          "tableTo": "apartments",
+          "columnsFrom": [
+            "apartment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1777222800000,
       "tag": "0008_locations_of_interest",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1777318431337,
+      "tag": "0009_violet_groot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/apartments/__tests__/apartments-page.test.tsx
+++ b/src/app/apartments/__tests__/apartments-page.test.tsx
@@ -412,3 +412,31 @@ describe("Apartments page — search", () => {
     expect(screen.queryByText("Seeblick 7")).toBeNull();
   });
 });
+
+describe("Apartments page — listing gone badge", () => {
+  it("renders a Gone badge for apartments with listingGone=true", async () => {
+    const goneApartments = [
+      { ...APARTMENTS[0], listingGone: true },
+      { ...APARTMENTS[1], listingGone: false },
+      { ...APARTMENTS[2], listingGone: null },
+    ];
+    vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url === "/api/locations") {
+        return { ok: true, json: () => Promise.resolve([]) } as Response;
+      }
+      return {
+        ok: true,
+        json: () => Promise.resolve(goneApartments),
+      } as Response;
+    });
+
+    render(<ApartmentsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+
+    const goneBadges = screen.getAllByText("Gone");
+    expect(goneBadges).toHaveLength(1);
+  });
+});

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -10,6 +10,7 @@ import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
 import { AddressLink } from "@/components/address-link";
 import {
+  AlertTriangle,
   ArrowDown,
   ArrowUp,
   Building2,
@@ -67,6 +68,7 @@ interface ApartmentSummary {
   avgOverall: string | null;
   myRating: number | null;
   createdAt: string | null;
+  listingGone: boolean | null;
 }
 
 type ViewMode = "grid" | "list";
@@ -144,6 +146,20 @@ export default function ApartmentsPage() {
           setLocations((await locRes.json()) as LocationOfInterest[]);
         }
         setLoading(false);
+
+        try {
+          const checkRes = await fetch("/api/apartments/check-listings", {
+            method: "POST",
+          });
+          if (checkRes.ok) {
+            const refreshed = await fetch(url);
+            if (refreshed.ok) {
+              setApartments((await refreshed.json()) as ApartmentSummary[]);
+            }
+          }
+        } catch {
+          // background check failure is non-fatal
+        }
       } catch (err) {
         setError({
           headline: "Couldn't load apartments",
@@ -315,7 +331,10 @@ export default function ApartmentsPage() {
                 <CardContent className="space-y-2 p-4">
                   <div className="flex items-start justify-between gap-2">
                     <ShortCode code={apt.shortCode} size="md" />
-                    <RatedBadge myRating={apt.myRating} />
+                    <div className="flex items-center gap-1.5">
+                      {apt.listingGone && <GoneBadge />}
+                      <RatedBadge myRating={apt.myRating} />
+                    </div>
                   </div>
                   <div className="flex items-start justify-between">
                     <h3 className="font-medium leading-tight">{apt.name}</h3>
@@ -385,7 +404,8 @@ export default function ApartmentsPage() {
                   <Badge variant="secondary">{apt.numRooms} rm</Badge>
                 )}
               </div>
-              <div className="shrink-0">
+              <div className="flex shrink-0 items-center gap-1.5">
+                {apt.listingGone && <GoneBadge />}
                 <RatedBadge myRating={apt.myRating} />
               </div>
               {apt.avgOverall && (
@@ -400,6 +420,18 @@ export default function ApartmentsPage() {
         </div>
       )}
     </div>
+  );
+}
+
+function GoneBadge() {
+  return (
+    <Badge
+      variant="secondary"
+      className="gap-1 border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300"
+    >
+      <AlertTriangle className="h-3 w-3" />
+      Gone
+    </Badge>
   );
 }
 

--- a/src/app/api/apartments/check-listings/route.ts
+++ b/src/app/api/apartments/check-listings/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { apartments } from "@/lib/db/schema";
+import { eq, isNotNull } from "drizzle-orm";
+import { checkListings } from "@/lib/listing-status";
+
+export async function POST() {
+  try {
+    const rows = await db
+      .select({ id: apartments.id, listingUrl: apartments.listingUrl })
+      .from(apartments)
+      .where(isNotNull(apartments.listingUrl));
+
+    const checkable = rows.filter(
+      (r): r is { id: number; listingUrl: string } =>
+        typeof r.listingUrl === "string" && r.listingUrl.trim().length > 0
+    );
+
+    const results = await checkListings(checkable);
+    const checkedAt = new Date();
+
+    let updated = 0;
+    for (const r of results) {
+      if (r.gone === null) continue;
+      await db
+        .update(apartments)
+        .set({ listingGone: r.gone, listingCheckedAt: checkedAt })
+        .where(eq(apartments.id, r.apartmentId));
+      updated++;
+    }
+
+    return NextResponse.json({
+      checked: results.length,
+      updated,
+      results,
+    });
+  } catch (error) {
+    console.error("[apartments/check-listings:POST] Error:", error);
+    return NextResponse.json(
+      {
+        error:
+          error instanceof Error ? error.message : "Failed to check listings",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/apartments/route.ts
+++ b/src/app/api/apartments/route.ts
@@ -42,6 +42,8 @@ export async function GET() {
         listingUrl: apartments.listingUrl,
         summary: apartments.summary,
         availableFrom: apartments.availableFrom,
+        listingGone: apartments.listingGone,
+        listingCheckedAt: apartments.listingCheckedAt,
         shortCode: apartments.shortCode,
         createdAt: apartments.createdAt,
         avgKitchen: avg(ratings.kitchen),

--- a/src/lib/__tests__/listing-status.test.ts
+++ b/src/lib/__tests__/listing-status.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from "vitest";
+import { checkListingUrl, checkListings } from "../listing-status";
+
+function makeFetch(map: Record<string, number | "throw">) {
+  return vi.fn(async (url: string | URL) => {
+    const key = url.toString();
+    const value = map[key];
+    if (value === "throw") throw new Error("network");
+    return { status: value } as Response;
+  }) as unknown as typeof fetch;
+}
+
+describe("checkListingUrl", () => {
+  it("returns true on 404", async () => {
+    const fetchImpl = makeFetch({ "https://x/listing": 404 });
+    expect(await checkListingUrl("https://x/listing", fetchImpl)).toBe(true);
+  });
+
+  it("returns true on 410", async () => {
+    const fetchImpl = makeFetch({ "https://x/listing": 410 });
+    expect(await checkListingUrl("https://x/listing", fetchImpl)).toBe(true);
+  });
+
+  it("returns false on 200", async () => {
+    const fetchImpl = makeFetch({ "https://x/listing": 200 });
+    expect(await checkListingUrl("https://x/listing", fetchImpl)).toBe(false);
+  });
+
+  it("returns null on network error", async () => {
+    const fetchImpl = makeFetch({ "https://x/listing": "throw" });
+    expect(await checkListingUrl("https://x/listing", fetchImpl)).toBe(null);
+  });
+
+  it("returns null on 500", async () => {
+    const fetchImpl = makeFetch({ "https://x/listing": 500 });
+    expect(await checkListingUrl("https://x/listing", fetchImpl)).toBe(null);
+  });
+});
+
+describe("checkListings", () => {
+  it("checks each apartment and returns one result per item", async () => {
+    const fetchImpl = makeFetch({
+      "https://a": 200,
+      "https://b": 404,
+      "https://c": 500,
+    });
+    const items = [
+      { id: 1, listingUrl: "https://a" },
+      { id: 2, listingUrl: "https://b" },
+      { id: 3, listingUrl: "https://c" },
+    ];
+    const results = await checkListings(items, fetchImpl, 2);
+    const byId = new Map(results.map((r) => [r.apartmentId, r.gone]));
+    expect(byId.get(1)).toBe(false);
+    expect(byId.get(2)).toBe(true);
+    expect(byId.get(3)).toBe(null);
+  });
+
+  it("handles empty input", async () => {
+    const fetchImpl = vi.fn() as unknown as typeof fetch;
+    const results = await checkListings([], fetchImpl);
+    expect(results).toEqual([]);
+  });
+});

--- a/src/lib/db/__tests__/migrate.test.ts
+++ b/src/lib/db/__tests__/migrate.test.ts
@@ -51,7 +51,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(9);
+    expect(migrations.rows).toHaveLength(10);
   });
 
   it("adds listing_url to a legacy database missing the column", async () => {
@@ -83,7 +83,7 @@ describe("applyMigrations", () => {
       sql: "SELECT hash FROM __drizzle_migrations",
       args: [],
     });
-    expect(migrations.rows).toHaveLength(9);
+    expect(migrations.rows).toHaveLength(10);
   });
 
   it("reconciles a DB that already has has_washing_machine but no 0002 marker", async () => {
@@ -146,13 +146,13 @@ describe("applyMigrations", () => {
     // try to re-add has_washing_machine).
     await applyMigrations(client);
 
-    // 0002 recorded via reconcile + 0003..0008 run normally = 9 total
-    // (0000/0001 were seeded, 0002 stamped by reconcile, 0003+0004+0005+0006+0007+0008 by migrator).
+    // 0002 recorded via reconcile + 0003..0009 run normally = 10 total
+    // (0000/0001 were seeded, 0002 stamped by reconcile, 0003..0009 by migrator).
     const rows = await client.execute({
       sql: "SELECT COUNT(*) as n FROM __drizzle_migrations",
       args: [],
     });
-    expect(Number(rows.rows[0].n)).toBe(9);
+    expect(Number(rows.rows[0].n)).toBe(10);
   });
 
   it("backfills the users table from distinct rating user_names", async () => {

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -25,6 +25,8 @@ export const apartments = sqliteTable("apartments", {
   userEditedFields: text("user_edited_fields"),
   summary: text("summary"),
   availableFrom: text("available_from"),
+  listingGone: integer("listing_gone", { mode: "boolean" }).default(false),
+  listingCheckedAt: integer("listing_checked_at", { mode: "timestamp" }),
   createdAt: integer("created_at", { mode: "timestamp" }).default(
     sql`(unixepoch())`
   ),

--- a/src/lib/listing-status.ts
+++ b/src/lib/listing-status.ts
@@ -1,0 +1,61 @@
+export interface ListingCheckResult {
+  apartmentId: number;
+  gone: boolean | null;
+}
+
+const REQUEST_TIMEOUT_MS = 10_000;
+const CONCURRENCY = 5;
+
+export async function checkListingUrl(
+  url: string,
+  fetchImpl: typeof fetch = fetch
+): Promise<boolean | null> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    let res: Response;
+    try {
+      res = await fetchImpl(url, {
+        method: "HEAD",
+        redirect: "follow",
+        signal: controller.signal,
+      });
+    } catch {
+      res = await fetchImpl(url, {
+        method: "GET",
+        redirect: "follow",
+        signal: controller.signal,
+      });
+    }
+    if (res.status === 404 || res.status === 410) return true;
+    if (res.status >= 200 && res.status < 400) return false;
+    return null;
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function checkListings<T extends { id: number; listingUrl: string }>(
+  items: T[],
+  fetchImpl: typeof fetch = fetch,
+  concurrency: number = CONCURRENCY
+): Promise<ListingCheckResult[]> {
+  const results: ListingCheckResult[] = [];
+  let cursor = 0;
+  async function worker() {
+    while (cursor < items.length) {
+      const idx = cursor++;
+      const item = items[idx];
+      const gone = await checkListingUrl(item.listingUrl, fetchImpl);
+      results.push({ apartmentId: item.id, gone });
+    }
+  }
+  const workers = Array.from(
+    { length: Math.min(concurrency, items.length) },
+    () => worker()
+  );
+  await Promise.all(workers);
+  return results;
+}


### PR DESCRIPTION
## Summary
- Adds `listing_gone` + `listing_checked_at` columns and a migration.
- New `POST /api/apartments/check-listings` endpoint probes each apartment's `listingUrl` (HEAD with GET fallback, 10s timeout, concurrency 5) and persists the result. Only a real 404/410 marks an apartment as gone; network errors / 5xx are treated as unknown so transient outages don't mislabel apartments.
- Apartments page fires the check in the background after the initial load and refetches on success. A red "Gone" badge renders in both grid and list views.

## Test plan
- [x] `npm test` — 266 tests pass, including new unit tests for `checkListingUrl` / `checkListings` and a component test that verifies the Gone badge.
- [x] Migration test count updated (9 → 10).
- [ ] Manual: load /apartments with a known-gone listing URL and confirm the badge appears after refetch.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)