### PR TITLE
refactor: split four oversized pages into colocated components (#130)

### DIFF
--- a/src/app/apartments/[id]/_components/apartment-actions.tsx
+++ b/src/app/apartments/[id]/_components/apartment-actions.tsx
@@ -1,0 +1,91 @@
+import { Button, buttonVariants } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+interface ApartmentActionsProps {
+  pdfUrl: string | null;
+  listingUrl: string | null;
+  editing: boolean;
+  reprocessing: boolean;
+  deleting: boolean;
+  onEdit: () => void;
+  onReprocess: () => void;
+  onDelete: () => void;
+}
+
+export function ApartmentActions({
+  pdfUrl,
+  listingUrl,
+  editing,
+  reprocessing,
+  deleting,
+  onEdit,
+  onReprocess,
+  onDelete,
+}: ApartmentActionsProps) {
+  return (
+    <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
+      {pdfUrl && (
+        <a
+          href={pdfUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            buttonVariants({ variant: "outline", size: "sm" }),
+            "w-full sm:w-auto"
+          )}
+        >
+          View PDF
+        </a>
+      )}
+      {listingUrl ? (
+        <a
+          href={listingUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(
+            buttonVariants({ variant: "outline", size: "sm" }),
+            "w-full sm:w-auto"
+          )}
+        >
+          Original Listing
+        </a>
+      ) : (
+        <Badge
+          variant="secondary"
+          className="w-full justify-center text-muted-foreground sm:w-auto sm:justify-start"
+        >
+          URL missing
+        </Badge>
+      )}
+      {!editing && (
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onEdit}
+          className="w-full sm:w-auto"
+        >
+          Edit
+        </Button>
+      )}
+      <Button
+        variant="outline"
+        size="sm"
+        disabled={reprocessing || editing || !pdfUrl}
+        onClick={onReprocess}
+        className="w-full sm:w-auto"
+      >
+        {reprocessing ? "Reprocessing..." : "Reprocess"}
+      </Button>
+      <Button
+        variant="destructive"
+        size="sm"
+        disabled={deleting || editing}
+        onClick={onDelete}
+        className="w-full sm:w-auto"
+      >
+        {deleting ? "Deleting..." : "Delete"}
+      </Button>
+    </div>
+  );
+}

--- a/src/app/apartments/[id]/_components/apartment-metric-badges.tsx
+++ b/src/app/apartments/[id]/_components/apartment-metric-badges.tsx
@@ -1,0 +1,52 @@
+import { WashingMachine } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import type { ApartmentDetail } from "./types";
+
+export function ApartmentMetricBadges({
+  apartment,
+}: {
+  apartment: ApartmentDetail;
+}) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {apartment.rentChf && (
+        <Badge variant="secondary">
+          CHF {apartment.rentChf.toLocaleString()}/mo
+        </Badge>
+      )}
+      {apartment.sizeM2 && (
+        <Badge variant="secondary">{apartment.sizeM2} m²</Badge>
+      )}
+      {apartment.numRooms && (
+        <Badge variant="secondary">{apartment.numRooms} rooms</Badge>
+      )}
+      {apartment.numBathrooms != null && (
+        <Badge variant="secondary">{apartment.numBathrooms} bath</Badge>
+      )}
+      {apartment.numBalconies != null && (
+        <Badge variant="secondary">
+          {apartment.numBalconies} balcon
+          {apartment.numBalconies !== 1 ? "ies" : "y"}
+        </Badge>
+      )}
+      <Badge
+        variant="secondary"
+        title={
+          apartment.hasWashingMachine === true
+            ? "Washing machine: yes"
+            : apartment.hasWashingMachine === false
+              ? "Washing machine: no (or shared)"
+              : "Washing machine: unknown"
+        }
+        className="gap-1"
+      >
+        <WashingMachine className="h-3 w-3" />
+        {apartment.hasWashingMachine === true
+          ? "Yes"
+          : apartment.hasWashingMachine === false
+            ? "No"
+            : "?"}
+      </Badge>
+    </div>
+  );
+}

--- a/src/app/apartments/[id]/_components/apartment-pager-nav.tsx
+++ b/src/app/apartments/[id]/_components/apartment-pager-nav.tsx
@@ -1,0 +1,52 @@
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface PagerNavProps {
+  prevId: number | null;
+  nextId: number | null;
+  position: number | null;
+  total: number;
+  onNavigate: (id: number) => void;
+}
+
+export function ApartmentPagerNav({
+  prevId,
+  nextId,
+  position,
+  total,
+  onNavigate,
+}: PagerNavProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={prevId === null}
+        onClick={() => {
+          if (prevId !== null) onNavigate(prevId);
+        }}
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Previous
+      </Button>
+      {position !== null && total > 0 && (
+        <span className="text-sm text-muted-foreground">
+          {position} of {total}
+        </span>
+      )}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={nextId === null}
+        onClick={() => {
+          if (nextId !== null) onNavigate(nextId);
+        }}
+      >
+        Next
+        <ArrowRight className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/app/apartments/[id]/_components/distance-section.tsx
+++ b/src/app/apartments/[id]/_components/distance-section.tsx
@@ -1,0 +1,64 @@
+import { iconComponentFor } from "@/lib/location-icons";
+import type { LocationLite } from "./types";
+
+interface DistanceSectionProps {
+  locations: LocationLite[];
+  distances: {
+    locationId: number;
+    bikeMin: number | null;
+    transitMin: number | null;
+  }[];
+  apartmentAddress: string | null;
+}
+
+export function DistanceSection({
+  locations,
+  distances,
+  apartmentAddress,
+}: DistanceSectionProps) {
+  const distancesByLoc = new Map(distances.map((d) => [d.locationId, d]));
+  return (
+    <div className="space-y-2">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+        Distance to locations
+      </h2>
+      <div className="space-y-1.5">
+        {locations.map((loc) => {
+          const Icon = iconComponentFor(loc.icon);
+          const d = distancesByLoc.get(loc.id);
+          const bike = d?.bikeMin;
+          const transit = d?.transitMin;
+          const mapsUrl = apartmentAddress
+            ? `https://www.google.com/maps/dir/?api=1&origin=${encodeURIComponent(apartmentAddress)}&destination=${encodeURIComponent(loc.address)}&travelmode=bicycling`
+            : null;
+          return (
+            <div key={loc.id} className="flex items-center gap-3 text-sm">
+              {mapsUrl ? (
+                <a
+                  href={mapsUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label={`Bike directions to ${loc.label}`}
+                  className="text-muted-foreground hover:text-foreground"
+                >
+                  <Icon className="h-4 w-4" />
+                </a>
+              ) : (
+                <Icon
+                  className="h-4 w-4 text-muted-foreground"
+                  aria-label={loc.label}
+                />
+              )}
+              <span className="font-medium">{loc.label}</span>
+              <span className="text-muted-foreground">
+                {bike != null ? `${bike} min bike` : "— bike"}
+                {" · "}
+                {transit != null ? `${transit} min transit` : "— transit"}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/apartments/[id]/_components/types.ts
+++ b/src/app/apartments/[id]/_components/types.ts
@@ -1,0 +1,42 @@
+export interface Rating {
+  id: number;
+  userName: string;
+  kitchen: number;
+  balconies: number;
+  location: number;
+  floorplan: number;
+  overallFeeling: number;
+  comment: string;
+}
+
+export interface ApartmentDetail {
+  id: number;
+  name: string;
+  address: string | null;
+  sizeM2: number | null;
+  numRooms: number | null;
+  numBathrooms: number | null;
+  numBalconies: number | null;
+  hasWashingMachine: boolean | null;
+  rentChf: number | null;
+  pdfUrl: string | null;
+  listingUrl: string | null;
+  summary: string | null;
+  availableFrom: string | null;
+  userEditedFields: string | null;
+  shortCode: string | null;
+  mapEmbedUrl: string | null;
+  ratings: Rating[];
+  distances: {
+    locationId: number;
+    bikeMin: number | null;
+    transitMin: number | null;
+  }[];
+}
+
+export interface LocationLite {
+  id: number;
+  label: string;
+  icon: string;
+  address: string;
+}

--- a/src/app/apartments/[id]/page.tsx
+++ b/src/app/apartments/[id]/page.tsx
@@ -3,16 +3,11 @@
 import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { Card, CardContent } from "@/components/ui/card";
-import { Button, buttonVariants } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { ShortCode } from "@/components/short-code";
 import { AddressLink } from "@/components/address-link";
 import { ApartmentMap } from "@/components/apartment-map";
-import { ArrowLeft, ArrowRight, WashingMachine } from "lucide-react";
-import { iconComponentFor } from "@/lib/location-icons";
 import { ErrorDisplay } from "@/components/error-display";
-import { cn } from "@/lib/utils";
 import {
   formFromApartment,
   formToPayload,
@@ -31,49 +26,18 @@ import {
 import { useApartmentPager } from "@/lib/use-apartment-pager";
 import { setUnsavedRating } from "@/lib/unsaved-changes";
 import { formatSwissDate } from "@/lib/iso-date";
+import { ApartmentPagerNav } from "./_components/apartment-pager-nav";
+import { ApartmentActions } from "./_components/apartment-actions";
+import { ApartmentMetricBadges } from "./_components/apartment-metric-badges";
+import { DistanceSection } from "./_components/distance-section";
+import type {
+  ApartmentDetail,
+  LocationLite,
+} from "./_components/types";
 
 interface ErrorState {
   headline: string;
   details?: ErrorDetails;
-}
-
-interface Rating {
-  id: number;
-  userName: string;
-  kitchen: number;
-  balconies: number;
-  location: number;
-  floorplan: number;
-  overallFeeling: number;
-  comment: string;
-}
-
-interface ApartmentDetail {
-  id: number;
-  name: string;
-  address: string | null;
-  sizeM2: number | null;
-  numRooms: number | null;
-  numBathrooms: number | null;
-  numBalconies: number | null;
-  hasWashingMachine: boolean | null;
-  rentChf: number | null;
-  pdfUrl: string | null;
-  listingUrl: string | null;
-  summary: string | null;
-  availableFrom: string | null;
-  userEditedFields: string | null;
-  shortCode: string | null;
-  mapEmbedUrl: string | null;
-  ratings: Rating[];
-  distances: { locationId: number; bikeMin: number | null; transitMin: number | null }[];
-}
-
-interface LocationLite {
-  id: number;
-  label: string;
-  icon: string;
-  address: string;
 }
 
 function getCookieValue(name: string): string | null {
@@ -377,37 +341,13 @@ export default function ApartmentDetailPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center gap-3">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={pager.prevId === null}
-          onClick={() => {
-            if (pager.prevId !== null) router.push(`/apartments/${pager.prevId}`);
-          }}
-        >
-          <ArrowLeft className="h-4 w-4" />
-          Previous
-        </Button>
-        {pager.position !== null && pager.total > 0 && (
-          <span className="text-sm text-muted-foreground">
-            {pager.position} of {pager.total}
-          </span>
-        )}
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          disabled={pager.nextId === null}
-          onClick={() => {
-            if (pager.nextId !== null) router.push(`/apartments/${pager.nextId}`);
-          }}
-        >
-          Next
-          <ArrowRight className="h-4 w-4" />
-        </Button>
-      </div>
+      <ApartmentPagerNav
+        prevId={pager.prevId}
+        nextId={pager.nextId}
+        position={pager.position}
+        total={pager.total}
+        onNavigate={(id) => router.push(`/apartments/${id}`)}
+      />
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="space-y-1">
           <ShortCode code={apartment.shortCode} size="lg" />
@@ -419,69 +359,16 @@ export default function ApartmentDetailPage() {
             />
           )}
         </div>
-        <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
-          {apartment.pdfUrl && (
-            <a
-              href={apartment.pdfUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={cn(
-                buttonVariants({ variant: "outline", size: "sm" }),
-                "w-full sm:w-auto"
-              )}
-            >
-              View PDF
-            </a>
-          )}
-          {apartment.listingUrl ? (
-            <a
-              href={apartment.listingUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className={cn(
-                buttonVariants({ variant: "outline", size: "sm" }),
-                "w-full sm:w-auto"
-              )}
-            >
-              Original Listing
-            </a>
-          ) : (
-            <Badge
-              variant="secondary"
-              className="w-full justify-center text-muted-foreground sm:w-auto sm:justify-start"
-            >
-              URL missing
-            </Badge>
-          )}
-          {!editing && (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={startEdit}
-              className="w-full sm:w-auto"
-            >
-              Edit
-            </Button>
-          )}
-          <Button
-            variant="outline"
-            size="sm"
-            disabled={reprocessing || editing || !apartment.pdfUrl}
-            onClick={handleReprocess}
-            className="w-full sm:w-auto"
-          >
-            {reprocessing ? "Reprocessing..." : "Reprocess"}
-          </Button>
-          <Button
-            variant="destructive"
-            size="sm"
-            disabled={deleting || editing}
-            onClick={handleDelete}
-            className="w-full sm:w-auto"
-          >
-            {deleting ? "Deleting..." : "Delete"}
-          </Button>
-        </div>
+        <ApartmentActions
+          pdfUrl={apartment.pdfUrl}
+          listingUrl={apartment.listingUrl}
+          editing={editing}
+          reprocessing={reprocessing}
+          deleting={deleting}
+          onEdit={startEdit}
+          onReprocess={handleReprocess}
+          onDelete={handleDelete}
+        />
       </div>
 
       {apartment.summary && (
@@ -513,45 +400,7 @@ export default function ApartmentDetailPage() {
           onCancel={cancelEdit}
         />
       ) : (
-        <div className="flex flex-wrap gap-2">
-          {apartment.rentChf && (
-            <Badge variant="secondary">
-              CHF {apartment.rentChf.toLocaleString()}/mo
-            </Badge>
-          )}
-          {apartment.sizeM2 && (
-            <Badge variant="secondary">{apartment.sizeM2} m²</Badge>
-          )}
-          {apartment.numRooms && (
-            <Badge variant="secondary">{apartment.numRooms} rooms</Badge>
-          )}
-          {apartment.numBathrooms != null && (
-            <Badge variant="secondary">{apartment.numBathrooms} bath</Badge>
-          )}
-          {apartment.numBalconies != null && (
-            <Badge variant="secondary">
-              {apartment.numBalconies} balcon{apartment.numBalconies !== 1 ? "ies" : "y"}
-            </Badge>
-          )}
-          <Badge
-            variant="secondary"
-            title={
-              apartment.hasWashingMachine === true
-                ? "Washing machine: yes"
-                : apartment.hasWashingMachine === false
-                  ? "Washing machine: no (or shared)"
-                  : "Washing machine: unknown"
-            }
-            className="gap-1"
-          >
-            <WashingMachine className="h-3 w-3" />
-            {apartment.hasWashingMachine === true
-              ? "Yes"
-              : apartment.hasWashingMachine === false
-                ? "No"
-                : "?"}
-          </Badge>
-        </div>
+        <ApartmentMetricBadges apartment={apartment} />
       )}
 
       {apartment.availableFrom && (
@@ -589,55 +438,3 @@ export default function ApartmentDetailPage() {
   );
 }
 
-function DistanceSection({
-  locations,
-  distances,
-  apartmentAddress,
-}: {
-  locations: LocationLite[];
-  distances: { locationId: number; bikeMin: number | null; transitMin: number | null }[];
-  apartmentAddress: string | null;
-}) {
-  const distancesByLoc = new Map(distances.map((d) => [d.locationId, d]));
-  return (
-    <div className="space-y-2">
-      <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-        Distance to locations
-      </h2>
-      <div className="space-y-1.5">
-        {locations.map((loc) => {
-          const Icon = iconComponentFor(loc.icon);
-          const d = distancesByLoc.get(loc.id);
-          const bike = d?.bikeMin;
-          const transit = d?.transitMin;
-          const mapsUrl = apartmentAddress
-            ? `https://www.google.com/maps/dir/?api=1&origin=${encodeURIComponent(apartmentAddress)}&destination=${encodeURIComponent(loc.address)}&travelmode=bicycling`
-            : null;
-          return (
-            <div key={loc.id} className="flex items-center gap-3 text-sm">
-              {mapsUrl ? (
-                <a
-                  href={mapsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label={`Bike directions to ${loc.label}`}
-                  className="text-muted-foreground hover:text-foreground"
-                >
-                  <Icon className="h-4 w-4" />
-                </a>
-              ) : (
-                <Icon className="h-4 w-4 text-muted-foreground" aria-label={loc.label} />
-              )}
-              <span className="font-medium">{loc.label}</span>
-              <span className="text-muted-foreground">
-                {bike != null ? `${bike} min bike` : "— bike"}
-                {" · "}
-                {transit != null ? `${transit} min transit` : "— transit"}
-              </span>
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}

--- a/src/app/apartments/_components/apartment-badges.tsx
+++ b/src/app/apartments/_components/apartment-badges.tsx
@@ -1,0 +1,34 @@
+import { AlertTriangle, CheckCircle2, Circle } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+
+export function GoneBadge() {
+  return (
+    <Badge
+      variant="secondary"
+      className="gap-1 border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300"
+    >
+      <AlertTriangle className="h-3 w-3" />
+      Gone
+    </Badge>
+  );
+}
+
+export function RatedBadge({ myRating }: { myRating: number | null }) {
+  if (myRating !== null) {
+    return (
+      <Badge
+        variant="secondary"
+        className="gap-1 border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300"
+      >
+        <CheckCircle2 className="h-3 w-3" />
+        Rated
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="outline" className="gap-1 text-muted-foreground">
+      <Circle className="h-3 w-3" />
+      Not yet rated
+    </Badge>
+  );
+}

--- a/src/app/apartments/_components/apartment-card.tsx
+++ b/src/app/apartments/_components/apartment-card.tsx
@@ -1,0 +1,53 @@
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { StarRating } from "@/components/star-rating";
+import { ShortCode } from "@/components/short-code";
+import { AddressLink } from "@/components/address-link";
+import { GoneBadge, RatedBadge } from "./apartment-badges";
+import type { ApartmentSummary } from "./apartment-summary";
+
+export function ApartmentCard({ apt }: { apt: ApartmentSummary }) {
+  return (
+    <Link href={`/apartments/${apt.id}`}>
+      <Card className="transition-shadow hover:shadow-md">
+        <CardContent className="space-y-2 p-4">
+          <div className="flex items-start justify-between gap-2">
+            <ShortCode code={apt.shortCode} size="md" />
+            <div className="flex items-center gap-1.5">
+              {apt.listingGone && <GoneBadge />}
+              <RatedBadge myRating={apt.myRating} />
+            </div>
+          </div>
+          <div className="flex items-start justify-between">
+            <h3 className="font-medium leading-tight">{apt.name}</h3>
+            {apt.avgOverall && (
+              <StarRating
+                value={Math.round(parseFloat(apt.avgOverall))}
+                readonly
+                size="sm"
+              />
+            )}
+          </div>
+          {apt.address && (
+            <AddressLink
+              address={apt.address}
+              className="text-sm text-muted-foreground"
+            />
+          )}
+          <div className="flex flex-wrap gap-2">
+            {apt.rentChf && (
+              <Badge variant="secondary">
+                CHF {apt.rentChf.toLocaleString()}
+              </Badge>
+            )}
+            {apt.sizeM2 && <Badge variant="secondary">{apt.sizeM2} m²</Badge>}
+            {apt.numRooms && (
+              <Badge variant="secondary">{apt.numRooms} rooms</Badge>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/src/app/apartments/_components/apartment-row.tsx
+++ b/src/app/apartments/_components/apartment-row.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link";
+import { Badge } from "@/components/ui/badge";
+import { StarRating } from "@/components/star-rating";
+import { ShortCode } from "@/components/short-code";
+import { GoneBadge, RatedBadge } from "./apartment-badges";
+import type { ApartmentSummary } from "./apartment-summary";
+
+export function ApartmentRow({ apt }: { apt: ApartmentSummary }) {
+  return (
+    <Link
+      href={`/apartments/${apt.id}`}
+      className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent/50"
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <ShortCode code={apt.shortCode} size="sm" />
+          <h3 className="truncate font-medium leading-tight">{apt.name}</h3>
+        </div>
+        {apt.address && (
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {apt.address}
+          </p>
+        )}
+      </div>
+      <div className="hidden flex-wrap items-center gap-2 sm:flex">
+        {apt.rentChf && (
+          <Badge variant="secondary">CHF {apt.rentChf.toLocaleString()}</Badge>
+        )}
+        {apt.numRooms && <Badge variant="secondary">{apt.numRooms} rm</Badge>}
+      </div>
+      <div className="flex shrink-0 items-center gap-1.5">
+        {apt.listingGone && <GoneBadge />}
+        <RatedBadge myRating={apt.myRating} />
+      </div>
+      {apt.avgOverall && (
+        <StarRating
+          value={Math.round(parseFloat(apt.avgOverall))}
+          readonly
+          size="sm"
+        />
+      )}
+    </Link>
+  );
+}

--- a/src/app/apartments/_components/apartment-summary.ts
+++ b/src/app/apartments/_components/apartment-summary.ts
@@ -1,0 +1,22 @@
+export interface ApartmentSummary {
+  id: number;
+  name: string;
+  address: string | null;
+  sizeM2: number | null;
+  numRooms: number | null;
+  numBathrooms: number | null;
+  numBalconies: number | null;
+  rentChf: number | null;
+  distances: {
+    locationId: number;
+    bikeMin: number | null;
+    transitMin: number | null;
+  }[];
+  shortCode: string | null;
+  avgOverall: string | null;
+  myRating: number | null;
+  createdAt: string | null;
+  listingGone: boolean | null;
+  latitude: number | null;
+  longitude: number | null;
+}

--- a/src/app/apartments/new/__tests__/full-flow.test.tsx
+++ b/src/app/apartments/new/__tests__/full-flow.test.tsx
@@ -65,14 +65,6 @@ function jsonRes(body: unknown, ok = true, status = 200) {
   return res as unknown as Response;
 }
 
-async function dropPdf(user: ReturnType<typeof userEvent.setup>, file: File) {
-  const input = document.querySelector(
-    'input[type="file"]'
-  ) as HTMLInputElement;
-  expect(input).toBeTruthy();
-  await user.upload(input, file);
-}
-
 beforeEach(() => {
   pushMock.mockReset();
   _resetBlobModeProbeForTests();

--- a/src/app/apartments/new/_components/review-step.tsx
+++ b/src/app/apartments/new/_components/review-step.tsx
@@ -1,0 +1,169 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  ApartmentFormFields,
+  type ApartmentForm,
+} from "@/components/apartment-form-fields";
+import type { ErrorDetails } from "@/lib/fetch-error";
+import type { UploadItem } from "./types";
+import { StatusBadge } from "./status-badge";
+
+interface ReviewStepProps {
+  items: UploadItem[];
+  saving: boolean;
+  error: { headline: string; details?: ErrorDetails } | null;
+  onSaveAll: () => void;
+  onUploadMore: () => void;
+  onRetry: (id: string) => void;
+  onUpdateItem: (id: string, patch: Partial<UploadItem>) => void;
+  onUpdateForm: (id: string, field: keyof ApartmentForm, value: string) => void;
+  onUpdateWashingMachine: (id: string, value: boolean | null) => void;
+  onDiscard: (id: string) => void;
+}
+
+export function ReviewStep({
+  items,
+  saving,
+  error,
+  onSaveAll,
+  onUploadMore,
+  onRetry,
+  onUpdateItem,
+  onUpdateForm,
+  onUpdateWashingMachine,
+  onDiscard,
+}: ReviewStepProps) {
+  const saveable = items.filter(
+    (i) =>
+      i.status === "done" && !i.saved && !i.discarded && i.form.name.trim()
+  );
+  const savedCount = items.filter((i) => i.saved).length;
+  const allDone = items.every(
+    (i) => i.saved || i.discarded || i.status === "error"
+  );
+
+  return (
+    <div className="mx-auto max-w-2xl space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Review Apartments</h1>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={onUploadMore}>
+            Upload more
+          </Button>
+          {saveable.length > 0 && (
+            <Button onClick={onSaveAll} disabled={saving}>
+              {saving
+                ? "Saving..."
+                : `Save ${saveable.length === 1 ? "apartment" : `all ${saveable.length}`}`}
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {allDone && savedCount > 0 && (
+        <p className="text-sm text-muted-foreground">
+          All apartments saved. Redirecting...
+        </p>
+      )}
+
+      {error && <ErrorDisplay headline={error.headline} details={error.details} />}
+
+      <div className="space-y-3">
+        {items.map((item) => {
+          if (item.discarded) return null;
+
+          return (
+            <Card key={item.id} className={cn(item.saved && "opacity-60")}>
+              <CardHeader
+                className="cursor-pointer"
+                onClick={() =>
+                  !item.saved &&
+                  onUpdateItem(item.id, { expanded: !item.expanded })
+                }
+              >
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-3 min-w-0">
+                    <span className="text-sm text-muted-foreground">
+                      {item.expanded ? "▼" : "▶"}
+                    </span>
+                    <div className="min-w-0">
+                      <CardTitle className="text-base truncate">
+                        {item.form.name || item.fileName}
+                      </CardTitle>
+                      <p className="text-xs text-muted-foreground truncate">
+                        {[
+                          item.form.address,
+                          item.form.rentChf && `CHF ${item.form.rentChf}`,
+                          item.form.sizeM2 && `${item.form.sizeM2} m²`,
+                          item.form.numRooms && `${item.form.numRooms} rooms`,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ") || item.fileName}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2 shrink-0">
+                    <StatusBadge
+                      status={item.status}
+                      error={item.error}
+                      saved={item.saved}
+                    />
+                    {!item.saved && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDiscard(item.id);
+                        }}
+                      >
+                        ✕
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              </CardHeader>
+
+              {item.status === "error" && item.error && (
+                <CardContent>
+                  <div className="flex items-center gap-2 flex-wrap">
+                    <p className="text-sm text-destructive">{item.error}</p>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => onRetry(item.id)}
+                    >
+                      Retry
+                    </Button>
+                  </div>
+                </CardContent>
+              )}
+
+              {item.expanded && !item.saved && item.status !== "error" && (
+                <CardContent>
+                  <ApartmentFormFields
+                    form={item.form}
+                    onChange={(field, value) =>
+                      onUpdateForm(item.id, field, value)
+                    }
+                    onWashingMachineChange={(v) =>
+                      onUpdateWashingMachine(item.id, v)
+                    }
+                  />
+                </CardContent>
+              )}
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/apartments/new/_components/single-entry-step.tsx
+++ b/src/app/apartments/new/_components/single-entry-step.tsx
@@ -1,0 +1,63 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { ErrorDisplay } from "@/components/error-display";
+import {
+  ApartmentFormFields,
+  type ApartmentForm,
+} from "@/components/apartment-form-fields";
+import type { ErrorDetails } from "@/lib/fetch-error";
+
+interface SingleEntryStepProps {
+  form: ApartmentForm;
+  saving: boolean;
+  error: { headline: string; details?: ErrorDetails } | null;
+  onSubmit: (e: React.FormEvent) => void;
+  onChange: (field: keyof ApartmentForm, value: string) => void;
+  onWashingMachineChange: (v: boolean | null) => void;
+  onCancel: () => void;
+}
+
+export function SingleEntryStep({
+  form,
+  saving,
+  error,
+  onSubmit,
+  onChange,
+  onWashingMachineChange,
+  onCancel,
+}: SingleEntryStepProps) {
+  return (
+    <div className="mx-auto max-w-lg">
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Apartment Manually</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            Fill in the apartment details
+          </p>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={onSubmit} className="space-y-4">
+            <ApartmentFormFields
+              form={form}
+              onChange={onChange}
+              onWashingMachineChange={onWashingMachineChange}
+            />
+
+            {error && (
+              <ErrorDisplay headline={error.headline} details={error.details} />
+            )}
+
+            <div className="flex gap-2">
+              <Button type="submit" className="flex-1" disabled={saving}>
+                {saving ? "Saving..." : "Save Apartment"}
+              </Button>
+              <Button type="button" variant="outline" onClick={onCancel}>
+                Cancel
+              </Button>
+            </div>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/apartments/new/_components/status-badge.tsx
+++ b/src/app/apartments/new/_components/status-badge.tsx
@@ -1,0 +1,31 @@
+import { Badge } from "@/components/ui/badge";
+import type { UploadItem } from "./types";
+
+export function StatusBadge({
+  status,
+  error,
+  saved,
+}: {
+  status: UploadItem["status"];
+  error?: string;
+  saved?: boolean;
+}) {
+  if (saved) {
+    return <Badge className="bg-green-100 text-green-700">Saved</Badge>;
+  }
+
+  switch (status) {
+    case "queued":
+      return <Badge variant="secondary">Queued</Badge>;
+    case "uploading":
+      return <Badge variant="secondary">Uploading...</Badge>;
+    case "done":
+      return <Badge className="bg-blue-100 text-blue-700">Parsed</Badge>;
+    case "error":
+      return (
+        <Badge variant="destructive" title={error}>
+          Error
+        </Badge>
+      );
+  }
+}

--- a/src/app/apartments/new/_components/types.ts
+++ b/src/app/apartments/new/_components/types.ts
@@ -1,0 +1,14 @@
+import type { ApartmentForm } from "@/components/apartment-form-fields";
+
+export type UploadItem = {
+  id: string;
+  fileName: string;
+  status: "queued" | "uploading" | "done" | "error";
+  error?: string;
+  errorReason?: "quota" | "invalid_pdf" | "unknown";
+  errorRetryAfterSeconds?: number;
+  form: ApartmentForm;
+  expanded: boolean;
+  saved: boolean;
+  discarded: boolean;
+};

--- a/src/app/apartments/new/_components/upload-step.tsx
+++ b/src/app/apartments/new/_components/upload-step.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { ErrorDisplay } from "@/components/error-display";
+import type { ErrorDetails } from "@/lib/fetch-error";
+
+interface UploadStepProps {
+  onFiles: (files: FileList) => void;
+  onManualEntry: () => void;
+  error: { headline: string; details?: ErrorDetails } | null;
+}
+
+export function UploadStep({ onFiles, onManualEntry, error }: UploadStepProps) {
+  const [dragOver, setDragOver] = useState(false);
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6">
+      <h1 className="text-2xl font-semibold">Upload Listings</h1>
+
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDragOver(true);
+        }}
+        onDragLeave={() => setDragOver(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDragOver(false);
+          onFiles(e.dataTransfer.files);
+        }}
+        className={cn(
+          "flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed p-12 transition-colors",
+          dragOver
+            ? "border-primary bg-primary/5"
+            : "border-muted-foreground/25"
+        )}
+      >
+        <p className="text-muted-foreground">
+          Drag and drop one or more PDFs here, or
+        </p>
+        <input
+          type="file"
+          accept=".pdf"
+          multiple
+          className="hidden"
+          id="pdf-file-input"
+          onChange={(e) => {
+            if (e.target.files) onFiles(e.target.files);
+          }}
+        />
+        <Button
+          variant="outline"
+          onClick={() => {
+            document.getElementById("pdf-file-input")?.click();
+          }}
+        >
+          Choose files
+        </Button>
+      </div>
+
+      {error && <ErrorDisplay headline={error.headline} details={error.details} />}
+
+      <div className="text-center">
+        <Button variant="link" onClick={onManualEntry}>
+          Or add manually without PDF
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/apartments/new/page.tsx
+++ b/src/app/apartments/new/page.tsx
@@ -2,13 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { cn } from "@/lib/utils";
-import { ErrorDisplay } from "@/components/error-display";
 import {
-  ApartmentFormFields,
   emptyApartmentForm,
   formFromExtracted,
   formToPayload,
@@ -20,24 +14,16 @@ import {
   fetchErrorFromException,
 } from "@/lib/fetch-error";
 import { uploadAndParsePdf } from "@/lib/upload-pdf";
+import { UploadStep } from "./_components/upload-step";
+import { ReviewStep } from "./_components/review-step";
+import { SingleEntryStep } from "./_components/single-entry-step";
+import { StatusBadge } from "./_components/status-badge";
+import type { UploadItem } from "./_components/types";
 
 interface ErrorState {
   headline: string;
   details?: ErrorDetails;
 }
-
-type UploadItem = {
-  id: string;
-  fileName: string;
-  status: "queued" | "uploading" | "done" | "error";
-  error?: string;
-  errorReason?: "quota" | "invalid_pdf" | "unknown";
-  errorRetryAfterSeconds?: number;
-  form: ApartmentForm;
-  expanded: boolean;
-  saved: boolean;
-  discarded: boolean;
-};
 
 export default function UploadPage() {
   const router = useRouter();
@@ -49,7 +35,6 @@ export default function UploadPage() {
   const [singleForm, setSingleForm] = useState<ApartmentForm>(emptyApartmentForm);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<ErrorState | null>(null);
-  const [dragOver, setDragOver] = useState(false);
   const processingRef = useRef(false);
   const fileMapRef = useRef<Map<string, File>>(new Map());
 
@@ -67,6 +52,19 @@ export default function UploadPage() {
           : item
       )
     );
+  }
+
+  function updateItemWashingMachine(id: string, value: boolean | null) {
+    setItems((prev) =>
+      prev.map((it) =>
+        it.id === id ? { ...it, form: { ...it.form, hasWashingMachine: value } } : it
+      )
+    );
+  }
+
+  function discardItem(id: string) {
+    fileMapRef.current.delete(id);
+    updateItem(id, { discarded: true });
   }
 
   async function parseOne(itemId: string, file: File) {
@@ -204,13 +202,7 @@ export default function UploadPage() {
 
   const handleFiles = useCallback(
     (fileList: FileList) => {
-      const files = Array.from(fileList);
-      if (files.length === 1) {
-        // Single file — same flow as before but through the batch system
-        processFiles(files);
-      } else {
-        processFiles(files);
-      }
+      processFiles(Array.from(fileList));
     },
     [processFiles]
   );
@@ -306,73 +298,19 @@ export default function UploadPage() {
     }
   }
 
-  // --- Upload step ---
   if (step === "upload") {
     return (
-      <div className="mx-auto max-w-lg space-y-6">
-        <h1 className="text-2xl font-semibold">Upload Listings</h1>
-
-        <div
-          onDragOver={(e) => {
-            e.preventDefault();
-            setDragOver(true);
-          }}
-          onDragLeave={() => setDragOver(false)}
-          onDrop={(e) => {
-            e.preventDefault();
-            setDragOver(false);
-            handleFiles(e.dataTransfer.files);
-          }}
-          className={cn(
-            "flex flex-col items-center justify-center gap-4 rounded-lg border-2 border-dashed p-12 transition-colors",
-            dragOver
-              ? "border-primary bg-primary/5"
-              : "border-muted-foreground/25"
-          )}
-        >
-          <p className="text-muted-foreground">
-            Drag and drop one or more PDFs here, or
-          </p>
-          <input
-            type="file"
-            accept=".pdf"
-            multiple
-            className="hidden"
-            id="pdf-file-input"
-            onChange={(e) => {
-              if (e.target.files) handleFiles(e.target.files);
-            }}
-          />
-          <Button
-            variant="outline"
-            onClick={() => {
-              document.getElementById("pdf-file-input")?.click();
-            }}
-          >
-            Choose files
-          </Button>
-        </div>
-
-        {error && (
-          <ErrorDisplay headline={error.headline} details={error.details} />
-        )}
-
-        <div className="text-center">
-          <Button
-            variant="link"
-            onClick={() => {
-              setSingleForm(emptyApartmentForm);
-              setStep("single");
-            }}
-          >
-            Or add manually without PDF
-          </Button>
-        </div>
-      </div>
+      <UploadStep
+        onFiles={handleFiles}
+        onManualEntry={() => {
+          setSingleForm(emptyApartmentForm);
+          setStep("single");
+        }}
+        error={error}
+      />
     );
   }
 
-  // --- Processing step ---
   if (step === "processing") {
     const doneCount = items.filter(
       (i) => i.status === "done" || i.status === "error"
@@ -397,230 +335,42 @@ export default function UploadPage() {
     );
   }
 
-  // --- Review step (batch) ---
   if (step === "review") {
-    const saveable = items.filter(
-      (i) => i.status === "done" && !i.saved && !i.discarded && i.form.name.trim()
-    );
-    const savedCount = items.filter((i) => i.saved).length;
-    const allDone = items.every(
-      (i) => i.saved || i.discarded || i.status === "error"
-    );
-
     return (
-      <div className="mx-auto max-w-2xl space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="text-2xl font-semibold">Review Apartments</h1>
-          <div className="flex gap-2">
-            <Button
-              variant="outline"
-              onClick={() => {
-                setItems([]);
-                setStep("upload");
-              }}
-            >
-              Upload more
-            </Button>
-            {saveable.length > 0 && (
-              <Button onClick={handleSaveAll} disabled={saving}>
-                {saving
-                  ? "Saving..."
-                  : `Save ${saveable.length === 1 ? "apartment" : `all ${saveable.length}`}`}
-              </Button>
-            )}
-          </div>
-        </div>
-
-        {allDone && savedCount > 0 && (
-          <p className="text-sm text-muted-foreground">
-            All apartments saved. Redirecting...
-          </p>
-        )}
-
-        {error && (
-          <ErrorDisplay headline={error.headline} details={error.details} />
-        )}
-
-        <div className="space-y-3">
-          {items.map((item) => {
-            if (item.discarded) return null;
-
-            return (
-              <Card
-                key={item.id}
-                className={cn(item.saved && "opacity-60")}
-              >
-                <CardHeader
-                  className="cursor-pointer"
-                  onClick={() =>
-                    !item.saved &&
-                    updateItem(item.id, { expanded: !item.expanded })
-                  }
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-3 min-w-0">
-                      <span className="text-sm text-muted-foreground">
-                        {item.expanded ? "▼" : "▶"}
-                      </span>
-                      <div className="min-w-0">
-                        <CardTitle className="text-base truncate">
-                          {item.form.name || item.fileName}
-                        </CardTitle>
-                        <p className="text-xs text-muted-foreground truncate">
-                          {[
-                            item.form.address,
-                            item.form.rentChf &&
-                              `CHF ${item.form.rentChf}`,
-                            item.form.sizeM2 && `${item.form.sizeM2} m²`,
-                            item.form.numRooms &&
-                              `${item.form.numRooms} rooms`,
-                          ]
-                            .filter(Boolean)
-                            .join(" · ") || item.fileName}
-                        </p>
-                      </div>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <StatusBadge
-                        status={item.status}
-                        error={item.error}
-                        saved={item.saved}
-                      />
-                      {!item.saved && (
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="h-7 w-7 p-0 text-muted-foreground hover:text-destructive"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            fileMapRef.current.delete(item.id);
-                            updateItem(item.id, { discarded: true });
-                          }}
-                        >
-                          ✕
-                        </Button>
-                      )}
-                    </div>
-                  </div>
-                </CardHeader>
-
-                {item.status === "error" && item.error && (
-                  <CardContent>
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <p className="text-sm text-destructive">{item.error}</p>
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => retryItem(item.id)}
-                      >
-                        Retry
-                      </Button>
-                    </div>
-                  </CardContent>
-                )}
-
-                {item.expanded && !item.saved && item.status !== "error" && (
-                  <CardContent>
-                    <ApartmentFormFields
-                      form={item.form}
-                      onChange={(field, value) =>
-                        updateItemForm(item.id, field, value)
-                      }
-                      onWashingMachineChange={(v) =>
-                        setItems((prev) =>
-                          prev.map((it) =>
-                            it.id === item.id
-                              ? { ...it, form: { ...it.form, hasWashingMachine: v } }
-                              : it
-                          )
-                        )
-                      }
-                    />
-                  </CardContent>
-                )}
-              </Card>
-            );
-          })}
-        </div>
-      </div>
+      <ReviewStep
+        items={items}
+        saving={saving}
+        error={error}
+        onSaveAll={handleSaveAll}
+        onUploadMore={() => {
+          setItems([]);
+          setStep("upload");
+        }}
+        onRetry={retryItem}
+        onUpdateItem={updateItem}
+        onUpdateForm={updateItemForm}
+        onUpdateWashingMachine={updateItemWashingMachine}
+        onDiscard={discardItem}
+      />
     );
   }
 
-  // --- Manual single entry ---
   return (
-    <div className="mx-auto max-w-lg">
-      <Card>
-        <CardHeader>
-          <CardTitle>Add Apartment Manually</CardTitle>
-          <p className="text-sm text-muted-foreground">
-            Fill in the apartment details
-          </p>
-        </CardHeader>
-        <CardContent>
-          <form onSubmit={handleSaveSingle} className="space-y-4">
-            <ApartmentFormFields
-              form={singleForm}
-              onChange={(field, value) =>
-                setSingleForm((prev) => ({ ...prev, [field]: value }))
-              }
-              onWashingMachineChange={(v) =>
-                setSingleForm((prev) => ({ ...prev, hasWashingMachine: v }))
-              }
-            />
-
-            {error && (
-          <ErrorDisplay headline={error.headline} details={error.details} />
-        )}
-
-            <div className="flex gap-2">
-              <Button type="submit" className="flex-1" disabled={saving}>
-                {saving ? "Saving..." : "Save Apartment"}
-              </Button>
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  setSingleForm(emptyApartmentForm);
-                  setStep("upload");
-                }}
-              >
-                Cancel
-              </Button>
-            </div>
-          </form>
-        </CardContent>
-      </Card>
-    </div>
+    <SingleEntryStep
+      form={singleForm}
+      saving={saving}
+      error={error}
+      onSubmit={handleSaveSingle}
+      onChange={(field, value) =>
+        setSingleForm((prev) => ({ ...prev, [field]: value }))
+      }
+      onWashingMachineChange={(v) =>
+        setSingleForm((prev) => ({ ...prev, hasWashingMachine: v }))
+      }
+      onCancel={() => {
+        setSingleForm(emptyApartmentForm);
+        setStep("upload");
+      }}
+    />
   );
-}
-
-// --- Status badge ---
-
-function StatusBadge({
-  status,
-  error,
-  saved,
-}: {
-  status: UploadItem["status"];
-  error?: string;
-  saved?: boolean;
-}) {
-  if (saved) {
-    return <Badge className="bg-green-100 text-green-700">Saved</Badge>;
-  }
-
-  switch (status) {
-    case "queued":
-      return <Badge variant="secondary">Queued</Badge>;
-    case "uploading":
-      return <Badge variant="secondary">Uploading...</Badge>;
-    case "done":
-      return <Badge className="bg-blue-100 text-blue-700">Parsed</Badge>;
-    case "error":
-      return (
-        <Badge variant="destructive" title={error}>
-          Error
-        </Badge>
-      );
-  }
 }

--- a/src/app/apartments/page.tsx
+++ b/src/app/apartments/page.tsx
@@ -2,20 +2,12 @@
 
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Card, CardContent } from "@/components/ui/card";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
-import { Badge } from "@/components/ui/badge";
-import { StarRating } from "@/components/star-rating";
-import { ShortCode } from "@/components/short-code";
-import { AddressLink } from "@/components/address-link";
 import {
-  AlertTriangle,
   ArrowDown,
   ArrowUp,
   Building2,
-  CheckCircle2,
-  Circle,
   LayoutGrid,
   List as ListIcon,
   Search,
@@ -49,29 +41,13 @@ import {
 } from "@/lib/apartment-sort";
 import type { LocationOfInterest } from "@/lib/db/schema";
 import { ApartmentsOverviewMap } from "@/components/apartments-overview-map";
+import { ApartmentCard } from "./_components/apartment-card";
+import { ApartmentRow } from "./_components/apartment-row";
+import type { ApartmentSummary } from "./_components/apartment-summary";
 
 interface ErrorState {
   headline: string;
   details?: ErrorDetails;
-}
-
-interface ApartmentSummary {
-  id: number;
-  name: string;
-  address: string | null;
-  sizeM2: number | null;
-  numRooms: number | null;
-  numBathrooms: number | null;
-  numBalconies: number | null;
-  rentChf: number | null;
-  distances: { locationId: number; bikeMin: number | null; transitMin: number | null }[];
-  shortCode: string | null;
-  avgOverall: string | null;
-  myRating: number | null;
-  createdAt: string | null;
-  listingGone: boolean | null;
-  latitude: number | null;
-  longitude: number | null;
 }
 
 type ViewMode = "grid" | "list";
@@ -371,48 +347,7 @@ export default function ApartmentsPage() {
           className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3"
         >
           {sortedApartments.map((apt) => (
-            <Link key={apt.id} href={`/apartments/${apt.id}`}>
-              <Card className="transition-shadow hover:shadow-md">
-                <CardContent className="space-y-2 p-4">
-                  <div className="flex items-start justify-between gap-2">
-                    <ShortCode code={apt.shortCode} size="md" />
-                    <div className="flex items-center gap-1.5">
-                      {apt.listingGone && <GoneBadge />}
-                      <RatedBadge myRating={apt.myRating} />
-                    </div>
-                  </div>
-                  <div className="flex items-start justify-between">
-                    <h3 className="font-medium leading-tight">{apt.name}</h3>
-                    {apt.avgOverall && (
-                      <StarRating
-                        value={Math.round(parseFloat(apt.avgOverall))}
-                        readonly
-                        size="sm"
-                      />
-                    )}
-                  </div>
-                  {apt.address && (
-                    <AddressLink
-                      address={apt.address}
-                      className="text-sm text-muted-foreground"
-                    />
-                  )}
-                  <div className="flex flex-wrap gap-2">
-                    {apt.rentChf && (
-                      <Badge variant="secondary">
-                        CHF {apt.rentChf.toLocaleString()}
-                      </Badge>
-                    )}
-                    {apt.sizeM2 && (
-                      <Badge variant="secondary">{apt.sizeM2} m²</Badge>
-                    )}
-                    {apt.numRooms && (
-                      <Badge variant="secondary">{apt.numRooms} rooms</Badge>
-                    )}
-                  </div>
-                </CardContent>
-              </Card>
-            </Link>
+            <ApartmentCard key={apt.id} apt={apt} />
           ))}
         </div>
       ) : (
@@ -421,81 +356,10 @@ export default function ApartmentsPage() {
           className="divide-y overflow-hidden rounded-lg border"
         >
           {sortedApartments.map((apt) => (
-            <Link
-              key={apt.id}
-              href={`/apartments/${apt.id}`}
-              className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-accent/50"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="flex items-center gap-2">
-                  <ShortCode code={apt.shortCode} size="sm" />
-                  <h3 className="truncate font-medium leading-tight">
-                    {apt.name}
-                  </h3>
-                </div>
-                {apt.address && (
-                  <p className="mt-0.5 truncate text-xs text-muted-foreground">
-                    {apt.address}
-                  </p>
-                )}
-              </div>
-              <div className="hidden flex-wrap items-center gap-2 sm:flex">
-                {apt.rentChf && (
-                  <Badge variant="secondary">
-                    CHF {apt.rentChf.toLocaleString()}
-                  </Badge>
-                )}
-                {apt.numRooms && (
-                  <Badge variant="secondary">{apt.numRooms} rm</Badge>
-                )}
-              </div>
-              <div className="flex shrink-0 items-center gap-1.5">
-                {apt.listingGone && <GoneBadge />}
-                <RatedBadge myRating={apt.myRating} />
-              </div>
-              {apt.avgOverall && (
-                <StarRating
-                  value={Math.round(parseFloat(apt.avgOverall))}
-                  readonly
-                  size="sm"
-                />
-              )}
-            </Link>
+            <ApartmentRow key={apt.id} apt={apt} />
           ))}
         </div>
       )}
     </div>
-  );
-}
-
-function GoneBadge() {
-  return (
-    <Badge
-      variant="secondary"
-      className="gap-1 border-red-200 bg-red-50 text-red-700 dark:border-red-900 dark:bg-red-950 dark:text-red-300"
-    >
-      <AlertTriangle className="h-3 w-3" />
-      Gone
-    </Badge>
-  );
-}
-
-function RatedBadge({ myRating }: { myRating: number | null }) {
-  if (myRating !== null) {
-    return (
-      <Badge
-        variant="secondary"
-        className="gap-1 border-green-200 bg-green-50 text-green-700 dark:border-green-900 dark:bg-green-950 dark:text-green-300"
-      >
-        <CheckCircle2 className="h-3 w-3" />
-        Rated
-      </Badge>
-    );
-  }
-  return (
-    <Badge variant="outline" className="gap-1 text-muted-foreground">
-      <Circle className="h-3 w-3" />
-      Not yet rated
-    </Badge>
   );
 }

--- a/src/app/compare/_components/compare-column-header.tsx
+++ b/src/app/compare/_components/compare-column-header.tsx
@@ -1,0 +1,70 @@
+import { ExternalLink, FileText } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ShortCode } from "@/components/short-code";
+import { AddressLink } from "@/components/address-link";
+import type { ApartmentWithRatings } from "./compare-types";
+
+export function CompareColumnHeader({
+  apt,
+  onHide,
+}: {
+  apt: ApartmentWithRatings;
+  onHide: (id: number) => void;
+}) {
+  return (
+    <th className="min-w-[160px] px-4 py-3 text-left font-medium">
+      <div className="flex items-start justify-between gap-2">
+        <div className="space-y-1">
+          <div className="flex items-center gap-1.5">
+            <a
+              href={`/apartments/${apt.id}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-semibold hover:underline"
+            >
+              {apt.name}
+            </a>
+            {apt.pdfUrl && (
+              <a
+                href={apt.pdfUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`View PDF for ${apt.name}`}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <FileText className="h-3.5 w-3.5" />
+              </a>
+            )}
+            {apt.listingUrl && (
+              <a
+                href={apt.listingUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label={`Original listing for ${apt.name}`}
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            )}
+          </div>
+          <ShortCode code={apt.shortCode} />
+          {apt.address && (
+            <AddressLink
+              address={apt.address}
+              className="text-xs font-normal text-muted-foreground"
+            />
+          )}
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label={`Hide ${apt.name}`}
+          className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+          onClick={() => onHide(apt.id)}
+        >
+          ✕
+        </Button>
+      </div>
+    </th>
+  );
+}

--- a/src/app/compare/_components/compare-table.tsx
+++ b/src/app/compare/_components/compare-table.tsx
@@ -1,0 +1,236 @@
+import { Fragment } from "react";
+import { cn } from "@/lib/utils";
+import { StarRating } from "@/components/star-rating";
+import { iconComponentFor } from "@/lib/location-icons";
+import type { LocationOfInterest } from "@/lib/db/schema";
+import { CompareColumnHeader } from "./compare-column-header";
+import {
+  metricRows,
+  ratingKeys,
+  ratingLabels,
+  type ApartmentWithRatings,
+} from "./compare-types";
+
+interface CompareTableProps {
+  visible: ApartmentWithRatings[];
+  sortedVisible: ApartmentWithRatings[];
+  locations: LocationOfInterest[];
+  onHide: (id: number) => void;
+}
+
+export function CompareTable({
+  visible,
+  sortedVisible,
+  locations,
+  onHide,
+}: CompareTableProps) {
+  const allUsers = [
+    ...new Set(visible.flatMap((a) => a.ratings.map((r) => r.userName))),
+  ];
+
+  function findBest(key: string, direction: string) {
+    const values = visible
+      .map(
+        (a) =>
+          (a as unknown as Record<string, unknown>)[key] as number | null
+      )
+      .filter((v): v is number => v != null);
+    if (values.length === 0) return null;
+    return direction === "min" ? Math.min(...values) : Math.max(...values);
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-lg border">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/50">
+            <th className="sticky left-0 z-10 bg-muted/50 px-4 py-3 text-left font-medium">
+              &nbsp;
+            </th>
+            {sortedVisible.map((apt) => (
+              <CompareColumnHeader key={apt.id} apt={apt} onHide={onHide} />
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {metricRows.map((metric) => {
+            const bestVal = findBest(metric.key, metric.best);
+            return (
+              <tr key={metric.key} className="border-b">
+                <td className="sticky left-0 z-10 bg-background px-4 py-2 font-medium">
+                  {metric.label}
+                </td>
+                {sortedVisible.map((apt) => {
+                  const val = (apt as unknown as Record<string, unknown>)[
+                    metric.key
+                  ] as number | null;
+                  const isBest = val != null && val === bestVal;
+                  return (
+                    <td
+                      key={apt.id}
+                      className={cn(
+                        "px-4 py-2",
+                        isBest && "font-semibold text-green-600"
+                      )}
+                    >
+                      {val != null ? metric.format(val) : "—"}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+
+          {locations.map((loc) => {
+            const Icon = iconComponentFor(loc.icon);
+            return (
+              <tr key={`loc-${loc.id}`} className="border-b">
+                <td
+                  className="sticky left-0 z-10 bg-background px-4 py-2 font-medium"
+                  title={`Bike + transit to ${loc.label}`}
+                >
+                  <Icon className="h-4 w-4" aria-label={loc.label} />
+                </td>
+                {sortedVisible.map((apt) => {
+                  const d = apt.distances.find(
+                    (x) => x.locationId === loc.id
+                  );
+                  const bike = d?.bikeMin ?? null;
+                  const transit = d?.transitMin ?? null;
+                  return (
+                    <td key={apt.id} className="px-4 py-2 text-xs">
+                      {bike == null && transit == null ? (
+                        "—"
+                      ) : (
+                        <>
+                          {bike != null ? `${bike}` : "—"}
+                          {" / "}
+                          {transit != null ? `${transit} min` : "— min"}
+                        </>
+                      )}
+                    </td>
+                  );
+                })}
+              </tr>
+            );
+          })}
+
+          <tr className="border-b">
+            <td className="sticky left-0 z-10 bg-background px-4 py-2 font-medium">
+              Washing machine
+            </td>
+            {sortedVisible.map((apt) => (
+              <td
+                key={apt.id}
+                className={cn(
+                  "px-4 py-2",
+                  apt.hasWashingMachine === true &&
+                    "font-semibold text-green-600"
+                )}
+                title={
+                  apt.hasWashingMachine === true
+                    ? "Yes"
+                    : apt.hasWashingMachine === false
+                      ? "No (or shared)"
+                      : "Unknown"
+                }
+              >
+                {apt.hasWashingMachine === true
+                  ? "✓"
+                  : apt.hasWashingMachine === false
+                    ? "✕"
+                    : "—"}
+              </td>
+            ))}
+          </tr>
+
+          {allUsers.map((user) => (
+            <Fragment key={`user-${user}`}>
+              <tr className="border-b bg-muted/30">
+                <td
+                  colSpan={visible.length + 1}
+                  className="sticky left-0 z-10 bg-muted/30 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  {user}&apos;s ratings
+                </td>
+              </tr>
+              {ratingKeys.map((rKey) => (
+                <tr key={`${user}-${rKey}`} className="border-b">
+                  <td className="sticky left-0 z-10 bg-background px-4 py-2 pl-8 text-muted-foreground">
+                    {ratingLabels[rKey]}
+                  </td>
+                  {sortedVisible.map((apt) => {
+                    const rating = apt.ratings.find(
+                      (r) => r.userName === user
+                    );
+                    return (
+                      <td key={apt.id} className="px-4 py-2">
+                        {rating ? (
+                          <StarRating value={rating[rKey]} readonly size="sm" />
+                        ) : (
+                          <span className="text-muted-foreground">—</span>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+              <tr key={`${user}-comment`} className="border-b">
+                <td className="sticky left-0 z-10 bg-background px-4 py-2 pl-8 text-muted-foreground">
+                  Comment
+                </td>
+                {sortedVisible.map((apt) => {
+                  const rating = apt.ratings.find(
+                    (r) => r.userName === user
+                  );
+                  return (
+                    <td
+                      key={apt.id}
+                      className="max-w-[200px] px-4 py-2 text-xs"
+                    >
+                      {rating?.comment || "—"}
+                    </td>
+                  );
+                })}
+              </tr>
+            </Fragment>
+          ))}
+
+          <tr className="border-b bg-muted/30">
+            <td
+              colSpan={visible.length + 1}
+              className="sticky left-0 z-10 bg-muted/30 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Average Ratings
+            </td>
+          </tr>
+          {ratingKeys.map((rKey) => (
+            <tr key={`avg-${rKey}`} className="border-b">
+              <td className="sticky left-0 z-10 bg-background px-4 py-2 pl-8 font-medium">
+                {ratingLabels[rKey]}
+              </td>
+              {sortedVisible.map((apt) => {
+                const vals = apt.ratings
+                  .map((r) => r[rKey])
+                  .filter((v) => v > 0);
+                const avg =
+                  vals.length > 0
+                    ? vals.reduce((a, b) => a + b, 0) / vals.length
+                    : 0;
+                return (
+                  <td key={apt.id} className="px-4 py-2">
+                    {avg > 0 ? (
+                      <StarRating value={Math.round(avg)} readonly size="sm" />
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/compare/_components/compare-types.ts
+++ b/src/app/compare/_components/compare-types.ts
@@ -1,0 +1,79 @@
+export interface ApartmentWithRatings {
+  id: number;
+  name: string;
+  address: string | null;
+  sizeM2: number | null;
+  numRooms: number | null;
+  numBathrooms: number | null;
+  numBalconies: number | null;
+  hasWashingMachine: boolean | null;
+  rentChf: number | null;
+  distances: {
+    locationId: number;
+    bikeMin: number | null;
+    transitMin: number | null;
+  }[];
+  pdfUrl: string | null;
+  listingUrl: string | null;
+  shortCode: string | null;
+  createdAt: string | null;
+  avgOverall: string | null;
+  ratings: {
+    userName: string;
+    kitchen: number;
+    balconies: number;
+    location: number;
+    floorplan: number;
+    overallFeeling: number;
+    comment: string;
+  }[];
+}
+
+export const metricRows = [
+  {
+    key: "rentChf",
+    label: "Rent (CHF)",
+    format: (v: number) => `${v.toLocaleString()}`,
+    best: "min",
+  },
+  {
+    key: "sizeM2",
+    label: "Size (m²)",
+    format: (v: number) => `${v}`,
+    best: "max",
+  },
+  {
+    key: "numRooms",
+    label: "Rooms",
+    format: (v: number) => `${v}`,
+    best: "max",
+  },
+  {
+    key: "numBathrooms",
+    label: "Bathrooms",
+    format: (v: number) => `${v}`,
+    best: "max",
+  },
+  {
+    key: "numBalconies",
+    label: "Balconies",
+    format: (v: number) => `${v}`,
+    best: "max",
+  },
+] as const;
+
+export const ratingKeys = [
+  "kitchen",
+  "balconies",
+  "location",
+  "floorplan",
+  "overallFeeling",
+] as const;
+
+export const ratingLabels: Record<string, string> = {
+  kitchen: "Kitchen",
+  balconies: "Balconies",
+  location: "Location",
+  floorplan: "Floorplan",
+  overallFeeling: "Overall",
+};

--- a/src/app/compare/page.tsx
+++ b/src/app/compare/page.tsx
@@ -3,17 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { Button, buttonVariants } from "@/components/ui/button";
-import { StarRating } from "@/components/star-rating";
-import { ShortCode } from "@/components/short-code";
-import { AddressLink } from "@/components/address-link";
-import { cn } from "@/lib/utils";
-import {
-  ArrowDown,
-  ArrowUp,
-  BarChart3,
-  ExternalLink,
-  FileText,
-} from "lucide-react";
+import { ArrowDown, ArrowUp, BarChart3 } from "lucide-react";
 import { ErrorDisplay } from "@/components/error-display";
 import {
   type ErrorDetails,
@@ -32,7 +22,6 @@ import {
   type SortField,
 } from "@/lib/apartment-sort";
 import type { LocationOfInterest } from "@/lib/db/schema";
-import { iconComponentFor } from "@/lib/location-icons";
 import { usePersistedEnum } from "@/lib/use-persisted-enum";
 import {
   Select,
@@ -41,55 +30,13 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { CompareTable } from "./_components/compare-table";
+import type { ApartmentWithRatings } from "./_components/compare-types";
 
 interface ErrorState {
   headline: string;
   details?: ErrorDetails;
 }
-
-interface ApartmentWithRatings {
-  id: number;
-  name: string;
-  address: string | null;
-  sizeM2: number | null;
-  numRooms: number | null;
-  numBathrooms: number | null;
-  numBalconies: number | null;
-  hasWashingMachine: boolean | null;
-  rentChf: number | null;
-  distances: { locationId: number; bikeMin: number | null; transitMin: number | null }[];
-  pdfUrl: string | null;
-  listingUrl: string | null;
-  shortCode: string | null;
-  createdAt: string | null;
-  avgOverall: string | null;
-  ratings: {
-    userName: string;
-    kitchen: number;
-    balconies: number;
-    location: number;
-    floorplan: number;
-    overallFeeling: number;
-    comment: string;
-  }[];
-}
-
-const metricRows = [
-  { key: "rentChf", label: "Rent (CHF)", format: (v: number) => `${v.toLocaleString()}`, best: "min" },
-  { key: "sizeM2", label: "Size (m²)", format: (v: number) => `${v}`, best: "max" },
-  { key: "numRooms", label: "Rooms", format: (v: number) => `${v}`, best: "max" },
-  { key: "numBathrooms", label: "Bathrooms", format: (v: number) => `${v}`, best: "max" },
-  { key: "numBalconies", label: "Balconies", format: (v: number) => `${v}`, best: "max" },
-] as const;
-
-const ratingKeys = ["kitchen", "balconies", "location", "floorplan", "overallFeeling"] as const;
-const ratingLabels: Record<string, string> = {
-  kitchen: "Kitchen",
-  balconies: "Balconies",
-  location: "Location",
-  floorplan: "Floorplan",
-  overallFeeling: "Overall",
-};
 
 export default function ComparePage() {
   const [apartments, setApartments] = useState<ApartmentWithRatings[]>([]);
@@ -203,20 +150,6 @@ export default function ComparePage() {
     );
   }
 
-  // Collect all unique user names
-  const allUsers = [
-    ...new Set(visible.flatMap((a) => a.ratings.map((r) => r.userName))),
-  ];
-
-  // Find best values for highlighting
-  function findBest(key: string, direction: string) {
-    const values = visible
-      .map((a) => (a as unknown as Record<string, unknown>)[key] as number | null)
-      .filter((v): v is number => v != null);
-    if (values.length === 0) return null;
-    return direction === "min" ? Math.min(...values) : Math.max(...values);
-  }
-
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between gap-3">
@@ -265,271 +198,12 @@ export default function ComparePage() {
         </div>
       </div>
 
-      <div className="overflow-x-auto rounded-lg border">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b bg-muted/50">
-              <th className="sticky left-0 z-10 bg-muted/50 px-4 py-3 text-left font-medium">
-                &nbsp;
-              </th>
-              {sortedVisible.map((apt) => (
-                <th
-                  key={apt.id}
-                  className="min-w-[160px] px-4 py-3 text-left font-medium"
-                >
-                  <div className="flex items-start justify-between gap-2">
-                    <div className="space-y-1">
-                      <div className="flex items-center gap-1.5">
-                        <a
-                          href={`/apartments/${apt.id}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="font-semibold hover:underline"
-                        >
-                          {apt.name}
-                        </a>
-                        {apt.pdfUrl && (
-                          <a
-                            href={apt.pdfUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            aria-label={`View PDF for ${apt.name}`}
-                            className="text-muted-foreground hover:text-foreground"
-                          >
-                            <FileText className="h-3.5 w-3.5" />
-                          </a>
-                        )}
-                        {apt.listingUrl && (
-                          <a
-                            href={apt.listingUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            aria-label={`Original listing for ${apt.name}`}
-                            className="text-muted-foreground hover:text-foreground"
-                          >
-                            <ExternalLink className="h-3.5 w-3.5" />
-                          </a>
-                        )}
-                      </div>
-                      <ShortCode code={apt.shortCode} />
-                      {apt.address && (
-                        <AddressLink
-                          address={apt.address}
-                          className="text-xs font-normal text-muted-foreground"
-                        />
-                      )}
-                    </div>
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      aria-label={`Hide ${apt.name}`}
-                      className="h-6 w-6 shrink-0 p-0 text-muted-foreground hover:text-destructive"
-                      onClick={() =>
-                        setHiddenIds((prev) => new Set([...prev, apt.id]))
-                      }
-                    >
-                      ✕
-                    </Button>
-                  </div>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {/* Metric rows */}
-            {metricRows.map((metric) => {
-              const bestVal = findBest(metric.key, metric.best);
-              return (
-                <tr key={metric.key} className="border-b">
-                  <td className="sticky left-0 z-10 bg-background px-4 py-2 font-medium">
-                    {metric.label}
-                  </td>
-                  {sortedVisible.map((apt) => {
-                    const val = (apt as unknown as Record<string, unknown>)[
-                      metric.key
-                    ] as number | null;
-                    const isBest = val != null && val === bestVal;
-                    return (
-                      <td
-                        key={apt.id}
-                        className={cn(
-                          "px-4 py-2",
-                          isBest && "font-semibold text-green-600"
-                        )}
-                      >
-                        {val != null ? metric.format(val) : "—"}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
-
-            {/* Per-location distance rows. Header is icon-only with tooltip
-                because 5 locations × bike+transit can otherwise crowd out the
-                table. Each cell renders 'bike / transit' minutes inline. */}
-            {locations.map((loc) => {
-              const Icon = iconComponentFor(loc.icon);
-              return (
-                <tr key={`loc-${loc.id}`} className="border-b">
-                  <td
-                    className="sticky left-0 z-10 bg-background px-4 py-2 font-medium"
-                    title={`Bike + transit to ${loc.label}`}
-                  >
-                    <Icon className="h-4 w-4" aria-label={loc.label} />
-                  </td>
-                  {sortedVisible.map((apt) => {
-                    const d = apt.distances.find(
-                      (x) => x.locationId === loc.id
-                    );
-                    const bike = d?.bikeMin ?? null;
-                    const transit = d?.transitMin ?? null;
-                    return (
-                      <td key={apt.id} className="px-4 py-2 text-xs">
-                        {bike == null && transit == null ? (
-                          "—"
-                        ) : (
-                          <>
-                            {bike != null ? `${bike}` : "—"}
-                            {" / "}
-                            {transit != null ? `${transit} min` : "— min"}
-                          </>
-                        )}
-                      </td>
-                    );
-                  })}
-                </tr>
-              );
-            })}
-
-            {/* Washing machine row */}
-            <tr className="border-b">
-              <td className="sticky left-0 z-10 bg-background px-4 py-2 font-medium">
-                Washing machine
-              </td>
-              {sortedVisible.map((apt) => (
-                <td
-                  key={apt.id}
-                  className={cn(
-                    "px-4 py-2",
-                    apt.hasWashingMachine === true && "font-semibold text-green-600"
-                  )}
-                  title={
-                    apt.hasWashingMachine === true
-                      ? "Yes"
-                      : apt.hasWashingMachine === false
-                        ? "No (or shared)"
-                        : "Unknown"
-                  }
-                >
-                  {apt.hasWashingMachine === true
-                    ? "✓"
-                    : apt.hasWashingMachine === false
-                      ? "✕"
-                      : "—"}
-                </td>
-              ))}
-            </tr>
-
-            {/* Rating rows per user */}
-            {allUsers.map((user) => (
-              <>
-                <tr key={`header-${user}`} className="border-b bg-muted/30">
-                  <td
-                    colSpan={visible.length + 1}
-                    className="sticky left-0 z-10 bg-muted/30 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-                  >
-                    {user}&apos;s ratings
-                  </td>
-                </tr>
-                {ratingKeys.map((rKey) => (
-                  <tr key={`${user}-${rKey}`} className="border-b">
-                    <td className="sticky left-0 z-10 bg-background px-4 py-2 pl-8 text-muted-foreground">
-                      {ratingLabels[rKey]}
-                    </td>
-                    {sortedVisible.map((apt) => {
-                      const rating = apt.ratings.find(
-                        (r) => r.userName === user
-                      );
-                      return (
-                        <td key={apt.id} className="px-4 py-2">
-                          {rating ? (
-                            <StarRating
-                              value={rating[rKey]}
-                              readonly
-                              size="sm"
-                            />
-                          ) : (
-                            <span className="text-muted-foreground">—</span>
-                          )}
-                        </td>
-                      );
-                    })}
-                  </tr>
-                ))}
-                {/* Comment row */}
-                <tr key={`${user}-comment`} className="border-b">
-                  <td className="sticky left-0 z-10 bg-background px-4 py-2 pl-8 text-muted-foreground">
-                    Comment
-                  </td>
-                  {sortedVisible.map((apt) => {
-                    const rating = apt.ratings.find(
-                      (r) => r.userName === user
-                    );
-                    return (
-                      <td
-                        key={apt.id}
-                        className="max-w-[200px] px-4 py-2 text-xs"
-                      >
-                        {rating?.comment || "—"}
-                      </td>
-                    );
-                  })}
-                </tr>
-              </>
-            ))}
-
-            {/* Average row */}
-            <tr className="border-b bg-muted/30">
-              <td
-                colSpan={visible.length + 1}
-                className="sticky left-0 z-10 bg-muted/30 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
-              >
-                Average Ratings
-              </td>
-            </tr>
-            {ratingKeys.map((rKey) => (
-              <tr key={`avg-${rKey}`} className="border-b">
-                <td className="sticky left-0 z-10 bg-background px-4 py-2 pl-8 font-medium">
-                  {ratingLabels[rKey]}
-                </td>
-                {sortedVisible.map((apt) => {
-                  const vals = apt.ratings
-                    .map((r) => r[rKey])
-                    .filter((v) => v > 0);
-                  const avg =
-                    vals.length > 0
-                      ? vals.reduce((a, b) => a + b, 0) / vals.length
-                      : 0;
-                  return (
-                    <td key={apt.id} className="px-4 py-2">
-                      {avg > 0 ? (
-                        <StarRating
-                          value={Math.round(avg)}
-                          readonly
-                          size="sm"
-                        />
-                      ) : (
-                        <span className="text-muted-foreground">—</span>
-                      )}
-                    </td>
-                  );
-                })}
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
+      <CompareTable
+        visible={visible}
+        sortedVisible={sortedVisible}
+        locations={locations}
+        onHide={(id) => setHiddenIds((prev) => new Set([...prev, id]))}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Each of the four >500-line pages identified in the audit gets a sibling `_components/` folder; large render blocks become focused presentation components.

## Page line-count delta
| File | Before | After | Δ |
|---|---|---|---|
| `apartments/[id]/page.tsx` | 643 | **440** | -32% |
| `apartments/new/page.tsx` | 626 | **376** | -40% |
| `apartments/page.tsx` | 501 | **365** | -27% |
| `compare/page.tsx` | 535 | **209** | -61% |

Three of four are under the 400-line target. `apartments/[id]/page.tsx` sits at 440; the remaining bulk is handlers (`handleDelete`, `handleReprocess`, `startEdit`, `cancelEdit`, `handleSaveEdit`, `handleSaveRating`) and effects tightly coupled to local state. Pulling those out would need a `useApartmentDetail` custom hook — saving for a follow-up.

## What was extracted
**`src/app/apartments/_components/`**
- `apartment-summary.ts` — list-card view model type
- `apartment-badges.tsx` — `GoneBadge`, `RatedBadge`
- `apartment-card.tsx`, `apartment-row.tsx` — grid + list item views

**`src/app/apartments/[id]/_components/`**
- `types.ts` — `Rating`, `ApartmentDetail`, `LocationLite`
- `distance-section.tsx` — locations distance list
- `apartment-pager-nav.tsx` — prev/next nav
- `apartment-actions.tsx` — View PDF / Listing / Edit / Reprocess / Delete toolbar
- `apartment-metric-badges.tsx` — read-only metric badges

**`src/app/apartments/new/_components/`**
- `types.ts` — `UploadItem`
- `status-badge.tsx` — Queued/Uploading/Parsed/Saved/Error badge
- `upload-step.tsx`, `review-step.tsx`, `single-entry-step.tsx` — three of the four flow steps

**`src/app/compare/_components/`**
- `compare-types.ts` — `ApartmentWithRatings` + metric/rating constants
- `compare-column-header.tsx` — table `<th>` per apartment
- `compare-table.tsx` — entire `<table>` body

## Test plan
- [x] `npm test` — 338/338.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean (one stale unused helper in `full-flow.test.tsx` removed).

## Behavior
None changed. All existing tests pass without modification beyond the lint fix.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)