### PR TITLE
test: exclude vendored shadcn ui/* from coverage (#152)

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,13 @@ export default defineConfig({
     testTimeout: 15000,
     hookTimeout: 15000,
     coverage: {
+      // shadcn-generated primitives are vendored and re-emitted from the
+      // shadcn CLI; testing them adds noise without signal. Excluded so
+      // the threshold check tracks our code.
+      exclude: [
+        "src/components/ui/**",
+        // vitest's defaults (node_modules, dist, etc.) — kept implicit.
+      ],
       // Floor — we're well above as of #129; set here so a regression
       // (or a sneaky `if` slipping through without a test) fails CI.
       thresholds: {


### PR DESCRIPTION
## Summary
Add `src/components/ui/**` to `coverage.exclude` in `vitest.config.ts`. shadcn primitives are CLI-generated, not really our code — they were dragging individual file metrics down without signal (`dropdown-menu.tsx` at 50 %, `card.tsx` at 57 %, etc.).

## Coverage delta (with shadcn excluded)
| Metric | Before | After | Threshold |
|---|---|---|---|
| Statements | 83.72 % | **84.61 %** | 80 |
| Branches | 76.91 % | **77.52 %** | 75 |
| Functions | 81.25 % | **83.60 %** | 78 |
| Lines | 85.09 % | **86.04 %** | 80 |

All four thresholds still cleared; the bump comes from removing the 4 partially-tested primitives from the denominator.

## Test plan
- [x] `npx vitest run` — 396/396 (test count unchanged).
- [x] `npx vitest run --coverage` — exit 0, thresholds pass.
- [x] `src/components/ui/*` no longer appears in the coverage report.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)