### PR TITLE
docs: document LOCAL_DB_URL and DISABLE_SECURE_COOKIES

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,13 @@
 # Shared app password
 APP_PASSWORD=
 
+# Override the local SQLite file path (defaults to file:./data/flatpare.db).
+# Tests set this to a separate file so they don't clobber the dev database.
+# LOCAL_DB_URL=
+
+# Set to bypass the Secure cookie flag in dev (e.g. when serving over plain HTTP).
+# DISABLE_SECURE_COOKIES=
+
 # --- Cloud mode (Vercel deployment) ---
 
 # Turso database (omit for local SQLite)


### PR DESCRIPTION
## Summary
- Adds `LOCAL_DB_URL` and `DISABLE_SECURE_COOKIES` to `.env.example` so the file matches what the code actually reads.

Closes #98

## Test plan
- [x] `grep -roh 'process\.env\.[A-Z_]*' src/ scripts/ | sort -u` matches `.env.example` (modulo Vercel/Node conventional vars).

🤖 Generated with [Claude Code](https://claude.com/claude-code)