### PR TITLE
docs: refresh AGENTS.md with proxy gate, coverage thresholds, env vars (#154)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - Config: `vitest.config.ts`. Setup: `src/test-global-setup.ts` (env) and `src/test-setup.ts` (per-test).
 - Tests live in co-located `__tests__/` directories next to the source.
 - `npm test` runs once; `npm run test:watch` watches.
+- **Coverage thresholds are enforced in CI** via `vitest.config.ts`: lines ≥ 80, statements ≥ 80, functions ≥ 78, branches ≥ 75. New code without tests will fail the build.
 
 ## Auth
 - Shared-password + display-name model (no real accounts). See `src/lib/auth.ts` and `src/app/api/auth/`.
@@ -31,12 +32,24 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - On a successful match, two cookies are set:
   - **`flatpare-auth=true`** — httpOnly; `isAuthenticated()` checks this and returns a boolean.
   - **`flatpare-name=<display-name>`** — readable from client JS; `getDisplayName()` returns the value or `null`.
-- Server routes gate access by calling `isAuthenticated()` and return **401** on failure. There is no shared `requireUser()` helper — don't add one without discussion.
+- **`src/proxy.ts` is the primary gate.** It enforces auth on every page route (redirect → `/`) and every `/api/*` path (JSON 401), with `/api/auth/*` allow-listed for the login flow. The matcher only excludes `_next/static`, `_next/image`, and `favicon.ico`.
+- Route handlers may add an explicit `if (!(await isAuthenticated())) return unauthorized()` as defense-in-depth (already done on `/api/apartments/[id]`); prefer this for routes that hit paid third-party APIs or grant write tokens.
+- There is no shared `requireUser()` helper — don't add one without discussion.
 - `DISABLE_SECURE_COOKIES` (any truthy value) drops the `Secure` flag so cookies work over plain HTTP in dev.
+- **Accepted security advisories** are documented in `docs/security-notes.md` — check there before chasing a `npm audit` warning.
 
 ## File uploads
 - Files larger than ~4.5 MB **must** use `src/lib/upload-pdf.ts` (client-direct Vercel Blob upload via `/api/parse-pdf/upload-token`). Multipart-POSTing big bodies through serverless routes hits the body limit.
 - Smaller uploads and the local-disk fallback go through `src/lib/storage.ts`.
+- Cloud Blob mode requires `BLOB_READ_WRITE_TOKEN` (auto-set by Vercel). Without it, the upload-token probe reports `{ enabled: false }` and the client falls back to multipart through `/api/parse-pdf`.
+
+## Cloud-mode env vars
+Beyond auth + Turso, the following keys gate cloud features. If any is unset, the feature degrades cleanly to manual entry / no-op:
+
+- `BLOB_READ_WRITE_TOKEN` — Vercel Blob (file storage). See File uploads above.
+- `GOOGLE_GENERATIVE_AI_API_KEY` — Gemini 2.5 Flash for PDF extraction (`src/lib/parse-pdf.ts`). Without it, `/api/parse-pdf` falls back to manual entry.
+- `GOOGLE_MAPS_API_KEY` — Geocoding + Distance Matrix + Maps Embed (`src/lib/geocode.ts`, `distance.ts`, `map-embed.ts`). See `docs/google-apis.md` for which APIs to enable.
+- `OPENROUTESERVICE_API_KEY` — bike-distance fallback when Maps is unset (transit not supported).
 
 ## Dev server
 - `npm run dev` and `npm run start` listen on **port 3002** (not the Next.js default 3000); both scripts pass `-p 3002`.


### PR DESCRIPTION
## Summary
Four gaps the 2026-05-10 audit flagged in AGENTS.md, all addressed here.

## What changed

### Auth section
- Document that `src/proxy.ts` is the **primary** gate: redirects unauthed page hits to `/`, JSON-401s `/api/*` (with `/api/auth/*` allow-listed), and the matcher excludes only `_next/static`, `_next/image`, `favicon.ico`. (Reflects #144.)
- Note that route handlers can add an explicit `isAuthenticated()` check as defense-in-depth — already done on `/api/apartments/[id]` (#128); preferred for routes that hit paid third-party APIs or grant write tokens. (Issue #153 will roll this out further.)
- Link `docs/security-notes.md` so agents check there before chasing a `npm audit` warning.

### Tests section
- Call out the coverage thresholds in `vitest.config.ts` (lines ≥ 80, statements ≥ 80, functions ≥ 78, branches ≥ 75). CI fails below floor — contributors should know.

### File uploads section
- Mention `BLOB_READ_WRITE_TOKEN` and how the upload-token probe + multipart fallback behave when it's unset.

### New "Cloud-mode env vars" section
- One-line purpose for each cloud key: `BLOB_READ_WRITE_TOKEN`, `GOOGLE_GENERATIVE_AI_API_KEY`, `GOOGLE_MAPS_API_KEY`, `OPENROUTESERVICE_API_KEY`. Each lists the source file(s) it gates.

## Test plan
- [x] Verified threshold numbers against `vitest.config.ts` (match exactly).
- [x] Verified file paths and helper names against `src/proxy.ts`, `src/lib/auth.ts`, `src/lib/parse-pdf.ts`, `src/lib/distance.ts`.
- [x] No code changes — docs only.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)