### PR TITLE
refactor: split apartment detail page into composable components

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -11,6 +11,7 @@ const eslintConfig = defineConfig([
     ".next/**",
     "out/**",
     "build/**",
+    "coverage/**",
     "next-env.d.ts",
   ]),
 ]);

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -2,13 +2,10 @@
 
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
-import { Textarea } from "@/components/ui/textarea";
-import { Label } from "@/components/ui/label";
-import { StarRating } from "@/components/star-rating";
 import { ShortCode } from "@/components/short-code";
 import { AddressLink } from "@/components/address-link";
 import { ApartmentMap } from "@/components/apartment-map";
@@ -17,11 +14,15 @@ import { iconComponentFor } from "@/lib/location-icons";
 import { ErrorDisplay } from "@/components/error-display";
 import { cn } from "@/lib/utils";
 import {
-  ApartmentFormFields,
   formFromApartment,
   formToPayload,
   type ApartmentForm,
 } from "@/components/apartment-form-fields";
+import { ApartmentEditForm } from "@/components/apartment-edit-form";
+import {
+  MyRatingPanel,
+  OtherRatingPanel,
+} from "@/components/apartment-rating-panel";
 import {
   type ErrorDetails,
   fetchErrorFromResponse,
@@ -74,14 +75,6 @@ interface LocationLite {
   icon: string;
   address: string;
 }
-
-const ratingCategories = [
-  { key: "kitchen", label: "Kitchen" },
-  { key: "balconies", label: "Balconies" },
-  { key: "location", label: "Location" },
-  { key: "floorplan", label: "Floorplan" },
-  { key: "overallFeeling", label: "Overall feeling" },
-] as const;
 
 function getCookieValue(name: string): string | null {
   const match = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`));
@@ -505,38 +498,20 @@ export default function ApartmentDetailPage() {
 
       {/* Apartment metrics or edit form */}
       {editing && editForm ? (
-        <Card>
-          <CardHeader>
-            <CardTitle className="text-lg">Edit apartment</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <ApartmentFormFields
-              form={editForm}
-              onChange={(field, value) =>
-                setEditForm((prev) =>
-                  prev ? { ...prev, [field]: value } : prev
-                )
-              }
-              onWashingMachineChange={(v) =>
-                setEditForm((prev) =>
-                  prev ? { ...prev, hasWashingMachine: v } : prev
-                )
-              }
-            />
-            <div className="flex gap-2">
-              <Button onClick={handleSaveEdit} disabled={savingEdit}>
-                {savingEdit ? "Saving..." : "Save"}
-              </Button>
-              <Button
-                variant="outline"
-                onClick={cancelEdit}
-                disabled={savingEdit}
-              >
-                Cancel
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
+        <ApartmentEditForm
+          form={editForm}
+          saving={savingEdit}
+          onChange={(field, value) =>
+            setEditForm((prev) => (prev ? { ...prev, [field]: value } : prev))
+          }
+          onWashingMachineChange={(v) =>
+            setEditForm((prev) =>
+              prev ? { ...prev, hasWashingMachine: v } : prev
+            )
+          }
+          onSave={handleSaveEdit}
+          onCancel={cancelEdit}
+        />
       ) : (
         <div className="flex flex-wrap gap-2">
           {apartment.rentChf && (
@@ -597,79 +572,18 @@ export default function ApartmentDetailPage() {
 
       <Separator />
 
-      {/* My rating */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-lg">Your Rating ({userName})</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {ratingCategories.map(({ key, label }) => (
-            <div key={key} className="flex items-center justify-between">
-              <Label className="text-sm">{label}</Label>
-              <StarRating
-                value={myRating[key]}
-                onChange={(v) =>
-                  setMyRating((prev) => ({ ...prev, [key]: v }))
-                }
-              />
-            </div>
-          ))}
-          <div className="space-y-2">
-            <Label htmlFor="rating-comment">Comment</Label>
-            <Textarea
-              id="rating-comment"
-              value={myRating.comment}
-              onChange={(e) =>
-                setMyRating((prev) => ({ ...prev, comment: e.target.value }))
-              }
-              placeholder="Notes about this apartment..."
-              rows={3}
-            />
-          </div>
-          <div className="flex gap-2">
-            <Button
-              onClick={handleSaveRating}
-              disabled={saving || !isRatingDirty}
-            >
-              {saving ? "Saving..." : "Save Rating"}
-            </Button>
-            <Button
-              variant="outline"
-              onClick={handleCancelRating}
-              disabled={saving || !isRatingDirty}
-            >
-              Cancel
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
+      <MyRatingPanel
+        userName={userName}
+        rating={myRating}
+        saving={saving}
+        dirty={isRatingDirty}
+        onChange={setMyRating}
+        onSave={handleSaveRating}
+        onCancel={handleCancelRating}
+      />
 
-      {/* Other ratings */}
       {otherRatings.map((rating) => (
-        <Card key={rating.id}>
-          <CardHeader>
-            <CardTitle className="text-lg">
-              {rating.userName}&apos;s Rating
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3">
-            {ratingCategories.map(({ key, label }) => (
-              <div key={key} className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">{label}</span>
-                <StarRating
-                  value={rating[key]}
-                  readonly
-                  size="sm"
-                />
-              </div>
-            ))}
-            {rating.comment && (
-              <div className="rounded-md bg-muted p-3 text-sm">
-                {rating.comment}
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        <OtherRatingPanel key={rating.id} rating={rating} />
       ))}
     </div>
   );

--- a/src/components/apartment-edit-form.tsx
+++ b/src/components/apartment-edit-form.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import {
+  ApartmentFormFields,
+  type ApartmentForm,
+} from "@/components/apartment-form-fields";
+
+export function ApartmentEditForm({
+  form,
+  saving,
+  onChange,
+  onWashingMachineChange,
+  onSave,
+  onCancel,
+}: {
+  form: ApartmentForm;
+  saving: boolean;
+  onChange: (field: keyof ApartmentForm, value: string) => void;
+  onWashingMachineChange: (v: boolean | null) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Edit apartment</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ApartmentFormFields
+          form={form}
+          onChange={onChange}
+          onWashingMachineChange={onWashingMachineChange}
+        />
+        <div className="flex gap-2">
+          <Button onClick={onSave} disabled={saving}>
+            {saving ? "Saving..." : "Save"}
+          </Button>
+          <Button variant="outline" onClick={onCancel} disabled={saving}>
+            Cancel
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/apartment-rating-panel.tsx
+++ b/src/components/apartment-rating-panel.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { StarRating } from "@/components/star-rating";
+
+const RATING_CATEGORIES = [
+  { key: "kitchen", label: "Kitchen" },
+  { key: "balconies", label: "Balconies" },
+  { key: "location", label: "Location" },
+  { key: "floorplan", label: "Floorplan" },
+  { key: "overallFeeling", label: "Overall feeling" },
+] as const;
+
+export type RatingCategoryKey = (typeof RATING_CATEGORIES)[number]["key"];
+
+export type RatingState = Record<RatingCategoryKey, number> & {
+  comment: string;
+};
+
+export function MyRatingPanel({
+  userName,
+  rating,
+  saving,
+  dirty,
+  onChange,
+  onSave,
+  onCancel,
+}: {
+  userName: string;
+  rating: RatingState;
+  saving: boolean;
+  dirty: boolean;
+  onChange: (next: RatingState) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Your Rating ({userName})</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {RATING_CATEGORIES.map(({ key, label }) => (
+          <div key={key} className="flex items-center justify-between">
+            <Label className="text-sm">{label}</Label>
+            <StarRating
+              value={rating[key]}
+              onChange={(v) => onChange({ ...rating, [key]: v })}
+            />
+          </div>
+        ))}
+        <div className="space-y-2">
+          <Label htmlFor="rating-comment">Comment</Label>
+          <Textarea
+            id="rating-comment"
+            value={rating.comment}
+            onChange={(e) => onChange({ ...rating, comment: e.target.value })}
+            placeholder="Notes about this apartment..."
+            rows={3}
+          />
+        </div>
+        <div className="flex gap-2">
+          <Button onClick={onSave} disabled={saving || !dirty}>
+            {saving ? "Saving..." : "Save Rating"}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={saving || !dirty}
+          >
+            Cancel
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function OtherRatingPanel({
+  rating,
+}: {
+  rating: { id: number; userName: string; comment: string } & Record<
+    RatingCategoryKey,
+    number
+  >;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">{rating.userName}&apos;s Rating</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {RATING_CATEGORIES.map(({ key, label }) => (
+          <div key={key} className="flex items-center justify-between">
+            <span className="text-sm text-muted-foreground">{label}</span>
+            <StarRating value={rating[key]} readonly size="sm" />
+          </div>
+        ))}
+        {rating.comment && (
+          <div className="rounded-md bg-muted p-3 text-sm">{rating.comment}</div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
\`src/app/apartments/[id]/page.tsx\` was 729 lines and mixed display, edit form, and ratings in a single component.

- Extract the edit form Card into **\`ApartmentEditForm\`** (\`src/components/apartment-edit-form.tsx\`).
- Extract the My-Rating and Other-Rating cards into **\`MyRatingPanel\`** and **\`OtherRatingPanel\`** (\`src/components/apartment-rating-panel.tsx\`), with a shared \`RatingState\` type and the rating-category list co-located with the panel.
- Drop now-unused imports.
- Eslint: ignore the \`coverage/\` directory the v8 reporter generates (drive-by, surfaced during this PR's lint run).

Pure structural change — no behavior change. \`page.tsx\` 729 → **643** lines; new components are 47 + 108 lines.

The audit also suggested verifying \`use-apartment-pager\` hook usage and extracting keyboard handlers — the hook is fully used (line 94) and there are no keyboard handlers in the page to extract.

Closes #100

## Test plan
- [x] \`npm test\` → 292 / 292 passing on Node 24.
- [x] \`npx tsc --noEmit\` → only the pre-existing \`__cookieStore\` error remains.
- [x] \`npm run lint\` → clean.
- [x] \`npm run build\` → clean.
- [ ] Manual browser smoke (deferring to reviewer; pure structural extraction with full test coverage as a safety net).

🤖 Generated with [Claude Code](https://claude.com/claude-code)