### PR TITLE
fix(security): gate /api/* through the auth proxy (#144)

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy } from "../proxy";
+
+function makeRequest(
+  path: string,
+  cookies: Record<string, string> = {}
+): NextRequest {
+  const url = `http://localhost:3002${path}`;
+  const cookieHeader = Object.entries(cookies)
+    .map(([k, v]) => `${k}=${encodeURIComponent(v)}`)
+    .join("; ");
+  return new NextRequest(url, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+  });
+}
+
+const authedCookies = {
+  "flatpare-auth": "true",
+  "flatpare-name": "Alice",
+};
+
+describe("proxy — login page", () => {
+  it("lets an unauthenticated visitor see the login page", () => {
+    const res = proxy(makeRequest("/"));
+    // x-middleware-next: 1 indicates NextResponse.next()
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("redirects an authed visitor away from the login page", () => {
+    const res = proxy(makeRequest("/", authedCookies));
+    expect(res.status).toBe(307);
+    expect(res.headers.get("location")).toContain("/apartments");
+  });
+});
+
+describe("proxy — /api/auth bypass", () => {
+  it("lets unauthenticated callers reach /api/auth", () => {
+    const res = proxy(makeRequest("/api/auth"));
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+
+  it("lets unauthenticated callers reach /api/auth/name", () => {
+    const res = proxy(makeRequest("/api/auth/name"));
+    expect(res.headers.get("x-middleware-next")).toBe("1");
+  });
+});
+
+describe("proxy — protected API routes", () => {
+  const protectedPaths = [
+    "/api/apartments",
+    "/api/apartments/42",
+    "/api/apartments/42/ratings",
+    "/api/apartments/42/reprocess",
+    "/api/apartments/check-listings",
+    "/api/parse-pdf",
+    "/api/parse-pdf/upload-token",
+    "/api/locations",
+    "/api/locations/3",
+    "/api/locations/3/move",
+    "/api/geocode/backfill",
+    "/api/settings/recompute-distances",
+    "/api/costs",
+    "/api/pdf/some/file.pdf",
+    "/api/uploads/some/file.bin",
+  ];
+
+  for (const path of protectedPaths) {
+    it(`returns JSON 401 (not redirect) for unauthenticated ${path}`, async () => {
+      const res = proxy(makeRequest(path));
+      expect(res.status).toBe(401);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual({ error: "Not authenticated" });
+    });
+
+    it(`lets authenticated calls through to ${path}`, () => {
+      const res = proxy(makeRequest(path, authedCookies));
+      expect(res.headers.get("x-middleware-next")).toBe("1");
+    });
+  }
+
+  it("returns 401 when auth cookie is set but display name is missing", async () => {
+    const res = proxy(
+      makeRequest("/api/apartments", { "flatpare-auth": "true" })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when display name is set but auth cookie is missing", async () => {
+    const res = proxy(
+      makeRequest("/api/apartments", { "flatpare-name": "Alice" })
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("proxy — protected page routes", () => {
+  const pagePaths = [
+    "/apartments",
+    "/apartments/42",
+    "/apartments/new",
+    "/compare",
+    "/costs",
+    "/guide",
+    "/settings",
+  ];
+
+  for (const path of pagePaths) {
+    it(`redirects unauthenticated ${path} to /`, () => {
+      const res = proxy(makeRequest(path));
+      expect(res.status).toBe(307);
+      expect(res.headers.get("location")).toMatch(/\/$/);
+    });
+
+    it(`lets authenticated ${path} render`, () => {
+      const res = proxy(makeRequest(path, authedCookies));
+      expect(res.headers.get("x-middleware-next")).toBe("1");
+    });
+  }
+});

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,16 +8,28 @@ export function proxy(request: NextRequest) {
   const hasName = !!nameCookie?.value;
   const path = request.nextUrl.pathname;
 
-  // Allow access to login page and auth API
+  // Login page + auth API are always reachable.
   if (path === "/" || path.startsWith("/api/auth")) {
-    // If already fully authed, redirect away from login
+    // Bounce a fully-authed user away from the login page.
     if (path === "/" && isAuthed && hasName) {
       return NextResponse.redirect(new URL("/apartments", request.url));
     }
     return NextResponse.next();
   }
 
-  // Protect all other routes
+  // API routes return JSON 401 on failure — the UI handles that better than a
+  // 302 to an HTML login page, and external clients can detect it cleanly.
+  if (path.startsWith("/api/")) {
+    if (!isAuthed || !hasName) {
+      return NextResponse.json(
+        { error: "Not authenticated" },
+        { status: 401 }
+      );
+    }
+    return NextResponse.next();
+  }
+
+  // Page routes redirect to the login screen.
   if (!isAuthed || !hasName) {
     return NextResponse.redirect(new URL("/", request.url));
   }
@@ -27,6 +39,6 @@ export function proxy(request: NextRequest) {
 
 export const config = {
   matcher: [
-    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+    "/((?!_next/static|_next/image|favicon.ico).*)",
   ],
 };


### PR DESCRIPTION
## Summary
Plug the auth gap discovered while doing #128: every API route that didn't explicitly call \`isAuthenticated()\` was reachable without an auth cookie because the proxy matcher excluded \`/api\`.

## Approach (option A from the issue)
Single source of truth in `src/proxy.ts`:
- Matcher drops the `/api` exclusion (still skips `_next/static`, `_next/image`, `favicon.ico`).
- `/api/auth/*` is allow-listed (login flow needs to be reachable without cookies).
- Protected `/api/*` paths return **JSON 401** rather than a 302 to the HTML login page — the UI handles 401 cleanly, and external callers can detect it without HTML parsing.
- Page routes keep the redirect-to-`/` behavior.

The per-route `isAuthenticated()` guard added in #128 stays as defense in depth.

## Routes now actually protected
- `/api/apartments` (GET, POST)
- `/api/apartments/[id]/reprocess`
- `/api/apartments/check-listings`
- `/api/costs`
- `/api/geocode/backfill`
- `/api/locations/*` (incl. `[id]/move`)
- `/api/parse-pdf` and `/api/parse-pdf/upload-token`
- `/api/settings/recompute-distances`
- `/api/pdf/[...path]`
- `/api/uploads/[...path]`

## Tests
New `src/__tests__/proxy.test.ts` — **50 cases**:
- Login page allow + authed bounce.
- `/api/auth` and `/api/auth/name` bypass.
- For every protected `/api/*` path: JSON 401 unauthed; pass-through authed.
- For every protected page path: 307 redirect unauthed; pass-through authed.
- Partial-cookie failures (auth-only, name-only) → 401.

## Test plan
- [x] `npx vitest run` — **388/388** (was 338 + 50 new).
- [x] Coverage: **85.09 %** lines / **76.91 %** branches (above thresholds).
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)