### PR TITLE
refactor: remove unused exported types from db/schema.ts (#131)

### DIFF
--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -121,13 +121,5 @@ export const apartmentDistances = sqliteTable(
 );
 
 export type Apartment = typeof apartments.$inferSelect;
-export type NewApartment = typeof apartments.$inferInsert;
 export type Rating = typeof ratings.$inferSelect;
-export type NewRating = typeof ratings.$inferInsert;
-export type User = typeof users.$inferSelect;
-export type NewUser = typeof users.$inferInsert;
-export type ApiUsage = typeof apiUsage.$inferSelect;
 export type LocationOfInterest = typeof locationsOfInterest.$inferSelect;
-export type NewLocationOfInterest = typeof locationsOfInterest.$inferInsert;
-export type ApartmentDistance = typeof apartmentDistances.$inferSelect;
-export type NewApartmentDistance = typeof apartmentDistances.$inferInsert;


### PR DESCRIPTION
## Summary
- Delete 8 unused exported types from `src/lib/db/schema.ts`: `NewApartment`, `NewRating`, `User`, `NewUser`, `ApiUsage`, `NewLocationOfInterest`, `ApartmentDistance`, `NewApartmentDistance`.
- Keep the three types that **are** imported by application code: `Apartment`, `Rating`, `LocationOfInterest`.

## Why
Per the 2026-05-06 codebase audit. Each removed type had zero references across `src/` (verified via grep). The `apartments`, `ratings`, etc. *table values* are still exported and used widely — only the inferred Drizzle types are removed. `ApartmentDistance` in `src/lib/apartment-sort.ts:30` is a homonymous local type, not the deleted schema export.

## Test plan
- [x] `npm test` — 296/296 pass.
- [x] `npm run build` — clean.

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)