### PR TITLE
chore: prune unused exports in src/lib/

### DIFF
--- a/src/lib/apartment-sort.ts
+++ b/src/lib/apartment-sort.ts
@@ -1,4 +1,4 @@
-export type StaticSortField =
+type StaticSortField =
   | "createdAt"
   | "rentChf"
   | "sizeM2"
@@ -10,7 +10,7 @@ export type StaticSortField =
 
 // `bikeTo:<locationId>` and `transitTo:<locationId>` are generated at runtime
 // from the user's configured locations of interest.
-export type LocationSortField = `bikeTo:${number}` | `transitTo:${number}`;
+type LocationSortField = `bikeTo:${number}` | `transitTo:${number}`;
 
 export type SortField = StaticSortField | LocationSortField;
 
@@ -85,7 +85,7 @@ function extract(apt: SortableApartment, field: SortField): number | string | nu
   }
 }
 
-export const STATIC_LIST_SORT_LABELS: Record<StaticSortField, string> = {
+const STATIC_LIST_SORT_LABELS: Record<StaticSortField, string> = {
   createdAt: "Date added",
   rentChf: "Price",
   sizeM2: "Size",
@@ -98,7 +98,7 @@ export const STATIC_LIST_SORT_LABELS: Record<StaticSortField, string> = {
 
 // Apartments-list sort dropdown defaults — a curated subset of static fields
 // shown even when no locations are configured.
-export const STATIC_LIST_SORT_FIELDS: StaticSortField[] = [
+const STATIC_LIST_SORT_FIELDS: StaticSortField[] = [
   "createdAt",
   "rentChf",
   "sizeM2",
@@ -109,7 +109,7 @@ export const STATIC_LIST_SORT_FIELDS: StaticSortField[] = [
 
 export type LocationLite = { id: number; label: string };
 
-export type SortFieldOption = { id: SortField; label: string };
+type SortFieldOption = { id: SortField; label: string };
 
 export function listSortOptions(locations: LocationLite[]): SortFieldOption[] {
   const base: SortFieldOption[] = STATIC_LIST_SORT_FIELDS.map((id) => ({

--- a/src/lib/distance.ts
+++ b/src/lib/distance.ts
@@ -1,7 +1,7 @@
 import { db } from "@/lib/db";
 import { apiUsage } from "@/lib/db/schema";
 
-export interface DistanceResult {
+interface DistanceResult {
   bikeMinutes: number | null;
   transitMinutes: number | null;
 }

--- a/src/lib/edited-fields.ts
+++ b/src/lib/edited-fields.ts
@@ -12,7 +12,7 @@ export const INFERABLE_FIELDS = [
   "availableFrom",
 ] as const;
 
-export type InferableField = (typeof INFERABLE_FIELDS)[number];
+type InferableField = (typeof INFERABLE_FIELDS)[number];
 
 export function diffInferableFields(
   current: Record<string, unknown>,

--- a/src/lib/geocode.ts
+++ b/src/lib/geocode.ts
@@ -71,7 +71,7 @@ async function tryOrsGeocode(address: string): Promise<string | null> {
   }
 }
 
-export interface LatLng {
+interface LatLng {
   lat: number;
   lng: number;
 }
@@ -141,7 +141,7 @@ async function tryOrsGeocodeLatLng(
   }
 }
 
-export interface GeocodeAttempt {
+interface GeocodeAttempt {
   result: LatLng | null;
   googleReason?: string;
   orsReason?: string;

--- a/src/lib/listing-status.ts
+++ b/src/lib/listing-status.ts
@@ -1,4 +1,4 @@
-export interface ListingCheckResult {
+interface ListingCheckResult {
   apartmentId: number;
   gone: boolean | null;
 }

--- a/src/lib/location-icons.ts
+++ b/src/lib/location-icons.ts
@@ -32,7 +32,7 @@ export const LOCATION_ICONS = [
 
 export type LocationIconName = (typeof LOCATION_ICONS)[number]["name"];
 
-export const ICON_NAMES = LOCATION_ICONS.map((i) => i.name) as LocationIconName[];
+const ICON_NAMES = LOCATION_ICONS.map((i) => i.name) as LocationIconName[];
 
 export function isLocationIconName(value: string): value is LocationIconName {
   return (ICON_NAMES as string[]).includes(value);

--- a/src/lib/locations.ts
+++ b/src/lib/locations.ts
@@ -1,4 +1,4 @@
-import { asc, eq, sql } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   locationsOfInterest,
@@ -10,7 +10,7 @@ import {
 } from "@/lib/location-icons";
 import { geocodeLatLng } from "@/lib/geocode";
 
-export type LocationInput = {
+type LocationInput = {
   label: string;
   icon: string;
   address: string;
@@ -166,13 +166,4 @@ export async function moveLocation(
     .update(locationsOfInterest)
     .set({ sortOrder: swapWith.sortOrder })
     .where(eq(locationsOfInterest.id, current.id));
-}
-
-// Used by callers that just need to know if locations exist (e.g. apartment
-// detail rendering). Cheaper than listLocations when we only need a count.
-export async function locationCount(): Promise<number> {
-  const rows = await db
-    .select({ n: sql<number>`COUNT(*)` })
-    .from(locationsOfInterest);
-  return Number(rows[0]?.n ?? 0);
 }

--- a/src/lib/parse-pdf-error.ts
+++ b/src/lib/parse-pdf-error.ts
@@ -1,6 +1,6 @@
-export type ParsePdfErrorReason = "quota" | "invalid_pdf" | "unknown";
+type ParsePdfErrorReason = "quota" | "invalid_pdf" | "unknown";
 
-export interface ClassifiedParsePdfError {
+interface ClassifiedParsePdfError {
   reason: ParsePdfErrorReason;
   message: string;
   retryAfterSeconds?: number;

--- a/src/lib/parse-pdf.ts
+++ b/src/lib/parse-pdf.ts
@@ -61,7 +61,7 @@ export const apartmentExtractionSchema = z.object({
     ),
 });
 
-export type ApartmentExtraction = z.infer<typeof apartmentExtractionSchema>;
+type ApartmentExtraction = z.infer<typeof apartmentExtractionSchema>;
 
 const internalApartmentExtractionSchema = apartmentExtractionSchema.extend({
   laundryEvidence: z

--- a/src/lib/short-code.ts
+++ b/src/lib/short-code.ts
@@ -11,14 +11,14 @@ export function pickLetters(): string {
   return out;
 }
 
-export interface ShortCodeInput {
+interface ShortCodeInput {
   numRooms: number | null;
   numBathrooms: number | null;
   hasWashingMachine: boolean | null;
   address: string | null;
 }
 
-export interface ShortCodeParts {
+interface ShortCodeParts {
   rooms: string;
   baths: string;
   wash: string;

--- a/src/lib/use-apartment-pager.ts
+++ b/src/lib/use-apartment-pager.ts
@@ -17,7 +17,7 @@ import {
   fetchErrorFromResponse,
 } from "@/lib/fetch-error";
 
-export interface ApartmentPagerResult {
+interface ApartmentPagerResult {
   loading: boolean;
   error: ErrorDetails | null;
   total: number;


### PR DESCRIPTION
## Summary
Un-export 14 symbols whose only references are inside their own defining file, and delete \`locationCount()\` (defined but never called).

Kept exported (skipped per audit's conservative stance): \`checkListingUrl\`, \`generateShortCode\`, \`apartmentExtractionSchema\` — these have legitimate test imports; un-exporting would break tests.

Per audit instructions, kept the Drizzle insert-type aliases in \`src/lib/db/schema.ts\` untouched.

Closes #106

## Test plan
- [x] \`npx tsc --noEmit\` → only the pre-existing \`__cookieStore\` error remains.
- [x] \`npm test\` → 283 / 283 passing on Node 24.
- [x] \`npm run lint\` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)