### PR TITLE
docs: rewrite README as a comprehensive landing page (#135)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,86 +3,93 @@
 </p>
 
 <p align="center">
-  Collaborative apartment comparison tool for small groups hunting for rentals together.<br/>
-  Upload PDF listings, extract data with AI, rate apartments, compare side-by-side.
+  <strong>Compare apartments side-by-side without spreadsheets.</strong><br/>
+  Upload PDF listings, let AI pull out the numbers, rate places together with friends, see who's the best deal at a glance.
 </p>
 
 <p align="center">
   <a href="https://github.com/brlauuu/flatpare/actions/workflows/test.yml"><img alt="CI" src="https://github.com/brlauuu/flatpare/actions/workflows/test.yml/badge.svg" /></a>
-  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-3178C6?logo=typescript&logoColor=white" />
-  <img alt="Next.js" src="https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs" />
-  <img alt="React" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white" />
-  <img alt="Tailwind CSS" src="https://img.shields.io/badge/Tailwind-4-06B6D4?logo=tailwindcss&logoColor=white" />
+  <img alt="Next.js 16" src="https://img.shields.io/badge/Next.js-16-000000?logo=nextdotjs" />
+  <img alt="React 19" src="https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white" />
+  <img alt="TypeScript 6" src="https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white" />
+  <img alt="Tailwind 4" src="https://img.shields.io/badge/Tailwind-4-06B6D4?logo=tailwindcss&logoColor=white" />
   <img alt="Drizzle ORM" src="https://img.shields.io/badge/Drizzle-ORM-C5F74F?logo=drizzle&logoColor=black" />
-  <img alt="Vitest" src="https://img.shields.io/badge/Vitest-4-6E9F18?logo=vitest&logoColor=white" />
+  <img alt="Vitest 4" src="https://img.shields.io/badge/Vitest-4-6E9F18?logo=vitest&logoColor=white" />
+  <img alt="Node 24" src="https://img.shields.io/badge/Node-24-339933?logo=nodedotjs&logoColor=white" />
 </p>
 
-## Features
+<p align="center">
+  <em>Add a screenshot or short GIF of the apartments overview / compare page here once you have one — it sells the rest of the README.</em>
+</p>
 
-- **PDF upload & AI parsing** — listings are extracted into structured data (rent, size, rooms, address).
-- **Auto distance** — bike and transit travel time to user-managed locations of interest (work, schools, family).
-- **Star ratings & comparison grid** — each user rates on 5 categories; results show side-by-side.
-- **Simple auth** — shared password + display name, no accounts.
-- **Cloud or local** — deploy to Vercel, or run fully self-hosted.
+---
 
-## Quick start
+## What you get
+
+| | |
+|---|---|
+| 📄 **PDF → structured data** | Drop in a Swiss listing PDF, Gemini extracts rent, size, rooms, address, summary. Edits you make are preserved across re-parses. |
+| ⭐ **Per-user star ratings** | Each viewer rates kitchen, balconies, location, floorplan, and overall. Averages roll up automatically. |
+| 📊 **Comparison grid** | Sortable side-by-side table — best price, biggest, shortest commute — with hide/show per apartment. |
+| 🚲 **Auto distance** | Bike + transit minutes from each apartment to user-defined "locations of interest" (work, schools, family). |
+| 🗺️ **Map view** | Apartments overview map (Leaflet) plus an embedded Google Map per detail page. |
+| 💰 **Cost dashboard** | Tracks Gemini and Maps API usage with monthly cost estimates and a per-service breakdown. |
+| 🔐 **Simple auth** | Shared password + display name. No real accounts, no OAuth, no accidents. |
+| ☁️ **Cloud or local** | One repo runs on Vercel + Turso + Vercel Blob, or fully self-hosted with SQLite + local disk. |
+
+## Tech stack
+
+| Layer | Technology |
+|---|---|
+| Framework | **Next.js 16** App Router (Server Components + Route Handlers) |
+| Language | **TypeScript 6**, **React 19** |
+| Styling | **Tailwind CSS 4**, [shadcn/ui](https://ui.shadcn.com) |
+| Database | [**Drizzle ORM**](https://orm.drizzle.team) over libSQL — Turso (cloud) or local SQLite |
+| File storage | [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) (cloud) or `./uploads/` (local) |
+| AI | [Vercel AI SDK](https://sdk.vercel.ai) + Google Gemini 2.5 Flash |
+| Maps | Google Maps (Geocoding + Distance Matrix + Embed) with [OpenRouteService](https://openrouteservice.org) bike-distance fallback |
+| Tests | **Vitest 4** + React Testing Library, ~85% line coverage enforced in CI |
+| Deploy target | Vercel (preferred) or any Node 24+ host |
+
+## Quickstart
 
 ```bash
-cp .env.example .env.local   # set APP_PASSWORD at minimum
+cp .env.example .env.local        # set APP_PASSWORD at minimum
 docker compose up -d
 ```
 
-Open [http://localhost:3002](http://localhost:3002).
+Open <http://localhost:3002>. That's it for the local-only path — SQLite + filesystem uploads + manual entry, no cloud accounts required.
 
-For deployment and non-Docker setup, pick a path below.
+> **Port note:** the container listens on **3000**; `docker-compose.yml` publishes that to host port **3002**. Override the host side with `PORT=8080 docker compose up -d`. The container side is fixed.
 
-<details>
-<summary><strong>Deploy to Vercel</strong></summary>
-
-1. Import the repo in [Vercel](https://vercel.com/new).
-2. Add environment variables in **Project Settings > Environment Variables**:
-
-   | Variable | Required | Notes |
-   |----------|----------|-------|
-   | `APP_PASSWORD` | Yes | Shared access password |
-   | `TURSO_DATABASE_URL` | Yes | `libsql://...` URL from Turso |
-   | `TURSO_AUTH_TOKEN` | Yes | Auth token from Turso |
-   | `BLOB_READ_WRITE_TOKEN` | Yes | Auto-added when you connect Vercel Blob |
-   | `GOOGLE_GENERATIVE_AI_API_KEY` | Yes | PDF parsing |
-   | `GOOGLE_MAPS_API_KEY` | No | Distances, geocoding, embedded map (see [docs/google-apis.md](./docs/google-apis.md)) |
-
-3. Connect a **Blob store**: dashboard → **Storage** → **Create** → **Blob**.
-4. Push the database schema before first use:
-   ```bash
-   TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... npx drizzle-kit push
-   ```
-
-Subsequent pushes to `main` deploy automatically.
-
-</details>
-
-<details>
-<summary><strong>Cloud mode — run locally against Turso + Gemini</strong></summary>
-
-**Prerequisites:** Node.js 24+ (LTS), a [Turso](https://turso.tech) account, a [Google AI Studio](https://aistudio.google.com) API key, optionally a [Google Maps](https://console.cloud.google.com) key.
+## Running without Docker
 
 ```bash
-git clone <repo-url>
+git clone https://github.com/brlauuu/flatpare.git
 cd flatpare
 npm install
+cp .env.example .env.local        # set APP_PASSWORD
+npm run db:push                   # creates ./data/flatpare.db
+npm run dev                       # http://localhost:3002
 ```
 
-Create a Turso database:
+Drizzle migrations also run automatically at boot via `src/instrumentation.ts`, so first-time `npm run dev` is enough in most cases.
+
+<details>
+<summary><strong>Cloud mode — Turso + Gemini, run locally</strong></summary>
+
+**Prerequisites:** Node 24 LTS, a [Turso](https://turso.tech) database, a [Google AI Studio](https://aistudio.google.com) key, and (optional) a Google Maps Platform key.
 
 ```bash
+# Turso DB
 curl -sSfL https://get.tur.so/install.sh | bash
 turso auth signup
 turso db create flatpare
-turso db show flatpare --url           # libsql://flatpare-<you>.turso.io
-turso db tokens create flatpare        # auth token
+turso db show flatpare --url     # libsql://...
+turso db tokens create flatpare  # token
 ```
 
-Get a Gemini key at [aistudio.google.com/apikey](https://aistudio.google.com/apikey). For the Maps Platform key (distances, geocoding, embedded maps), enable **Geocoding API**, **Distance Matrix API**, and **Maps Embed API** in [Google Cloud Console](https://console.cloud.google.com/apis) and create a key — see [docs/google-apis.md](./docs/google-apis.md) for the full list and why each is needed.
+Get a Gemini key at <https://aistudio.google.com/apikey>. For Maps Platform (distances, geocoding, embedded maps) enable **Geocoding API**, **Distance Matrix API**, and **Maps Embed API** in [Google Cloud Console](https://console.cloud.google.com/apis) — see [docs/google-apis.md](./docs/google-apis.md) for full setup.
 
 Configure `.env.local`:
 
@@ -94,7 +101,7 @@ GOOGLE_GENERATIVE_AI_API_KEY=<key>
 GOOGLE_MAPS_API_KEY=<key, or omit>
 ```
 
-Push schema and run:
+Then:
 
 ```bash
 npx drizzle-kit push
@@ -102,188 +109,190 @@ npm run dev
 ```
 
 `BLOB_READ_WRITE_TOKEN` is only needed in production (Vercel adds it automatically).
-
 </details>
 
 <details>
-<summary><strong>Local / self-hosted — no cloud services</strong></summary>
+<summary><strong>Optional: OpenRouteService for bike distance</strong></summary>
 
-Runs with a local SQLite file, local filesystem storage, and free or no AI. The only required env var is `APP_PASSWORD`.
-
-```bash
-git clone <repo-url>
-cd flatpare
-npm install
-cp .env.example .env.local        # set APP_PASSWORD
-npx drizzle-kit push              # creates ./data/flatpare.db
-npm run dev
-```
-
-Data lives in `./data/flatpare.db`; uploaded PDFs go to `./uploads/`. Both are gitignored.
-
-**Optional — OpenRouteService for bike distance**
-
-Sign up at [openrouteservice.org/dev](https://openrouteservice.org/dev/#/signup) (free, no credit card). Transit is not supported — enter manually.
+Free, no credit card required. Sign up at [openrouteservice.org/dev](https://openrouteservice.org/dev/#/signup) and add to `.env.local`:
 
 ```env
 OPENROUTESERVICE_API_KEY=<key>
 ```
 
+Transit isn't supported — enter manually if you need it.
 </details>
 
-<details>
-<summary><strong>Docker details</strong></summary>
+## Deploying to Vercel
 
-The quick-start command above uses `docker compose up -d`. Data is persisted in Docker volumes (`flatpare-data`, `flatpare-uploads`).
+1. Import the repo in [Vercel](https://vercel.com/new).
+2. **Project Settings → Environment Variables** — add:
 
-Use a different host port:
+   | Variable | Required | Notes |
+   |---|---|---|
+   | `APP_PASSWORD` | yes | Shared access password |
+   | `TURSO_DATABASE_URL` | yes | `libsql://...` URL from Turso |
+   | `TURSO_AUTH_TOKEN` | yes | Auth token from Turso |
+   | `BLOB_READ_WRITE_TOKEN` | yes | Auto-added when you connect Vercel Blob |
+   | `GOOGLE_GENERATIVE_AI_API_KEY` | yes | Gemini PDF parsing |
+   | `GOOGLE_MAPS_API_KEY` | optional | Distances + geocoding + embedded map |
 
-```bash
-PORT=8080 docker compose up -d
+3. **Storage → Create → Blob** to provision the blob store.
+4. Push the schema once before first use:
+
+   ```bash
+   TURSO_DATABASE_URL=... TURSO_AUTH_TOKEN=... npx drizzle-kit push
+   ```
+
+5. Subsequent pushes to `main` deploy automatically. The `vercel-build` script in `package.json` runs the migration step inside the build.
+
+## Configuration
+
+All env vars live in `.env.local` (loaded via Next.js) or your Vercel project settings.
+
+| Variable | Required | Mode | Description |
+|---|---|---|---|
+| `APP_PASSWORD` | yes | both | Shared access password (env var, **not** the cookie name). |
+| `TURSO_DATABASE_URL` | cloud | cloud | Turso database URL. Local mode falls back to a SQLite file. |
+| `TURSO_AUTH_TOKEN` | cloud | cloud | Turso auth token. |
+| `BLOB_READ_WRITE_TOKEN` | cloud | cloud | Vercel Blob token (auto-set by Vercel). |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | optional | both | Without it, manual entry only. |
+| `GOOGLE_MAPS_API_KEY` | optional | both | Distances + geocoding + embed. |
+| `OPENROUTESERVICE_API_KEY` | optional | both | Bike-distance fallback when Maps key is unset. |
+| `LOCAL_DB_URL` | optional | local | Override the SQLite path (defaults to `file:./data/flatpare.db`; tests use `file:./data/test.db`). |
+| `DISABLE_SECURE_COOKIES` | optional | dev | Drops the `Secure` flag so cookies survive plain HTTP. |
+
+See [docs/google-apis.md](./docs/google-apis.md) for the Google Maps setup walk-through and [docs/security-notes.md](./docs/security-notes.md) for accepted `npm audit` advisories.
+
+## Auth model
+
+Flatpare uses a deliberately simple shared-password model — no accounts, no OAuth.
+
+- The password lives in the **`APP_PASSWORD` env var**. `verifyPassword(input)` (in `src/lib/auth.ts`) compares the submitted value against it.
+- A successful login sets two cookies:
+  - **`flatpare-auth=true`** (httpOnly) — `isAuthenticated()` checks this.
+  - **`flatpare-name=<display name>`** (readable from client JS) — `getDisplayName()` reads this.
+- API routes return **401** when `isAuthenticated()` is false. There is no `requireUser()` helper — guard explicitly per route.
+- `DISABLE_SECURE_COOKIES=true` strips the `Secure` flag so cookies work over plain HTTP in dev.
+
+## Project layout
+
+```
+src/
+  app/
+    page.tsx                      # Login (password gate)
+    add-user/page.tsx             # First-run user onboarding
+    apartments/
+      page.tsx                    # List view (grid + list, sortable, searchable)
+      _components/                # ApartmentCard, ApartmentRow, badges
+      new/page.tsx                # PDF upload + AI parse + review
+      new/_components/            # UploadStep, ReviewStep, SingleEntryStep, StatusBadge
+      [id]/page.tsx               # Apartment detail + ratings + edit
+      [id]/_components/           # PagerNav, Actions, MetricBadges, DistanceSection
+    compare/page.tsx              # Side-by-side comparison grid
+    compare/_components/          # CompareTable, CompareColumnHeader
+    costs/page.tsx                # API cost dashboard
+    guide/page.tsx                # In-app user guide (renders src/content/guide.md)
+    settings/page.tsx             # Locations of interest + distance recompute
+    api/
+      auth/                       # Password, name, users
+      apartments/                 # CRUD, ratings, reprocess, listing checks
+      parse-pdf/                  # Upload, AI extraction, blob upload tokens
+      geocode/backfill/           # Geocode rows missing lat/lng
+      locations/                  # Locations of interest CRUD + reorder
+      settings/                   # Recompute per-location distances
+      pdf/, uploads/              # Authenticated file streaming
+      costs/                      # API usage stats
+  components/                     # Shared UI (shadcn/ui + custom)
+  content/guide.md                # User guide source
+  lib/
+    db/                           # Drizzle schema, client, migration runner
+    auth.ts                       # Cookie helpers + password verifier
+    parse-pdf.ts                  # AI extraction (Gemini)
+    distance.ts                   # Distance (Maps / ORS)
+    geocode.ts                    # Address → lat/lng
+    locations.ts                  # Locations of interest helpers
+    listing-status.ts             # Detect expired listing URLs
+    map-embed.ts                  # Maps embed URL builder
+    short-code.ts                 # Apartment short-code generator
+    storage.ts                    # File storage (Blob / FS)
+    upload-pdf.ts                 # Client-direct Blob upload (>4.5 MB)
+  instrumentation.ts              # Boot hook — runs Drizzle migrations
+  proxy.ts                        # Auth gate (Next.js 16 renamed middleware.ts)
+drizzle/                          # SQL migrations
+docs/                             # google-apis.md, security-notes.md
 ```
 
-Rebuild after updates:
+## API surface
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `POST` | `/api/auth` | Verify password, set auth cookie |
+| `POST` | `/api/auth/name` | Set display-name cookie |
+| `GET` | `/api/auth/users` | List users |
+| `DELETE` | `/api/auth/users/[name]` | Remove a user |
+| `GET` / `POST` | `/api/apartments` | List / create |
+| `GET` / `PATCH` / `DELETE` | `/api/apartments/[id]` | Get, update, delete |
+| `POST` | `/api/apartments/[id]/ratings` | Upsert a rating |
+| `POST` | `/api/apartments/[id]/reprocess` | Re-run AI extraction |
+| `POST` | `/api/apartments/check-listings` | Probe URLs, mark expired |
+| `POST` | `/api/parse-pdf` | Upload PDF (≤ 4.5 MB), store, AI extract |
+| `GET` / `POST` | `/api/parse-pdf/upload-token` | Issue Blob client-upload tokens (large PDFs) |
+| `GET` | `/api/pdf/[...path]` | Authenticated PDF streaming |
+| `GET` | `/api/uploads/[...path]` | Authenticated raw upload streaming |
+| `GET` / `POST` | `/api/locations` | List / create locations of interest |
+| `GET` / `PUT` / `DELETE` | `/api/locations/[id]` | Get, update, delete |
+| `POST` | `/api/locations/[id]/move` | Reorder |
+| `POST` | `/api/geocode/backfill` | Geocode rows missing lat/lng |
+| `POST` | `/api/settings/recompute-distances` | Recompute all per-location distances |
+| `GET` | `/api/costs` | API usage stats + cost estimates |
+
+## Testing
 
 ```bash
+npm test            # one-shot
+npm run test:watch  # watch mode
+```
+
+[Vitest](https://vitest.dev/) + React Testing Library. Tests live next to their source in colocated `__tests__/` directories. CI fails if coverage drops below the floor configured in `vitest.config.ts` (lines ≥ 80 %, branches ≥ 75 %, functions ≥ 78 %, statements ≥ 80 %).
+
+## Database
+
+```bash
+npm run db:generate   # author a new migration
+npm run db:push       # push the schema directly (dev convenience)
+npm run db:migrate    # apply pending migrations
+npm run db:studio     # browser-based DB inspector
+```
+
+Schemas in `src/lib/db/schema.ts`, migrations in `drizzle/`. The runner in `src/lib/db/migrate.ts` is invoked automatically by `src/instrumentation.ts` at server start.
+
+## Docker
+
+```bash
+docker compose up -d            # default — host 3002 → container 3000
+PORT=8080 docker compose up -d  # different host port
+
+# Rebuild after pulling updates
 git pull
 docker compose build
 docker compose up -d
 ```
 
-</details>
-
-<details>
-<summary><strong>Tech stack</strong></summary>
-
-| Layer | Cloud (Vercel) | Local/self-hosted |
-|-------|---------------|-------------------|
-| Framework | Next.js 16 (App Router) | Same |
-| Database | SQLite via [Turso](https://turso.tech) | Local SQLite file |
-| ORM | [Drizzle ORM](https://orm.drizzle.team) | Same |
-| Styling | Tailwind CSS + [shadcn/ui](https://ui.shadcn.com) | Same |
-| File Storage | [Vercel Blob](https://vercel.com/docs/storage/vercel-blob) | Local filesystem |
-| PDF Parsing | [Vercel AI SDK](https://sdk.vercel.ai) + Google Gemini | Google Gemini or manual entry |
-| Distance API | Google Maps Distance Matrix | [OpenRouteService](https://openrouteservice.org) (free) or manual entry |
-| Deployment | [Vercel](https://vercel.com) | Any Node.js host |
-
-</details>
-
-<details>
-<summary><strong>Project structure</strong></summary>
-
-```
-src/
-  app/
-    page.tsx                    # Login (password gate)
-    add-user/page.tsx           # First-run user onboarding
-    apartments/
-      page.tsx                  # Apartment list
-      new/page.tsx              # PDF upload & parse
-      [id]/page.tsx             # Apartment detail & ratings
-    compare/page.tsx            # Comparison grid
-    costs/page.tsx              # API cost dashboard
-    guide/page.tsx              # In-app user guide
-    settings/page.tsx           # Locations of interest, distance recompute
-    api/
-      auth/                     # Password, name, users (incl. delete)
-      apartments/               # CRUD, ratings, reprocess, listing checks
-      parse-pdf/                # PDF upload, AI extraction, blob upload tokens
-      geocode/backfill/         # Geocode addresses missing lat/lng
-      locations/                # Locations of interest CRUD + reorder
-      settings/                 # Recompute per-location distances
-      pdf/, uploads/            # Authenticated file streaming
-      costs/                    # API usage cost estimates
-  components/                   # UI components (shadcn/ui + custom)
-  content/guide.md              # User guide markdown source
-  lib/
-    db/                         # Drizzle schema + client
-    auth.ts                     # Cookie/session helpers
-    parse-pdf.ts                # AI extraction (Gemini)
-    distance.ts                 # Distance (Google Maps / OpenRouteService)
-    geocode.ts                  # Address → lat/lng (Google / ORS)
-    locations.ts                # Locations of interest helpers
-    listing-status.ts           # Detect expired listing URLs
-    map-embed.ts                # Google Maps embed URL builder
-    short-code.ts               # Short-code generator for apartments
-    storage.ts                  # File storage (Blob / filesystem)
-    upload-pdf.ts               # Client-direct Vercel Blob upload (>4.5 MB)
-  instrumentation.ts            # Next.js instrumentation hook (DB migrate)
-  proxy.ts                      # Auth proxy (renamed middleware.ts in Next.js 16)
-```
-
-</details>
-
-<details>
-<summary><strong>Architecture</strong></summary>
-
-- **Authentication:** shared password gate with HTTP-only cookies; no accounts. The auth proxy (`proxy.ts`) redirects unauthenticated requests.
-- **PDF flow:** upload → store → AI extraction → structured data → user reviews & saves. Uses Google Gemini when configured; falls back to manual entry.
-- **Distance:** Google Maps preferred, OpenRouteService fallback. Bike and transit minutes are stored per (apartment, location of interest) pair in `apartment_distances`.
-- **Ratings:** one upsert per user per apartment across 5 categories; averages drive the comparison grid.
-- **Storage:** Turso or local SQLite for data; Vercel Blob or `./uploads/` for files. Uploads larger than ~4.5 MB go through `lib/upload-pdf.ts` (client-direct Blob upload) to bypass the serverless body limit.
-
-**Tables:** `apartments`, `ratings` (unique on `(apartmentId, userName)`), `users`, `api_usage`, `locations_of_interest`, `apartment_distances`.
-
-</details>
-
-<details>
-<summary><strong>API routes</strong></summary>
-
-| Method | Endpoint | Description |
-|--------|----------|-------------|
-| `POST` | `/api/auth` | Verify password, set auth cookie |
-| `POST` | `/api/auth/name` | Set display name cookie |
-| `GET` | `/api/auth/users` | List users |
-| `DELETE` | `/api/auth/users/[name]` | Remove a user |
-| `GET` / `POST` | `/api/apartments` | List apartments / create |
-| `GET` / `PATCH` / `DELETE` | `/api/apartments/[id]` | Get, update, delete an apartment |
-| `POST` | `/api/apartments/[id]/ratings` | Upsert a rating for the current user |
-| `POST` | `/api/apartments/[id]/reprocess` | Re-run AI extraction on an existing PDF |
-| `POST` | `/api/apartments/check-listings` | Probe listing URLs and mark expired ones |
-| `POST` | `/api/parse-pdf` | Upload PDF (≤ 4.5 MB), store, run AI extraction |
-| `GET` / `POST` | `/api/parse-pdf/upload-token` | Issue Vercel Blob client-upload tokens (large PDFs) |
-| `GET` | `/api/pdf/[...path]` | Authenticated PDF streaming |
-| `GET` | `/api/uploads/[...path]` | Authenticated raw upload streaming |
-| `GET` / `POST` | `/api/locations` | List / create locations of interest |
-| `GET` / `PUT` / `DELETE` | `/api/locations/[id]` | Get, update, delete a location |
-| `POST` | `/api/locations/[id]/move` | Reorder locations |
-| `POST` | `/api/geocode/backfill` | Geocode apartments missing lat/lng |
-| `POST` | `/api/settings/recompute-distances` | Recompute all per-location distances |
-| `GET` | `/api/costs` | Get API usage stats and estimated costs |
-
-</details>
-
-<details>
-<summary><strong>Environment variables</strong></summary>
-
-| Variable | Required | Mode | Description |
-|----------|----------|------|-------------|
-| `APP_PASSWORD` | Yes | All | Shared access password |
-| `TURSO_DATABASE_URL` | No | Cloud | Turso database URL |
-| `TURSO_AUTH_TOKEN` | No | Cloud | Turso auth token |
-| `BLOB_READ_WRITE_TOKEN` | No | Cloud | Vercel Blob token (auto-set on Vercel) |
-| `GOOGLE_GENERATIVE_AI_API_KEY` | No | Cloud | Google Gemini API key for PDF parsing |
-| `GOOGLE_MAPS_API_KEY` | No | Cloud | Maps Platform key — needs Geocoding, Distance Matrix, and Maps Embed APIs enabled. See [docs/google-apis.md](./docs/google-apis.md). |
-| `OPENROUTESERVICE_API_KEY` | No | Local | Free distance calculation alternative |
-| `DISABLE_SECURE_COOKIES` | No | Local | Set to bypass secure cookie flag in dev |
-
-</details>
-
-## Testing
-
-```bash
-npm test          # run once
-npm run test:watch
-```
-
-Uses [Vitest](https://vitest.dev/) with React Testing Library. Test files live next to their source in `__tests__/` directories.
+Data persists in two named volumes: `flatpare-data` (SQLite + uploads) and `flatpare-uploads`.
 
 ## Contributing
 
-1. Create a feature branch from `main`.
-2. Make changes, run `npm test` and `npm run lint`.
-3. Open a pull request.
+1. Branch from `main`.
+2. Make changes; keep tests green (`npm test`) and lint clean (`npm run lint`).
+3. Open a pull request; `main` is protected, all PRs run the test workflow.
+
+The repo uses Vitest, Drizzle, and Next 16-specific conventions — read [`AGENTS.md`](./AGENTS.md) before touching the proxy, instrumentation, or migration paths. It's terse on purpose and worth the 5-minute scan.
 
 ## License
 
-See [LICENSE](LICENSE).
+[MIT](./LICENSE).
+
+## Credits
+
+Flatpare is built and maintained by **[brlauuu](https://github.com/brlauuu)** in collaboration with **[Claude Code](https://claude.com/claude-code)** by [Anthropic](https://www.anthropic.com) — designed, debugged, and refactored together over many evenings.


### PR DESCRIPTION
## Summary
Restructures `README.md` around the outline in #135 and brings every claim in line with what landed earlier in this audit cycle.

## What changed
- **Hero** — logo, one-line value prop, screenshot placeholder. (Real screenshot/GIF can be dropped in later — `docs/images/` is a fine home.)
- **What you get** — features table with emoji and one-liners.
- **Tech stack** — bumped to TS 6, React 19, Next 16, Vitest 4, Node 24.
- **Quickstart** — Docker first (with the host 3002 → container 3000 note from #124).
- **Running without Docker, Cloud mode, Vercel deploy** — same content, less collapsed-detail clutter.
- **Configuration** — env-vars table now includes `LOCAL_DB_URL` and `DISABLE_SECURE_COOKIES`.
- **Auth model** — explicit env var (`APP_PASSWORD`) vs cookie (`flatpare-auth` / `flatpare-name`) wording per #125.
- **Project layout** — reflects the new colocated `_components/` directories from #130.
- **API surface, Testing, Database, Docker, Contributing, License** — refreshed and trimmed.
- **Credits** — section crediting brlauuu + Claude Code (Anthropic).

## Cross-references kept fresh
- `docs/google-apis.md` (existing)
- `docs/security-notes.md` (added in #132)
- `AGENTS.md` (referenced as the "read this first" guide)
- Coverage thresholds in `vitest.config.ts` (#129)

## Test plan
- [x] `npm test` — 338/338.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.
- [x] Markdown renders cleanly on GitHub (tables, headings, sizes).

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)