### PR TITLE
test: raise Vitest default timeouts to fix flake (#126)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,8 @@ export default defineConfig({
     setupFiles: ["./src/test-setup.ts"],
     globalSetup: ["./src/test-global-setup.ts"],
     include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
+    testTimeout: 15000,
+    hookTimeout: 15000,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Bump `testTimeout` and `hookTimeout` to 15s in `vitest.config.ts` so heavy `userEvent` flows don't time out under parallel CPU pressure.

## Why
Three tests were intermittently red on local + CI runs (per the 2026-05-06 codebase audit):
- `src/app/compare/__tests__/compare-page.test.tsx` — sort field re-orders (5s)
- `src/app/settings/__tests__/settings-page.test.tsx` — icon-picker modal add (5s)
- `src/app/apartments/[id]/__tests__/edit-flow.test.tsx` — edit form save (10s)

Each one passed in isolation but tripped on contention. Bumping the default cap removes the flake without masking real regressions; if a test ever blows past 15s we want to see it.

## Tried first, reverted
A global `userEvent.setup({ delay: null })` change introduced new failures in Select-dropdown tests (the artificial typing delay was actually giving Base UI's animated Select time to render its option list). Reverted.

## Test plan
- [x] 15 consecutive `npx vitest run` invocations all pass 296/296.
- [x] Closes the three flaky tests called out in the audit.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)