### PR TITLE
refactor: drop unused exports from apartment-sort.ts (#156)

### DIFF
--- a/src/lib/apartment-sort.ts
+++ b/src/lib/apartment-sort.ts
@@ -27,7 +27,7 @@ const STATIC_FIELDS: StaticSortField[] = [
 
 export type SortDirection = "asc" | "desc";
 
-export type ApartmentDistance = {
+type ApartmentDistance = {
   locationId: number;
   bikeMin: number | null;
   transitMin: number | null;
@@ -107,7 +107,7 @@ const STATIC_LIST_SORT_FIELDS: StaticSortField[] = [
   "shortCode",
 ];
 
-export type LocationLite = { id: number; label: string };
+type LocationLite = { id: number; label: string };
 
 type SortFieldOption = { id: SortField; label: string };
 


### PR DESCRIPTION
## Summary
Demote two types from `export` to local in `src/lib/apartment-sort.ts`:

- `ApartmentDistance` — only used by `SortableApartment` in the same file.
- `LocationLite` — only used in this file's two function signatures (`listSortOptions`, `compareSortOptions`). The `LocationLite` consumed elsewhere is a separate type at `src/app/apartments/[id]/_components/types.ts`.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npx vitest run` — 396/396.

Closes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)