### PR TITLE
chore: bump Node runtime + types to 24 LTS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
 
       - run: npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:24-alpine AS base
 
 # --- Dependencies ---
 FROM base AS deps

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Subsequent pushes to `main` deploy automatically.
 <details>
 <summary><strong>Cloud mode — run locally against Turso + Gemini</strong></summary>
 
-**Prerequisites:** Node.js 20+, a [Turso](https://turso.tech) account, a [Google AI Studio](https://aistudio.google.com) API key, optionally a [Google Maps](https://console.cloud.google.com) key.
+**Prerequisites:** Node.js 24+ (LTS), a [Turso](https://turso.tech) account, a [Google AI Studio](https://aistudio.google.com) API key, optionally a [Google Maps](https://console.cloud.google.com) key.
 
 ```bash
 git clone <repo-url>

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
         "@types/leaflet": "^1.9.21",
-        "@types/node": "^20",
+        "@types/node": "^24.12.2",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "drizzle-kit": "^0.31.10",
@@ -4243,12 +4243,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "24.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz",
+      "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/react": {
@@ -13591,9 +13591,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/leaflet": "^1.9.21",
-    "@types/node": "^20",
+    "@types/node": "^24.12.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "drizzle-kit": "^0.31.10",

--- a/src/app/api/__tests__/parse-pdf.test.ts
+++ b/src/app/api/__tests__/parse-pdf.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 vi.mock("@/lib/storage", () => ({


### PR DESCRIPTION
## Summary
Align dev / CI / Docker with Vercel's current default runtime (Node 24 LTS):

- \`Dockerfile\`: \`node:20-alpine\` → \`node:24-alpine\`
- \`.github/workflows/test.yml\`: setup-node \`20\` → \`24\`
- \`README.md\`: prereq \`Node.js 20+\` → \`Node.js 24+ (LTS)\`
- \`@types/node\`: \`^20\` → \`^24.12.2\`

ESLint 10 and TypeScript 6 from #105 are deferred (eslint 10 blocked by an old eslint-plugin-react inside eslint-config-next; TS 6 deferred behind a pre-existing TS error). See comments on #105.

Refs #105

## Test plan
- [x] \`npm test\` → 283 / 283 passing.
- [x] \`npm run build\` → clean.
- [x] \`docker build .\` with \`node:24-alpine\` → success, container boots Next.js.

🤖 Generated with [Claude Code](https://claude.com/claude-code)