### PR TITLE
test: raise overall coverage; lock thresholds (#129)

### DIFF
--- a/src/app/api/__tests__/apartments.test.ts
+++ b/src/app/api/__tests__/apartments.test.ts
@@ -200,6 +200,150 @@ describe("POST /api/apartments", () => {
     const data = await res.json();
     expect(data.name).toBe("New Place");
   });
+
+  it("retries on unique-constraint collisions and eventually succeeds", async () => {
+    const newApt = { name: "Retry Apt", address: null };
+    let attempts = 0;
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockImplementation(async () => {
+          attempts += 1;
+          if (attempts < 3) {
+            throw new Error("UNIQUE constraint failed: apartments.short_code");
+          }
+          return [{ id: 7, ...newApt }];
+        }),
+      }),
+    });
+
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: JSON.stringify(newApt),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    expect(attempts).toBeGreaterThanOrEqual(3);
+  });
+
+  it("returns 500 when the short-code retry budget is exhausted", async () => {
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockRejectedValue(
+          new Error("UNIQUE constraint failed: apartments.short_code")
+        ),
+      }),
+    });
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: JSON.stringify({ name: "x", address: null }),
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("ignores invalid availableFrom (stores null)", async () => {
+    let captured: Record<string, unknown> | null = null;
+    mockInsert.mockReturnValue({
+      values: vi.fn((v: Record<string, unknown>) => {
+        captured = v;
+        return {
+          returning: vi.fn().mockResolvedValue([{ id: 1, ...v }]),
+        };
+      }),
+    });
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "x",
+        address: null,
+        availableFrom: "not-a-date",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    expect((captured as Record<string, unknown>).availableFrom).toBeNull();
+  });
+
+  it("preserves a valid ISO availableFrom", async () => {
+    let captured: Record<string, unknown> | null = null;
+    mockInsert.mockReturnValue({
+      values: vi.fn((v: Record<string, unknown>) => {
+        captured = v;
+        return {
+          returning: vi.fn().mockResolvedValue([{ id: 1, ...v }]),
+        };
+      }),
+    });
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "x",
+        address: null,
+        availableFrom: "2026-07-01",
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    expect((captured as Record<string, unknown>).availableFrom).toBe(
+      "2026-07-01"
+    );
+  });
+
+  it("serializes rawExtractedData as JSON when provided", async () => {
+    let captured: Record<string, unknown> | null = null;
+    mockInsert.mockReturnValue({
+      values: vi.fn((v: Record<string, unknown>) => {
+        captured = v;
+        return {
+          returning: vi.fn().mockResolvedValue([{ id: 1, ...v }]),
+        };
+      }),
+    });
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "x",
+        address: null,
+        rawExtractedData: { foo: "bar", n: 42 },
+      }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(201);
+    const stored = (captured as Record<string, string>).rawExtractedData;
+    expect(JSON.parse(stored)).toEqual({ foo: "bar", n: 42 });
+  });
+
+  it("returns 500 on a non-constraint database error", async () => {
+    mockInsert.mockReturnValue({
+      values: vi.fn().mockReturnValue({
+        returning: vi.fn().mockRejectedValue(new Error("disk full")),
+      }),
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: JSON.stringify({ name: "x", address: null }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    const data = await res.json();
+    expect(data.error).toMatch(/disk full/);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("returns 500 on malformed JSON body", async () => {
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: "{not json",
+      headers: { "content-type": "application/json" },
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(req);
+    expect(res.status).toBe(500);
+    expect(errSpy).toHaveBeenCalled();
+  });
 });
 
 describe("GET /api/apartments/[id]", () => {

--- a/src/lib/__tests__/locations.test.ts
+++ b/src/lib/__tests__/locations.test.ts
@@ -4,6 +4,7 @@ import { locationsOfInterest, apartments } from "@/lib/db/schema";
 import {
   createLocation,
   deleteLocation,
+  getLocation,
   listLocations,
   moveLocation,
   updateLocation,
@@ -116,5 +117,64 @@ describe("locations", () => {
     await moveLocation(b.id, "down");
     const list = await listLocations();
     expect(list.map((l) => l.label)).toEqual(["A", "B"]);
+  });
+
+  it("getLocation returns null when the id is not found", async () => {
+    expect(await getLocation(99999)).toBeNull();
+  });
+
+  it("updateLocation patches address and triggers a re-geocode pass", async () => {
+    const created = await createLocation({
+      label: "A",
+      icon: "Train",
+      address: "Old St",
+    });
+    const updated = await updateLocation(created.id, { address: "New St 2" });
+    expect(updated.address).toBe("New St 2");
+  });
+
+  it("updateLocation patches icon", async () => {
+    const created = await createLocation({
+      label: "A",
+      icon: "Train",
+      address: "X",
+    });
+    const updated = await updateLocation(created.id, { icon: "Bus" });
+    expect(updated.icon).toBe("Bus");
+  });
+
+  it("updateLocation rejects an empty label or address (whitespace only)", async () => {
+    const created = await createLocation({
+      label: "A",
+      icon: "Train",
+      address: "X",
+    });
+    await expect(
+      updateLocation(created.id, { label: "   " })
+    ).rejects.toThrow(/label/i);
+    await expect(
+      updateLocation(created.id, { address: "  " })
+    ).rejects.toThrow(/address/i);
+  });
+
+  it("updateLocation rejects an unknown icon", async () => {
+    const created = await createLocation({
+      label: "A",
+      icon: "Train",
+      address: "X",
+    });
+    await expect(
+      updateLocation(created.id, { icon: "Skull" })
+    ).rejects.toThrow(/icon/i);
+  });
+
+  it("updateLocation throws when the id does not exist", async () => {
+    await expect(
+      updateLocation(99999, { label: "X" })
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it("moveLocation throws when the id does not exist", async () => {
+    await expect(moveLocation(99999, "up")).rejects.toThrow(/not found/i);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,16 @@ export default defineConfig({
     include: ["src/**/__tests__/**/*.test.{ts,tsx}"],
     testTimeout: 15000,
     hookTimeout: 15000,
+    coverage: {
+      // Floor — we're well above as of #129; set here so a regression
+      // (or a sneaky `if` slipping through without a test) fails CI.
+      thresholds: {
+        lines: 80,
+        statements: 80,
+        functions: 78,
+        branches: 75,
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Raise repo-wide branch coverage above the issue's 75% target.
- Add CI-enforced coverage thresholds in `vitest.config.ts`.

## Coverage delta

| Metric | Before | After | Threshold |
|---|---|---|---|
| Statements | 80.97% | **83.52%** | 80 |
| Branches | 73.94% | **76.58%** | 75 |
| Functions | 79.04% | **80.84%** | 78 |
| Lines | 82.35% | **84.9%** | 80 |

## What's added
- **`src/app/api/__tests__/apartments.test.ts`** (+7 tests): POST short-code retry on UNIQUE collision, retry budget exhaustion, valid & invalid `availableFrom`, `rawExtractedData` JSON serialization, non-constraint DB 500, malformed JSON 500.
- **`src/lib/__tests__/locations.test.ts`** (+7 tests): `getLocation` null path, `updateLocation` address-change/icon-change, validation on empty label/address/icon, `updateLocation` id-not-found, `moveLocation` id-not-found.
- **`vitest.config.ts`**: `coverage.thresholds` block — lines/statements 80, branches 75, functions 78. Floor only; we're sitting comfortably above.

## Test plan
- [x] `npx vitest run` — 338/338 (was 324 + 14 new).
- [x] `npx vitest run --coverage` — thresholds pass; CI now fails on regression.

## Files still below ideal (not addressed here)
Per-file gaps remain in:
- `compare/page.tsx`, `settings/page.tsx`, `apartments/[id]/page.tsx` (already covered by issues / not the lowest-leverage targets).
- `apartments-overview-map.tsx` (Leaflet branches require a real DOM with map).
- `db/migrate.ts` (error/recovery branches).
- `db/schema.ts` (table definitions — % is misleading; 100% branches).
- shadcn `ui/dropdown-menu.tsx` (vendored).

These can be addressed incrementally without violating the floor.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)