### PR TITLE
docs: refresh PRDs to v3.0 to match current implementation

### DIFF
--- a/prds/ApartmentTracker_MultiUser_Design.md
+++ b/prds/ApartmentTracker_MultiUser_Design.md
@@ -1,120 +1,190 @@
 # Flatpare - Technical Specification
 
-**Version:** v2.0
-**Date:** April 2026
+**Version:** v3.0
+**Date:** May 2026
 
 ---
 
 ## 1. Purpose
 
-This document describes the technical implementation details for Flatpare: database schema, API routes, PDF parsing strategy, authentication flow, and component architecture.
+This document describes the technical implementation details for Flatpare: database schema, API routes, PDF parsing strategy, authentication flow, and component architecture. The current schema, routes, and file layout are the source of truth — see `src/lib/db/schema.ts` and `src/app/api/`.
 
 ---
 
-## 2. Database Schema (Drizzle ORM + Turso/SQLite)
+## 2. Database Schema (Drizzle ORM + libSQL/SQLite)
 
-### 2.1 Apartments Table
+Six tables. Source: `src/lib/db/schema.ts`.
+
+### 2.1 `apartments`
 
 ```typescript
-export const apartments = sqliteTable('apartments', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  name: text('name').notNull(),
-  address: text('address'),
-  sizeM2: real('size_m2'),
-  numRooms: real('num_rooms'),
-  numBathrooms: integer('num_bathrooms'),
-  numBalconies: integer('num_balconies'),
-  rentChf: real('rent_chf'),
-  distanceBikeMin: integer('distance_bike_min'),
-  distanceTransitMin: integer('distance_transit_min'),
-  pdfUrl: text('pdf_url'),
-  rawExtractedData: text('raw_extracted_data', { mode: 'json' }),
-  createdAt: integer('created_at', { mode: 'timestamp' }).defaultNow(),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).defaultNow(),
+export const apartments = sqliteTable("apartments", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  name: text("name").notNull(),
+  address: text("address"),
+  sizeM2: real("size_m2"),
+  numRooms: real("num_rooms"),
+  numBathrooms: integer("num_bathrooms"),
+  numBalconies: integer("num_balconies"),
+  hasWashingMachine: integer("has_washing_machine", { mode: "boolean" }),
+  rentChf: real("rent_chf"),
+  pdfUrl: text("pdf_url"),
+  listingUrl: text("listing_url"),
+  shortCode: text("short_code").unique(),
+  rawExtractedData: text("raw_extracted_data"),
+  userEditedFields: text("user_edited_fields"),
+  summary: text("summary"),
+  availableFrom: text("available_from"),
+  listingGone: integer("listing_gone", { mode: "boolean" }).default(false),
+  listingCheckedAt: integer("listing_checked_at", { mode: "timestamp" }),
+  latitude: real("latitude"),
+  longitude: real("longitude"),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
 });
 ```
 
-### 2.2 Ratings Table
+### 2.2 `ratings`
 
 ```typescript
-export const ratings = sqliteTable('ratings', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  apartmentId: integer('apartment_id').notNull().references(() => apartments.id, { onDelete: 'cascade' }),
-  userName: text('user_name').notNull(),
-  kitchen: integer('kitchen').default(0),
-  balconies: integer('balconies').default(0),
-  location: integer('location').default(0),
-  floorplan: integer('floorplan').default(0),
-  overallFeeling: integer('overall_feeling').default(0),
-  comment: text('comment').default(''),
-  createdAt: integer('created_at', { mode: 'timestamp' }).defaultNow(),
-  updatedAt: integer('updated_at', { mode: 'timestamp' }).defaultNow(),
+export const ratings = sqliteTable("ratings", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  apartmentId: integer("apartment_id").notNull()
+    .references(() => apartments.id, { onDelete: "cascade" }),
+  userName: text("user_name").notNull(),
+  kitchen: integer("kitchen").default(0),
+  balconies: integer("balconies").default(0),
+  location: integer("location").default(0),
+  floorplan: integer("floorplan").default(0),
+  overallFeeling: integer("overall_feeling").default(0),
+  comment: text("comment").default(""),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
+}, (table) => [
+  uniqueIndex("ratings_apartment_user_idx").on(table.apartmentId, table.userName),
+]);
+```
+
+### 2.3 `users`
+
+```typescript
+export const users = sqliteTable("users", {
+  name: text("name").primaryKey().notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
 });
 ```
 
-### 2.3 Constraints
+The user list backs the display-name picker on the add-user page.
 
-- One rating per (apartment_id, user_name) pair — enforced via unique index
-- Ratings cascade-delete when an apartment is deleted
-- Star values: 0 = unrated, 1-5 = rated
+### 2.4 `api_usage`
+
+```typescript
+export const apiUsage = sqliteTable("api_usage", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  service: text("service").notNull(),     // e.g. "gemini", "google-maps"
+  operation: text("operation").notNull(),
+  inputTokens: integer("input_tokens"),
+  outputTokens: integer("output_tokens"),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
+});
+```
+
+Powers the `/costs` page.
+
+### 2.5 `locations_of_interest`
+
+```typescript
+export const locationsOfInterest = sqliteTable("locations_of_interest", {
+  id: integer("id").primaryKey({ autoIncrement: true }),
+  label: text("label").notNull(),
+  icon: text("icon").notNull(),
+  address: text("address").notNull(),
+  sortOrder: integer("sort_order").notNull(),
+  latitude: real("latitude"),
+  longitude: real("longitude"),
+  createdAt: integer("created_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
+});
+```
+
+User-managed reference points for distance calculations.
+
+### 2.6 `apartment_distances`
+
+```typescript
+export const apartmentDistances = sqliteTable("apartment_distances", {
+  apartmentId: integer("apartment_id").notNull()
+    .references(() => apartments.id, { onDelete: "cascade" }),
+  locationId: integer("location_id").notNull()
+    .references(() => locationsOfInterest.id, { onDelete: "cascade" }),
+  bikeMin: integer("bike_min"),
+  transitMin: integer("transit_min"),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).default(sql`(unixepoch())`),
+}, (table) => [
+  primaryKey({ columns: [table.apartmentId, table.locationId] }),
+]);
+```
+
+Composite primary key: one row per (apartment, location).
+
+### 2.7 Constraints
+
+- One rating per `(apartmentId, userName)` — unique index.
+- Ratings cascade-delete when an apartment is deleted.
+- Apartment distances cascade-delete when either side is deleted.
+- Star values: `0` = unrated, `1-5` = rated.
 
 ---
 
 ## 3. API Routes
 
+App Router route handlers under `src/app/api/`.
+
 ### 3.1 Authentication
 
-**`POST /api/auth`**
-- Body: `{ password: string }`
-- Validates against `APP_PASSWORD` env var
-- On success: sets HTTP-only cookie with session token, returns `{ success: true }`
-- On failure: returns 401
-
-**`POST /api/auth/name`**
-- Body: `{ displayName: string }`
-- Sets display name in cookie
-- Returns `{ success: true }`
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `POST` | `/api/auth` | Verify `APP_PASSWORD`, set HTTP-only auth cookie |
+| `POST` | `/api/auth/name` | Set display-name cookie |
+| `GET` / `POST` | `/api/auth/users` | List / create users |
+| `DELETE` | `/api/auth/users/[name]` | Remove a user |
 
 ### 3.2 Apartments
 
-**`GET /api/apartments`**
-- Returns all apartments with aggregated average ratings
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` / `POST` | `/api/apartments` | List with avg ratings / create |
+| `GET` / `PATCH` / `DELETE` | `/api/apartments/[id]` | Read / update / delete (cascades) |
+| `POST` | `/api/apartments/[id]/ratings` | Upsert rating for current user |
+| `POST` | `/api/apartments/[id]/reprocess` | Re-run AI extraction; preserves human-edited fields |
+| `POST` | `/api/apartments/check-listings` | Probe listing URLs and mark expired ones |
 
-**`POST /api/apartments`**
-- Body: apartment fields (from parsed PDF or manual entry)
-- Creates apartment record
-- Returns created apartment
+### 3.3 PDF Parsing & Files
 
-**`GET /api/apartments/[id]`**
-- Returns single apartment with all ratings
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `POST` | `/api/parse-pdf` | Direct upload (≤ 4.5 MB), store, run extraction |
+| `GET` / `POST` | `/api/parse-pdf/upload-token` | Issue Vercel Blob client-upload tokens for large PDFs |
+| `GET` | `/api/pdf/[...path]` | Authenticated PDF streaming |
+| `GET` | `/api/uploads/[...path]` | Authenticated raw upload streaming |
 
-**`PATCH /api/apartments/[id]`**
-- Updates apartment fields (for manual corrections)
+### 3.4 Locations & Distance
 
-**`DELETE /api/apartments/[id]`**
-- Deletes apartment and cascading ratings
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` / `POST` | `/api/locations` | List / create locations of interest |
+| `GET` / `PUT` / `DELETE` | `/api/locations/[id]` | Read / update / delete a location |
+| `POST` | `/api/locations/[id]/move` | Reorder by adjusting sort_order |
+| `POST` | `/api/geocode/backfill` | Geocode apartments missing lat/lng |
+| `POST` | `/api/settings/recompute-distances` | Recompute all per-location distances |
 
-### 3.3 Ratings
+There is **no** `POST /api/distance` endpoint. Distance calculation is invoked indirectly via the recompute and backfill routes; the underlying logic lives in `src/lib/distance.ts` and `src/lib/geocode.ts`.
 
-**`POST /api/apartments/[id]/ratings`**
-- Body: `{ kitchen, balconies, location, floorplan, overallFeeling, comment }`
-- Creates or updates rating for current user on this apartment (upsert)
+### 3.5 Costs
 
-### 3.4 PDF Parsing
-
-**`POST /api/parse-pdf`**
-- Receives PDF file upload
-- Uploads to Vercel Blob
-- Converts PDF pages to images
-- Sends to vision model via Vercel AI SDK with structured output schema
-- Returns extracted apartment data + blob URL
-
-### 3.5 Distance
-
-**`POST /api/distance`**
-- Body: `{ address: string }`
-- Calls Google Maps Distance Matrix API for bike + transit from Basel SBB
-- Returns `{ bikeMinutes: number, transitMinutes: number }`
+| Method | Endpoint | Purpose |
+|--------|----------|---------|
+| `GET` | `/api/costs` | API usage stats and estimated costs |
 
 ---
 
@@ -122,36 +192,30 @@ export const ratings = sqliteTable('ratings', {
 
 ### 4.1 Approach
 
-1. Accept PDF upload via multipart form data
-2. Store PDF in Vercel Blob
-3. Convert PDF pages to images (using pdf.js or similar)
-4. Send images to a vision-capable model via Vercel AI SDK
-5. Use structured output (JSON schema) to extract:
-   - Listing title / name
-   - Address
-   - Size in m2
-   - Number of rooms
-   - Number of bathrooms
-   - Number of balconies
-   - Monthly rent (CHF)
-   - Any mentioned travel distances
-6. Return structured data for user review
+1. Accept a PDF file. Small PDFs come through `/api/parse-pdf` directly; large ones are uploaded by the browser straight to Vercel Blob using a token from `/api/parse-pdf/upload-token`, then the route is called with the resulting blob URL.
+2. Store the PDF in Vercel Blob (cloud) or `./uploads/` (local).
+3. Send the **PDF bytes** as a Vercel AI SDK `file` content block to Google Gemini (`gemini-2.5-flash`) with a structured-output Zod schema. (No PDF→image conversion; Gemini accepts PDFs natively.)
+4. Apply post-processing (e.g. detect "shared laundry" phrases that should override `hasWashingMachine`).
+5. Return structured data plus blob URL for the upload form to display.
 
 ### 4.2 Prompt Design
 
-The extraction prompt must:
-- Handle both German and English listing text
-- Extract numeric values from text like "3.5 Zimmer" or "85 m2"
-- Return `null` for fields that cannot be determined
-- Handle multiple PDF pages (listing details may span pages)
+The schema and prompt (in `src/lib/parse-pdf.ts`) cover:
+
+- Bilingual listings (German + English).
+- Numeric extraction from phrases like "3.5 Zimmer" or "85 m²".
+- ISO date normalization for `availableFrom` (e.g. `Bezugstermin: 01.05.2026` → `2026-05-01`); `null` for "ab sofort".
+- A short `summary` field describing the apartment.
+- An evidence snippet for the laundry field used to disambiguate shared vs. in-unit laundry.
+- `null` for any field that cannot be determined.
 
 ### 4.3 Model Selection
 
-Use Vercel AI SDK which allows easy provider switching. Recommended initial providers:
-- Google Gemini (good multilingual + vision support)
-- OpenAI GPT-4o (strong structured output)
+Currently fixed to Google Gemini (`gemini-2.5-flash`) when `GOOGLE_GENERATIVE_AI_API_KEY` is set; otherwise extraction is skipped and the user enters data manually. The Vercel AI SDK abstraction makes swapping providers straightforward.
 
-The provider is configured via environment variable, making it easy to switch.
+### 4.4 Re-extraction
+
+`POST /api/apartments/[id]/reprocess` re-runs extraction on the stored PDF. Fields the user has edited (tracked in `userEditedFields`) are preserved; AI-only fields are refreshed.
 
 ---
 
@@ -160,87 +224,96 @@ The provider is configured via environment variable, making it easy to switch.
 ### 5.1 Password Gate
 
 ```
-User visits / -> Check cookie -> No auth cookie?
-  -> Show password screen
-  -> User enters password
-  -> POST /api/auth
-  -> Success? Set HTTP-only cookie + redirect to name prompt
-  -> Name entered? Set name cookie + redirect to /apartments
+User visits / -> proxy.ts checks auth cookie
+  No cookie?    -> show password screen
+  Password OK?  -> set HTTP-only auth cookie -> redirect to /add-user (or /apartments if a name is set)
+  Name picked?  -> set display-name cookie -> redirect to /apartments
 ```
 
 ### 5.2 Session Management
 
-- Auth state: HTTP-only cookie containing a signed token
-- Display name: separate cookie (readable by client)
-- Middleware checks auth cookie on all routes except `/` and `/api/auth`
-- No expiry for MVP (session lasts until cookie cleared)
+- Auth state: HTTP-only cookie containing a signed token.
+- Display name: separate cookie (readable by client).
+- The proxy (`src/proxy.ts` — this is what was `middleware.ts` before Next.js 16 renamed it) gates all routes except `/`, `/add-user`, and the auth API.
+- `requireUser()` in `src/lib/auth.ts` is the server-side helper used by route handlers.
+- Cookies are `Secure` in production unless `DISABLE_SECURE_COOKIES` is set.
+- No expiry for MVP (session lasts until cookie cleared).
 
 ---
 
-## 6. Component Architecture
+## 6. Component / File Architecture
 
 ```
-app/
-  layout.tsx          — Root layout, font loading, theme
-  page.tsx            — Password gate (login page)
-  middleware.ts       — Auth check on protected routes
-  
-  apartments/
-    page.tsx          — Apartment list grid
-    new/
-      page.tsx        — PDF upload + parse + review form
-    [id]/
-      page.tsx        — Apartment detail + ratings
-  
-  compare/
-    page.tsx          — Full comparison grid
-
-  api/
-    auth/
-      route.ts        — Password verification
-      name/
-        route.ts      — Set display name
+src/
+  app/
+    layout.tsx, error.tsx, globals.css
+    page.tsx                     # Password gate
+    add-user/page.tsx
     apartments/
-      route.ts        — GET all, POST new
-      [id]/
-        route.ts      — GET one, PATCH, DELETE
-        ratings/
-          route.ts    — POST (upsert rating)
-    parse-pdf/
-      route.ts        — PDF upload + AI parsing
-    distance/
-      route.ts        — Google Maps distance lookup
+      page.tsx                   # List
+      new/page.tsx               # Upload + parse
+      [id]/page.tsx              # Detail + ratings
+    compare/page.tsx
+    costs/page.tsx
+    guide/page.tsx
+    settings/page.tsx            # Locations of interest, recompute
+    api/
+      auth/                      # password, name, users, users/[name]
+      apartments/                # list, create, get, update, delete,
+                                 # ratings, reprocess, check-listings
+      parse-pdf/                 # POST + upload-token (client-direct Blob)
+      pdf/[...path], uploads/[...path]   # Authenticated file streaming
+      geocode/backfill
+      locations/                 # list, create, get, update, delete, move
+      settings/recompute-distances
+      costs
 
-components/
-  password-gate.tsx
-  apartment-card.tsx
-  star-rating.tsx
-  pdf-upload.tsx
-  comparison-grid.tsx
-  nav-bar.tsx
+  components/                    # shadcn/ui + custom (apartment cards,
+                                 # comparison grid, star rating, map, etc.)
+  content/guide.md               # User guide markdown source
 
-lib/
-  db.ts              — Drizzle + Turso client
-  schema.ts          — Drizzle schema definitions
-  auth.ts            — Cookie/session helpers
-  parse-pdf.ts       — AI parsing logic
-  distance.ts        — Google Maps API wrapper
+  lib/
+    db/                          # Drizzle schema, client, migrate
+    auth.ts                      # Cookie/session helpers, requireUser
+    parse-pdf.ts                 # AI extraction (Gemini)
+    parse-pdf-error.ts           # Classified error reasons
+    distance.ts                  # Google Maps / ORS distance
+    geocode.ts                   # Google / ORS geocoding
+    locations.ts                 # Locations of interest helpers
+    listing-status.ts            # Detect expired listings
+    map-embed.ts                 # Google Maps Embed URL builder
+    short-code.ts                # Short-code generator
+    storage.ts                   # File storage (Blob / filesystem)
+    upload-pdf.ts                # Client-direct Vercel Blob upload (>4.5 MB)
+    apartment-sort.ts, edited-fields.ts, fetch-error.ts, iso-date.ts,
+    location-icons.ts, unsaved-changes.ts, use-apartment-pager.ts,
+    use-persisted-enum.ts, utils.ts
+
+  proxy.ts                       # Auth gate (renamed middleware.ts in Next 16)
+  instrumentation.ts             # Boot-time hook (DB migrations)
 ```
 
 ---
 
 ## 7. Deployment
 
-### 7.1 Vercel Configuration
+### 7.1 Vercel
 
-- Framework preset: Next.js
-- Build command: `next build`
-- Environment variables: see PRD section 5.2
-- Vercel Blob: provision via Vercel dashboard
+- Framework preset: Next.js (16).
+- Build command: `next build` (a custom `vercel-build` script wraps it).
+- Environment variables: see `.env.example` and the README.
+- Vercel Blob: provision via Vercel dashboard.
+- Database migrations run at boot via `src/instrumentation.ts`.
 
-### 7.2 Turso Database
+### 7.2 Turso
 
-- Create database at turso.tech
-- Get connection URL and auth token
-- Set as environment variables in Vercel
-- Run migrations via `drizzle-kit push` before first deploy
+- Create database at turso.tech.
+- Set `TURSO_DATABASE_URL` and `TURSO_AUTH_TOKEN` in Vercel.
+- `npx drizzle-kit push` applies the schema before first deploy.
+
+### 7.3 Docker / self-hosted
+
+- `Dockerfile` is a multi-stage build on `node:24-alpine`.
+- `docker compose up -d` runs the app on port 3002 (configurable via `PORT`).
+- Data persists in volumes `flatpare-data` (SQLite) and `flatpare-uploads` (PDFs).
+- `docker-entrypoint.sh` runs migrations on start.

--- a/prds/ApartmentTracker_MultiUser_Design.md
+++ b/prds/ApartmentTracker_MultiUser_Design.md
@@ -146,7 +146,7 @@ App Router route handlers under `src/app/api/`.
 |--------|----------|---------|
 | `POST` | `/api/auth` | Verify `APP_PASSWORD`, set HTTP-only auth cookie |
 | `POST` | `/api/auth/name` | Set display-name cookie |
-| `GET` / `POST` | `/api/auth/users` | List / create users |
+| `GET` | `/api/auth/users` | List users |
 | `DELETE` | `/api/auth/users/[name]` | Remove a user |
 
 ### 3.2 Apartments
@@ -235,7 +235,7 @@ User visits / -> proxy.ts checks auth cookie
 - Auth state: HTTP-only cookie containing a signed token.
 - Display name: separate cookie (readable by client).
 - The proxy (`src/proxy.ts` — this is what was `middleware.ts` before Next.js 16 renamed it) gates all routes except `/`, `/add-user`, and the auth API.
-- `requireUser()` in `src/lib/auth.ts` is the server-side helper used by route handlers.
+- Route handlers gate access by calling `isAuthenticated()` (boolean) and read the current actor with `getDisplayName()`, both from `src/lib/auth.ts`. There's no shared `requireUser()` helper.
 - Cookies are `Secure` in production unless `DISABLE_SECURE_COOKIES` is set.
 - No expiry for MVP (session lasts until cookie cleared).
 
@@ -274,7 +274,7 @@ src/
 
   lib/
     db/                          # Drizzle schema, client, migrate
-    auth.ts                      # Cookie/session helpers, requireUser
+    auth.ts                      # Cookie/session helpers (isAuthenticated, getDisplayName, etc.)
     parse-pdf.ts                 # AI extraction (Gemini)
     parse-pdf-error.ts           # Classified error reasons
     distance.ts                  # Google Maps / ORS distance

--- a/prds/ApartmentTracker_PRD.md
+++ b/prds/ApartmentTracker_PRD.md
@@ -1,7 +1,7 @@
 # Flatpare - Product Requirements Document
 
-**Version:** v2.0
-**Date:** April 2026
+**Version:** v3.0
+**Date:** May 2026
 
 ---
 
@@ -16,32 +16,33 @@ When multiple people search for an apartment together, tracking and comparing li
 ### 1.2 Goals
 
 - Upload apartment listing PDFs and auto-extract structured data (size, rent, rooms, address, etc.)
-- Auto-calculate travel distance to Basel SBB by bike and public transit
+- Auto-calculate travel distance (bike + transit) from each apartment to user-managed locations of interest (work, schools, family)
 - Allow each user to independently rate apartments across five subjective categories
 - Provide a full comparison grid showing all apartments with metrics and ratings
+- Detect when a listing is removed from the source site so stale listings can be hidden
 - Modern, minimal design optimized for mobile and desktop
-- Simple shared-password access gate (no user account overhead)
-- Deploy on Vercel with minimal operational complexity
+- Simple shared-password access gate (no per-user account overhead)
+- Deploy on Vercel with minimal operational complexity, with a self-hosted Docker fallback
 
 ### 1.3 Non-Goals
 
 - Real-time collaboration / live sync (acceptable for 2-3 users)
-- Full authentication system with user accounts
+- Full authentication system with per-user passwords or RBAC
 - Automated scraping of listing websites
 - Native mobile app (responsive web is sufficient)
-- Docker / self-hosted deployment (Vercel only)
 
 ---
 
 ## 2. Users
 
-The app supports 2-3 simultaneous users identified by display name. There are no user accounts. After passing the shared password gate, each person enters a display name which is stored in a cookie. Ratings are attributed to the display name.
+The app supports 2-3 simultaneous users identified by display name. There are no per-user accounts. After passing the shared password gate, each person picks a display name from the user list (or creates one on first run). Display name is stored in a cookie and ratings are attributed to it.
 
 ### 2.1 Access Gate
 
 - Single shared password for all users (set via `APP_PASSWORD` env var)
 - On first visit, show password input screen
-- On success, prompt for display name, store auth state in HTTP-only cookie
+- On success, prompt for display name (existing user list, or add a new one)
+- Auth state stored in HTTP-only cookie; display name in a separate readable cookie
 - No "remember me" / no password reset / no RBAC
 
 ---
@@ -56,15 +57,23 @@ Each apartment record contains:
 |-------|------|--------|
 | `name` | string | Extracted from listing title |
 | `address` | string | Extracted from PDF |
-| `size_m2` | number | Extracted (square meters) |
-| `num_rooms` | number | Extracted (Swiss room count, e.g. 3.5) |
-| `num_bathrooms` | number | Extracted |
-| `num_balconies` | number | Extracted |
-| `rent_chf` | number | Extracted (monthly rent in CHF) |
-| `distance_bike_min` | number | Auto-calculated or manual |
-| `distance_transit_min` | number | Auto-calculated or manual |
-| `pdf_url` | string | Vercel Blob URL of uploaded PDF |
-| `raw_extracted_data` | JSON | Full AI extraction for reference |
+| `sizeM2` | number | Extracted (square meters) |
+| `numRooms` | number | Extracted (Swiss room count, e.g. 3.5) |
+| `numBathrooms` | number | Extracted |
+| `numBalconies` | number | Extracted |
+| `hasWashingMachine` | boolean | Extracted; in-unit only, not shared laundry |
+| `rentChf` | number | Extracted (monthly rent in CHF) |
+| `availableFrom` | string (ISO date) | Extracted; null for "ab sofort" |
+| `summary` | string | AI-written one-liner describing the apartment |
+| `pdfUrl` | string | Vercel Blob URL (or local path) of uploaded PDF |
+| `listingUrl` | string | Source listing URL, if visible in the PDF |
+| `shortCode` | string | Short, unique, human-friendly ID for the apartment |
+| `latitude` / `longitude` | number | Geocoded from address (Google or ORS) |
+| `listingGone` / `listingCheckedAt` | bool / timestamp | Set by the listing-status checker |
+| `userEditedFields` | JSON | Tracks which fields a human edited (so re-extraction won't overwrite them) |
+| `rawExtractedData` | JSON | Full AI extraction for reference |
+
+Per-location distances live in a separate `apartment_distances` table keyed on `(apartmentId, locationId)`, not on the apartment row itself.
 
 ### 3.2 Rating System
 
@@ -82,62 +91,71 @@ Plus a free-text comment field per apartment per user.
 
 ### 3.3 PDF Upload & Parsing
 
-1. User uploads a PDF via drag-and-drop or file picker
-2. PDF is stored in Vercel Blob
-3. PDF pages are sent to a vision-capable AI model via Vercel AI SDK
-4. AI extracts structured apartment data (handles German and English listings)
-5. Extracted data is shown in an editable form for user review/correction
-6. User confirms and saves the apartment record
+1. User uploads a PDF via drag-and-drop or file picker.
+2. Small PDFs (≤ 4.5 MB) are POSTed straight to `/api/parse-pdf`. Larger PDFs use the client-direct Vercel Blob upload path (`/api/parse-pdf/upload-token`) to bypass the serverless body limit.
+3. The PDF bytes are sent to Google Gemini (`gemini-2.5-flash`) via the Vercel AI SDK as a `file` content block, with a structured-output Zod schema.
+4. Extracted data is shown in an editable form for user review/correction.
+5. User confirms and saves the apartment record. Edited fields are tracked so a later "Reprocess" doesn't clobber human corrections.
 
 ### 3.4 Distance Calculation
 
-- Reference point: Basel SBB (hardcoded, coordinates: 47.5476, 7.5897)
-- Auto-calculate bike and public transit travel time via Google Maps Distance Matrix API
-- If API fails or address is unclear, fall back to manual input
-- Users can always manually override calculated distances
+- Reference points are user-managed **locations of interest** (label, icon, address, sort order, geocoded lat/lng).
+- For each (apartment, location) pair, bike and transit minutes are computed via Google Maps Distance Matrix (preferred) or OpenRouteService (free fallback, bike only).
+- Distances are recomputed on demand from the settings page; manual overrides are not currently supported.
 
 ### 3.5 Comparison View
 
-- Shows ALL apartments by default in a horizontally scrollable grid
-- Columns = apartments, rows = metrics and ratings
-- Each column has a "Hide" button to temporarily remove it from view (does not delete from DB)
-- Hidden state resets on page refresh (stored in component state only)
-- Visual indicators (color coding) for best/worst values in each metric row
-- Rows include: all extracted metrics + each user's ratings + average ratings
+- Shows all apartments by default in a horizontally scrollable grid.
+- Columns = apartments, rows = metrics, distances, and ratings.
+- Each column has a "Hide" button (visual only; doesn't delete from DB).
+- Hidden state resets on page refresh.
+- Visual highlights for best/worst values per row.
+
+### 3.6 Listing Status Checks
+
+A periodic-or-on-demand check pings each listing URL and marks the apartment as "listing gone" when the URL is removed (HTTP error or expired-listing pattern). The detail view shows a stale-listing badge so users can choose to hide or delete it.
 
 ---
 
 ## 4. Pages & Navigation
 
 ### 4.1 Password Gate (`/`)
-- Centered card with password input
-- On success, prompt for display name
-- Redirect to apartment list
+- Centered card with password input.
+- On success, redirects to user picker / add-user flow.
 
-### 4.2 Apartment List (`/apartments`)
-- Grid of apartment cards: name, address, size, rent, average rating
-- "Upload New" button
-- Sort by: rent, size, average rating, date added
-- Filter by: min/max rooms, min/max size
+### 4.2 Add User (`/add-user`)
+- First-run user onboarding: pick from existing display names or create a new one.
 
-### 4.3 Upload & Parse (`/apartments/new`)
-- Drag-and-drop PDF upload area
-- Progress indicator: uploading -> parsing -> extracting distances
-- Editable form showing extracted data
-- Save button creates apartment record
+### 4.3 Apartment List (`/apartments`)
+- Grid or list of apartment cards: name, address, size, rent, average rating, listing-gone badge.
+- "Upload New" button.
+- Sortable by rent, size, average rating, distance to a chosen location, date added.
 
-### 4.4 Apartment Detail (`/apartments/[id]`)
-- Full extracted data display
-- Link to view/download PDF
-- All users' ratings with per-category averages
-- Current user's rating form (star selector + comment)
-- Edit button for extracted data corrections
+### 4.4 Upload & Parse (`/apartments/new`)
+- Drag-and-drop PDF upload (auto-routes between direct POST and client-direct Blob upload by file size).
+- Progress indicator: uploading → parsing → geocoding → distances.
+- Editable form showing extracted data with retry support.
 
-### 4.5 Comparison (`/compare`)
-- Full-width horizontally scrollable grid
-- All apartments shown by default
-- Hide/show individual apartments
-- Best/worst highlighting per row
+### 4.5 Apartment Detail (`/apartments/[id]`)
+- Full extracted data, embedded map, link to view/download PDF.
+- All users' ratings with per-category averages.
+- Current user's rating form (stars + comment).
+- Edit, reprocess, and delete actions.
+
+### 4.6 Comparison (`/compare`)
+- Full-width horizontally scrollable grid.
+- All apartments shown by default; per-column hide toggle.
+- Best/worst highlighting per row.
+
+### 4.7 Settings (`/settings`)
+- Manage locations of interest (CRUD + reorder).
+- Trigger distance recompute and geocode backfill.
+
+### 4.8 Costs (`/costs`)
+- API usage stats per service/operation with estimated cost.
+
+### 4.9 Guide (`/guide`)
+- In-app user guide (markdown source in `src/content/guide.md`).
 
 ---
 
@@ -147,46 +165,41 @@ Plus a free-text comment field per apartment per user.
 
 | Layer | Technology |
 |-------|-----------|
-| Framework | Next.js 15 (App Router) |
+| Framework | Next.js 16 (App Router) |
 | Language | TypeScript |
-| Database | SQLite via Turso |
-| ORM | Drizzle ORM |
-| Styling | Tailwind CSS + shadcn/ui |
-| File Storage | Vercel Blob |
-| PDF Parsing | Vercel AI SDK (vision model) |
-| Distance API | Google Maps Distance Matrix |
-| Deployment | Vercel |
+| Database | SQLite via Turso (cloud) or local file (self-hosted) |
+| ORM | Drizzle ORM (libSQL client) |
+| Styling | Tailwind CSS 4 + shadcn/ui |
+| File Storage | Vercel Blob (cloud) or local filesystem |
+| PDF Parsing | Vercel AI SDK + Google Gemini (`gemini-2.5-flash`) |
+| Distance API | Google Maps Distance Matrix; OpenRouteService fallback |
+| Geocoding | Google Geocoding; OpenRouteService fallback |
+| Map embed | Google Maps Embed (or Leaflet for the overview map) |
+| Deployment | Vercel (primary), Docker (self-hosted) |
 
 ### 5.2 Environment Variables
 
-| Variable | Purpose |
-|----------|---------|
-| `APP_PASSWORD` | Shared access password |
-| `TURSO_DATABASE_URL` | Turso database connection URL |
-| `TURSO_AUTH_TOKEN` | Turso authentication token |
-| `BLOB_READ_WRITE_TOKEN` | Vercel Blob access token |
-| `GOOGLE_MAPS_API_KEY` | Google Maps Distance Matrix API |
-| AI provider key (e.g. `GOOGLE_GENERATIVE_AI_API_KEY` or `OPENAI_API_KEY`) | For PDF parsing |
+See `.env.example` and the README's Environment Variables section. Notable additions since v2.0: `LOCAL_DB_URL` (local SQLite path override) and `DISABLE_SECURE_COOKIES` (HTTP-dev convenience).
 
 ### 5.3 Database
 
-SQLite via Turso with Drizzle ORM. Two tables: `apartments` and `ratings`. See Technical Specification for schema details.
+Six tables: `apartments`, `ratings`, `users`, `api_usage`, `locations_of_interest`, `apartment_distances`. Schema details and routes live in the Technical Specification.
 
 ---
 
 ## 6. Design Principles
 
-- **Minimal**: Clean, uncluttered UI with generous whitespace
-- **Mobile-first**: All views usable on phone screens; comparison view uses horizontal scroll
-- **Fast**: Optimistic UI updates, loading skeletons, no unnecessary page reloads
-- **Forgiving**: AI extraction errors are easily correctable via editable forms
+- **Minimal**: clean, uncluttered UI with generous whitespace.
+- **Mobile-first**: all views usable on phone screens; comparison view uses horizontal scroll.
+- **Fast**: optimistic UI, loading skeletons, no unnecessary page reloads.
+- **Forgiving**: AI extraction errors are easily correctable; reprocess preserves human edits.
 
 ---
 
 ## 7. Future Work
 
-- Sortable/filterable comparison columns
-- Photo gallery from PDF images
-- SBB open data API for more accurate transit times
-- Export comparison as PDF/spreadsheet
-- Configurable reference points (not just Basel SBB)
+- Sortable / filterable comparison columns.
+- Photo gallery from PDF images.
+- SBB open-data API for more accurate transit times.
+- Export comparison as PDF/spreadsheet.
+- Manual override for individual per-location distances.


### PR DESCRIPTION
## Summary
Both PRDs had drifted significantly from the code. Refresh both to v3.0 reflecting the current state.

**Main PRD changes:**
- Stack: Next.js 15 → 16; remove "Vercel only" non-goal (Docker is supported).
- Apartment data model gains the fields added since v2: \`hasWashingMachine\`, \`listingUrl\`, \`shortCode\`, \`userEditedFields\`, \`summary\`, \`availableFrom\`, \`listingGone\`, \`listingCheckedAt\`, \`latitude\`, \`longitude\`. Distance fields move out (now in \`apartment_distances\`).
- Distance reframed as user-managed locations of interest, not just Basel SBB.
- Add settings page, add-user page, listing-status checks, reprocess flow.

**Technical spec changes:**
- Schema block now shows all 6 tables.
- API table: drop ghost \`POST /api/distance\`; add ~11 routes that actually exist (reprocess, check-listings, upload-token, geocode/backfill, locations CRUD, recompute-distances, etc.).
- Auth: \`middleware.ts\` → \`src/proxy.ts\` (Next.js 16 rename).
- PDF parsing: rewrite the "convert pages to images" step — actual code sends PDF bytes as a Vercel AI SDK \`file\` block to Gemini.
- Add the client-direct Vercel Blob upload pattern for large PDFs.

Closes #99

## Test plan
- [x] Schema block matches \`src/lib/db/schema.ts\`.
- [x] API table matches \`find src/app/api -name route.ts\`.
- [x] File-architecture block matches actual \`src/\` layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)