### PR TITLE
fix: refresh apartment cards when the active user changes (#121)

### DIFF
--- a/src/app/apartments/__tests__/user-switch.test.tsx
+++ b/src/app/apartments/__tests__/user-switch.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+import ApartmentsPage from "../page";
+
+// Alice has rated this apartment; Bob hasn't. Switching from Alice to Bob
+// must flip the "Rated" badge to "Not yet rated".
+const ALICE_VIEW = [
+  {
+    id: 1,
+    name: "Sonnenweg 3",
+    address: "Sonnenweg 3, 8001 Zürich",
+    sizeM2: 60,
+    numRooms: 2.5,
+    rentChf: 2200,
+    shortCode: "ABC-2.5B-WY-4057",
+    avgOverall: "4.0",
+    myRating: 5,
+    createdAt: "2026-01-15T10:00:00Z",
+  },
+];
+
+const BOB_VIEW = [
+  {
+    ...ALICE_VIEW[0],
+    myRating: null,
+  },
+];
+
+let currentApartments: typeof ALICE_VIEW = ALICE_VIEW;
+
+beforeEach(() => {
+  localStorage.clear();
+  currentApartments = ALICE_VIEW;
+  vi.spyOn(global, "fetch").mockImplementation(async (input) => {
+    const url = typeof input === "string" ? input : (input as Request).url;
+    if (url === "/api/locations") {
+      return { ok: true, json: () => Promise.resolve([]) } as Response;
+    }
+    if (url.includes("/api/apartments/check-listings")) {
+      return { ok: true, json: () => Promise.resolve({}) } as Response;
+    }
+    return {
+      ok: true,
+      json: () => Promise.resolve(currentApartments),
+    } as Response;
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Apartments list — user switch", () => {
+  it("re-fetches and updates the per-user 'Rated' badge when the user changes", async () => {
+    render(<ApartmentsPage />);
+
+    // Initial load: Alice has rated this apartment.
+    await waitFor(() => {
+      expect(screen.getByText("Rated")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Not yet rated")).toBeNull();
+
+    // Switch to Bob — backend now returns the same apartment with no rating.
+    currentApartments = BOB_VIEW as unknown as typeof ALICE_VIEW;
+    window.dispatchEvent(new Event("flatpare-user-changed"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Not yet rated")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Rated")).toBeNull();
+  });
+});

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -127,29 +127,31 @@ export default function ApartmentsPage() {
     );
   }, [filteredApartments, sortField, sortDirection]);
 
-  useEffect(() => {
+  // Fetches apartments + locations. The optional listing-status check only
+  // runs on the initial mount — re-fetches triggered by user switching just
+  // need fresh ratings, not another network probe.
+  async function reload(opts?: { runListingCheck?: boolean }) {
     const url = "/api/apartments";
-    (async () => {
-      try {
-        const [aptRes, locRes] = await Promise.all([
-          fetch(url),
-          fetch("/api/locations"),
-        ]);
-        if (!aptRes.ok) {
-          setError({
-            headline: "Couldn't load apartments",
-            details: await fetchErrorFromResponse(aptRes, url),
-          });
-          setLoading(false);
-          return;
-        }
-        const data = (await aptRes.json()) as ApartmentSummary[];
-        setApartments(data);
-        if (locRes.ok) {
-          setLocations((await locRes.json()) as LocationOfInterest[]);
-        }
+    try {
+      const [aptRes, locRes] = await Promise.all([
+        fetch(url),
+        fetch("/api/locations"),
+      ]);
+      if (!aptRes.ok) {
+        setError({
+          headline: "Couldn't load apartments",
+          details: await fetchErrorFromResponse(aptRes, url),
+        });
         setLoading(false);
+        return;
+      }
+      setApartments((await aptRes.json()) as ApartmentSummary[]);
+      if (locRes.ok) {
+        setLocations((await locRes.json()) as LocationOfInterest[]);
+      }
+      setLoading(false);
 
+      if (opts?.runListingCheck) {
         try {
           const checkRes = await fetch("/api/apartments/check-listings", {
             method: "POST",
@@ -163,14 +165,32 @@ export default function ApartmentsPage() {
         } catch {
           // background check failure is non-fatal
         }
-      } catch (err) {
-        setError({
-          headline: "Couldn't load apartments",
-          details: fetchErrorFromException(err, url),
-        });
-        setLoading(false);
       }
+    } catch (err) {
+      setError({
+        headline: "Couldn't load apartments",
+        details: fetchErrorFromException(err, url),
+      });
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void (async () => {
+      await reload({ runListingCheck: true });
     })();
+  }, []);
+
+  // Re-fetch when the active user switches so apartment cards show ratings
+  // belonging to the new user, not the previous one.
+  useEffect(() => {
+    function handler() {
+      void (async () => {
+        await reload();
+      })();
+    }
+    window.addEventListener("flatpare-user-changed", handler);
+    return () => window.removeEventListener("flatpare-user-changed", handler);
   }, []);
 
   const sortOptions = useMemo(() => listSortOptions(locations), [locations]);


### PR DESCRIPTION
## Summary
The apartments list page fetched ratings on mount only and ignored the \`flatpare-user-changed\` event the nav bar dispatches. After switching users, cards kept showing the previous user's \`myRating\` until a manual page refresh.

## Changes
- \`src/app/apartments/page.tsx\`: extract fetch into a \`reload()\` function. Mount runs it with the listing-status check; \`flatpare-user-changed\` re-runs it without the check (no need for another network probe just because the user switched).
- \`src/app/apartments/__tests__/user-switch.test.tsx\`: new test mirroring the existing one for the detail page — fires the event and asserts the per-user "Rated" badge flips appropriately.

The compare page was checked but doesn't read the active-user cookie (it shows all users' ratings as columns), so it doesn't need this fix.

Closes #121

## Test plan
- [x] \`npm test\` → 296 / 296 passing on Node 24 (was 295; +1 new test).
- [x] \`npm run lint\` → clean.
- [x] \`npm run build\` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)