### PR TITLE
docs: clarify Docker host vs container port (#124)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,4 +35,5 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - Smaller uploads and the local-disk fallback go through `src/lib/storage.ts`.
 
 ## Dev server
-- Runs on **port 3002**, not 3000 (`dev` and `start` scripts in `package.json`). Same in Docker.
+- `npm run dev` and `npm run start` listen on **port 3002** (not the Next.js default 3000); both scripts pass `-p 3002`.
+- In Docker the container's Next.js server runs on the standalone-image default of **3000**; `docker-compose.yml` publishes it to the host on `${PORT:-3002}` (i.e. host `3002` → container `3000`). Override the host port with `PORT=...` if 3002 is taken; the container side is fixed.


### PR DESCRIPTION
## Summary
- Replace the misleading "Same in Docker" line in `AGENTS.md` with a precise description of the host→container mapping.

## Why
`AGENTS.md` said the dev server runs on 3002 "Same in Docker", but:
- `Dockerfile` sets `ENV PORT=3000` and `EXPOSE 3000`
- `docker-compose.yml` maps `\${PORT:-3002}:3000`

So the container listens on 3000, while the host port defaults to 3002. Important for anyone attaching to the container, writing healthchecks, or changing the port.

## Approach
Option (A) from the issue: docs-only fix. Kept 3000 inside the container because that's the Next.js standalone-image convention; bucking it would surprise anyone deploying with the same image elsewhere.

## Test plan
- [x] `grep -n "3002\\|3000" Dockerfile docker-compose.yml package.json README.md` confirms all references align with the new wording.
- [x] No code changes; existing tests unaffected.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)