### PR TITLE
test: full happy-path coverage for 4 untested routes (#162)

### DIFF
--- a/src/app/api/apartments/[id]/reprocess/__tests__/route.test.ts
+++ b/src/app/api/apartments/[id]/reprocess/__tests__/route.test.ts
@@ -1,0 +1,378 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockIsAuthenticated,
+  selectMock,
+  updateMock,
+  insertMock,
+  deleteMock,
+  readStoredFileMock,
+  extractMock,
+  classifyMock,
+  listLocationsMock,
+  calcDistanceMock,
+  geocodeMock,
+} = vi.hoisted(() => ({
+  mockIsAuthenticated: vi.fn(async () => true),
+  selectMock: vi.fn(),
+  updateMock: vi.fn(),
+  insertMock: vi.fn(),
+  deleteMock: vi.fn(),
+  readStoredFileMock: vi.fn(),
+  extractMock: vi.fn(),
+  classifyMock: vi.fn(),
+  listLocationsMock: vi.fn(),
+  calcDistanceMock: vi.fn(),
+  geocodeMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  isAuthenticated: mockIsAuthenticated,
+  unauthorized: () =>
+    new Response(JSON.stringify({ error: "Not authenticated" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+    delete: (...args: unknown[]) => deleteMock(...args),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apartments: { id: "id", address: "address" },
+  apartmentDistances: { apartmentId: "apartment_id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+}));
+
+vi.mock("@/lib/parse-pdf", () => ({
+  extractApartmentData: extractMock,
+}));
+
+vi.mock("@/lib/parse-pdf-error", () => ({
+  classifyParsePdfError: classifyMock,
+}));
+
+vi.mock("@/lib/edited-fields", () => ({
+  INFERABLE_FIELDS: ["name", "address", "rentChf", "sizeM2"],
+}));
+
+vi.mock("@/lib/storage", () => ({
+  readStoredFile: readStoredFileMock,
+}));
+
+vi.mock("@/lib/locations", () => ({
+  listLocations: listLocationsMock,
+}));
+
+vi.mock("@/lib/distance", () => ({
+  calculateDistance: calcDistanceMock,
+}));
+
+vi.mock("@/lib/geocode", () => ({
+  geocodeLatLng: geocodeMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAuthenticated.mockResolvedValue(true);
+});
+
+function withParams(id: string) {
+  return { params: Promise.resolve({ id }) };
+}
+
+function selectReturns(rows: unknown[]) {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        limit: vi.fn().mockResolvedValue(rows),
+      }),
+    }),
+  });
+}
+
+function updateReturning(returnRow: unknown) {
+  updateMock.mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([returnRow]),
+      }),
+    }),
+  });
+}
+
+function updateNoReturn() {
+  updateMock.mockReturnValueOnce({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+}
+
+function deleteOk() {
+  deleteMock.mockReturnValueOnce({
+    where: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+function insertOk() {
+  insertMock.mockReturnValue({
+    values: vi.fn().mockResolvedValue(undefined),
+  });
+}
+
+describe("POST /api/apartments/[id]/reprocess", () => {
+  it("returns 404 when the apartment is missing", async () => {
+    selectReturns([]);
+    const req = new Request("http://x/api/apartments/999/reprocess", {
+      method: "POST",
+    });
+    const res = await POST(req, withParams("999"));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when the apartment has no PDF on file", async () => {
+    selectReturns([{ id: 1, pdfUrl: null }]);
+    const req = new Request("http://x/api/apartments/1/reprocess", {
+      method: "POST",
+    });
+    const res = await POST(req, withParams("1"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/No PDF/i);
+  });
+
+  it("returns 500 when the PDF cannot be read from storage", async () => {
+    selectReturns([{ id: 1, pdfUrl: "stored.pdf" }]);
+    readStoredFileMock.mockRejectedValue(new Error("missing"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const req = new Request("http://x/api/apartments/1/reprocess", {
+      method: "POST",
+    });
+    const res = await POST(req, withParams("1"));
+    expect(res.status).toBe(500);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("propagates a classified error from the AI extractor with its status", async () => {
+    selectReturns([{ id: 1, pdfUrl: "stored.pdf" }]);
+    readStoredFileMock.mockResolvedValue(Buffer.from("pdf"));
+    extractMock.mockRejectedValue(new Error("rate limit"));
+    classifyMock.mockReturnValue({
+      message: "AI quota exceeded",
+      reason: "quota",
+      retryAfterSeconds: 30,
+      status: 429,
+    });
+
+    const req = new Request("http://x/api/apartments/1/reprocess", {
+      method: "POST",
+    });
+    const res = await POST(req, withParams("1"));
+    expect(res.status).toBe(429);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: "AI quota exceeded",
+      reason: "quota",
+      retryAfterSeconds: 30,
+    });
+  });
+
+  it("returns the existing row unchanged when every inferable field has been edited", async () => {
+    const apt = {
+      id: 1,
+      pdfUrl: "stored.pdf",
+      address: "Old St",
+      userEditedFields: JSON.stringify(["name", "address", "rentChf", "sizeM2"]),
+    };
+    selectReturns([apt]);
+    readStoredFileMock.mockResolvedValue(Buffer.from("pdf"));
+    extractMock.mockResolvedValue({
+      name: "Whatever",
+      address: "Different St",
+      rentChf: 9999,
+      sizeM2: 9999,
+    });
+
+    const res = await POST(
+      new Request("http://x/api/apartments/1/reprocess", { method: "POST" }),
+      withParams("1")
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.id).toBe(1);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("merges only non-edited inferable fields and returns the updated row", async () => {
+    const apt = {
+      id: 1,
+      pdfUrl: "stored.pdf",
+      address: "Same St",
+      userEditedFields: JSON.stringify(["name"]),
+    };
+    selectReturns([apt]);
+    readStoredFileMock.mockResolvedValue(Buffer.from("pdf"));
+    extractMock.mockResolvedValue({
+      name: "Should be ignored",
+      address: "Same St",
+      rentChf: 1234,
+      sizeM2: 50,
+    });
+    let captured: Record<string, unknown> | null = null;
+    updateMock.mockReturnValueOnce({
+      set: vi.fn((v: Record<string, unknown>) => {
+        captured = v;
+        return {
+          where: vi.fn().mockReturnValue({
+            returning: vi
+              .fn()
+              .mockResolvedValue([{ id: 1, address: "Same St", rentChf: 1234 }]),
+          }),
+        };
+      }),
+    });
+
+    const res = await POST(
+      new Request("http://x/api/apartments/1/reprocess", { method: "POST" }),
+      withParams("1")
+    );
+    expect(res.status).toBe(200);
+    // `name` is in edited set → must NOT be in update payload.
+    expect(captured).not.toBeNull();
+    expect(Object.keys(captured!)).not.toContain("name");
+    expect(captured!.rentChf).toBe(1234);
+    expect(captured!.address).toBe("Same St");
+  });
+
+  it("re-geocodes and rebuilds distances when the address changes", async () => {
+    const apt = { id: 1, pdfUrl: "stored.pdf", address: "Old St", userEditedFields: null };
+    selectReturns([apt]);
+    readStoredFileMock.mockResolvedValue(Buffer.from("pdf"));
+    extractMock.mockResolvedValue({
+      name: "X",
+      address: "New St",
+      rentChf: null,
+      sizeM2: null,
+    });
+    // First update — applies the field merge, returns the new row.
+    updateReturning({ id: 1, address: "New St" });
+    geocodeMock.mockResolvedValue({ lat: 47.5, lng: 8.5 });
+    // Second update — sets coords (no returning).
+    updateNoReturn();
+    deleteOk();
+    listLocationsMock.mockResolvedValue([
+      { id: 7, label: "Train", icon: "Train", address: "Basel SBB" },
+    ]);
+    calcDistanceMock.mockResolvedValue({ bikeMinutes: 12, transitMinutes: 25 });
+    insertOk();
+
+    const res = await POST(
+      new Request("http://x/api/apartments/1/reprocess", { method: "POST" }),
+      withParams("1")
+    );
+    expect(res.status).toBe(200);
+    expect(geocodeMock).toHaveBeenCalledWith("New St");
+    expect(deleteMock).toHaveBeenCalledTimes(1);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fail the request when geocoding throws after an address change", async () => {
+    const apt = { id: 1, pdfUrl: "stored.pdf", address: "Old St", userEditedFields: null };
+    selectReturns([apt]);
+    readStoredFileMock.mockResolvedValue(Buffer.from("pdf"));
+    extractMock.mockResolvedValue({
+      name: null,
+      address: "New St",
+      rentChf: null,
+      sizeM2: null,
+    });
+    updateReturning({ id: 1, address: "New St" });
+    geocodeMock.mockRejectedValue(new Error("rate limit"));
+    deleteOk();
+    listLocationsMock.mockResolvedValue([]);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST(
+      new Request("http://x/api/apartments/1/reprocess", { method: "POST" }),
+      withParams("1")
+    );
+    expect(res.status).toBe(200);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("logs and continues when distance calculation fails for one location", async () => {
+    const apt = { id: 1, pdfUrl: "stored.pdf", address: "Old St", userEditedFields: null };
+    selectReturns([apt]);
+    readStoredFileMock.mockResolvedValue(Buffer.from("pdf"));
+    extractMock.mockResolvedValue({
+      name: null,
+      address: "New St",
+      rentChf: null,
+      sizeM2: null,
+    });
+    updateReturning({ id: 1, address: "New St" });
+    geocodeMock.mockResolvedValue(null);
+    updateNoReturn();
+    deleteOk();
+    listLocationsMock.mockResolvedValue([
+      { id: 7, address: "x" },
+      { id: 8, address: "y" },
+    ]);
+    calcDistanceMock
+      .mockRejectedValueOnce(new Error("rate limit"))
+      .mockResolvedValueOnce({ bikeMinutes: 9, transitMinutes: 18 });
+    insertOk();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST(
+      new Request("http://x/api/apartments/1/reprocess", { method: "POST" }),
+      withParams("1")
+    );
+    expect(res.status).toBe(200);
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("falls back to 500 on an unexpected outer error", async () => {
+    selectMock.mockImplementationOnce(() => {
+      throw new Error("synchronous boom");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST(
+      new Request("http://x/api/apartments/1/reprocess", { method: "POST" }),
+      withParams("1")
+    );
+    expect(res.status).toBe(500);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("recovers from malformed userEditedFields JSON (treats as empty)", async () => {
+    const apt = { id: 1, pdfUrl: "stored.pdf", address: "Same St", userEditedFields: "{not json" };
+    selectReturns([apt]);
+    readStoredFileMock.mockResolvedValue(Buffer.from("pdf"));
+    extractMock.mockResolvedValue({
+      name: "New",
+      address: "Same St",
+      rentChf: 1500,
+      sizeM2: 60,
+    });
+    updateReturning({ id: 1, name: "New" });
+
+    const res = await POST(
+      new Request("http://x/api/apartments/1/reprocess", { method: "POST" }),
+      withParams("1")
+    );
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/app/api/apartments/check-listings/__tests__/route.test.ts
+++ b/src/app/api/apartments/check-listings/__tests__/route.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockIsAuthenticated, dbMocks, checkListingsMock } = vi.hoisted(
+  () => ({
+    mockIsAuthenticated: vi.fn(async () => true),
+    dbMocks: {
+      select: vi.fn(),
+      update: vi.fn(),
+    },
+    checkListingsMock: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/auth", () => ({
+  isAuthenticated: mockIsAuthenticated,
+  unauthorized: () =>
+    new Response(JSON.stringify({ error: "Not authenticated" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: (...args: unknown[]) => dbMocks.select(...args),
+    update: (...args: unknown[]) => dbMocks.update(...args),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apartments: {
+    id: "id",
+    listingUrl: "listing_url",
+    listingGone: "listing_gone",
+    listingCheckedAt: "listing_checked_at",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn(),
+  isNotNull: vi.fn(),
+}));
+
+vi.mock("@/lib/listing-status", () => ({
+  checkListings: checkListingsMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAuthenticated.mockResolvedValue(true);
+});
+
+function selectReturns(rows: unknown[]) {
+  dbMocks.select.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  });
+}
+
+function updateReturnsOk() {
+  dbMocks.update.mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+}
+
+describe("POST /api/apartments/check-listings", () => {
+  it("checks each listing and updates rows whose `gone` status was determined", async () => {
+    selectReturns([
+      { id: 1, listingUrl: "https://example.com/a" },
+      { id: 2, listingUrl: "https://example.com/b" },
+      { id: 3, listingUrl: "  " }, // whitespace — filtered out
+    ]);
+    checkListingsMock.mockResolvedValue([
+      { apartmentId: 1, gone: false, checkedAt: new Date() },
+      { apartmentId: 2, gone: true, checkedAt: new Date() },
+    ]);
+    updateReturnsOk();
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.checked).toBe(2);
+    expect(body.updated).toBe(2);
+    expect(checkListingsMock).toHaveBeenCalledWith([
+      { id: 1, listingUrl: "https://example.com/a" },
+      { id: 2, listingUrl: "https://example.com/b" },
+    ]);
+    // Two updates fired (one per gone-or-not-gone result).
+    expect(dbMocks.update).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips updates when gone is null (indeterminate)", async () => {
+    selectReturns([{ id: 1, listingUrl: "https://example.com/a" }]);
+    checkListingsMock.mockResolvedValue([
+      { apartmentId: 1, gone: null },
+    ]);
+    updateReturnsOk();
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.checked).toBe(1);
+    expect(body.updated).toBe(0);
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when checkListings throws", async () => {
+    selectReturns([{ id: 1, listingUrl: "https://example.com/a" }]);
+    checkListingsMock.mockRejectedValue(new Error("network"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST();
+    expect(res.status).toBe(500);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("returns an empty result when no apartments have listing URLs", async () => {
+    selectReturns([]);
+    checkListingsMock.mockResolvedValue([]);
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      checked: 0,
+      updated: 0,
+      results: [],
+    });
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/geocode/backfill/__tests__/route.test.ts
+++ b/src/app/api/geocode/backfill/__tests__/route.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockIsAuthenticated, selectMock, updateMock, geocodeMock } =
+  vi.hoisted(() => ({
+    mockIsAuthenticated: vi.fn(async () => true),
+    selectMock: vi.fn(),
+    updateMock: vi.fn(),
+    geocodeMock: vi.fn(),
+  }));
+
+vi.mock("@/lib/auth", () => ({
+  isAuthenticated: mockIsAuthenticated,
+  unauthorized: () =>
+    new Response(JSON.stringify({ error: "Not authenticated" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    update: (...args: unknown[]) => updateMock(...args),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apartments: {
+    id: "id",
+    address: "address",
+    latitude: "latitude",
+    longitude: "longitude",
+  },
+  locationsOfInterest: {
+    id: "id",
+    address: "address",
+    latitude: "latitude",
+    longitude: "longitude",
+  },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  and: vi.fn(),
+  eq: vi.fn(),
+  isNull: vi.fn(),
+  isNotNull: vi.fn(),
+}));
+
+vi.mock("@/lib/geocode", () => ({
+  geocodeLatLngWithReason: geocodeMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAuthenticated.mockResolvedValue(true);
+});
+
+function selectReturns(rows: unknown[]) {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(rows),
+    }),
+  });
+}
+
+function updateReturnsOk() {
+  updateMock.mockReturnValue({
+    set: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
+    }),
+  });
+}
+
+describe("POST /api/geocode/backfill", () => {
+  it("geocodes pending apartments + locations and writes the lat/lng", async () => {
+    selectReturns([{ id: 1, address: "Apt St 1" }]);
+    selectReturns([{ id: 11, address: "Loc St 1" }]);
+    geocodeMock
+      .mockResolvedValueOnce({ result: { lat: 47.5, lng: 8.5 } })
+      .mockResolvedValueOnce({ result: { lat: 46.0, lng: 7.0 } });
+    updateReturnsOk();
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pending).toBe(2);
+    expect(body.updated).toBe(2);
+    expect(body.failures).toEqual([]);
+    expect(updateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("collects failures with reasons when geocoding cannot resolve", async () => {
+    selectReturns([{ id: 1, address: "Bogus Address" }]);
+    selectReturns([]); // no pending locations
+    geocodeMock.mockResolvedValueOnce({
+      result: null,
+      googleReason: "no_results",
+      orsReason: "no_results",
+    });
+    updateReturnsOk();
+
+    const res = await POST();
+    const body = await res.json();
+    expect(body.updated).toBe(0);
+    expect(body.failures).toEqual([
+      {
+        table: "apartments",
+        id: 1,
+        address: "Bogus Address",
+        googleReason: "no_results",
+        orsReason: "no_results",
+      },
+    ]);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("filters out rows with empty/whitespace addresses before queuing", async () => {
+    selectReturns([
+      { id: 1, address: "" },
+      { id: 2, address: "   " },
+      { id: 3, address: "Real Address" },
+    ]);
+    selectReturns([]);
+    geocodeMock.mockResolvedValueOnce({ result: { lat: 1, lng: 2 } });
+    updateReturnsOk();
+
+    const res = await POST();
+    const body = await res.json();
+    expect(body.pending).toBe(1);
+    expect(body.updated).toBe(1);
+    expect(geocodeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs and continues when a worker throws (does not halt the run)", async () => {
+    selectReturns([
+      { id: 1, address: "a" },
+      { id: 2, address: "b" },
+    ]);
+    selectReturns([]);
+    geocodeMock
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ result: { lat: 1, lng: 2 } });
+    updateReturnsOk();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST();
+    const body = await res.json();
+    expect(body.pending).toBe(2);
+    expect(body.updated).toBe(1);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("returns 500 when the apartments query throws synchronously", async () => {
+    selectMock.mockImplementationOnce(() => {
+      throw new Error("db unreachable");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST();
+    expect(res.status).toBe(500);
+    expect(errSpy).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/settings/recompute-distances/__tests__/route.test.ts
+++ b/src/app/api/settings/recompute-distances/__tests__/route.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const {
+  mockIsAuthenticated,
+  selectMock,
+  insertMock,
+  listLocationsMock,
+  calcDistanceMock,
+} = vi.hoisted(() => ({
+  mockIsAuthenticated: vi.fn(async () => true),
+  selectMock: vi.fn(),
+  insertMock: vi.fn(),
+  listLocationsMock: vi.fn(),
+  calcDistanceMock: vi.fn(),
+}));
+
+vi.mock("@/lib/auth", () => ({
+  isAuthenticated: mockIsAuthenticated,
+  unauthorized: () =>
+    new Response(JSON.stringify({ error: "Not authenticated" }), {
+      status: 401,
+      headers: { "content-type": "application/json" },
+    }),
+}));
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    select: (...args: unknown[]) => selectMock(...args),
+    insert: (...args: unknown[]) => insertMock(...args),
+  },
+}));
+
+vi.mock("@/lib/db/schema", () => ({
+  apartments: { id: "id", address: "address" },
+  apartmentDistances: {
+    apartmentId: "apartment_id",
+    locationId: "location_id",
+  },
+}));
+
+vi.mock("@/lib/distance", () => ({
+  calculateDistance: calcDistanceMock,
+}));
+
+vi.mock("@/lib/locations", () => ({
+  listLocations: listLocationsMock,
+}));
+
+import { POST } from "../route";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAuthenticated.mockResolvedValue(true);
+});
+
+function selectApartments(rows: unknown[]) {
+  selectMock.mockReturnValueOnce({
+    from: vi.fn().mockResolvedValue(rows),
+  });
+}
+
+function insertReturnsOk() {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(undefined);
+  insertMock.mockReturnValue({
+    values: vi.fn().mockReturnValue({ onConflictDoUpdate }),
+  });
+  return onConflictDoUpdate;
+}
+
+const sampleLocations = [
+  { id: 7, label: "Train", icon: "Train", address: "Basel SBB" },
+];
+
+describe("POST /api/settings/recompute-distances", () => {
+  it("upserts a distance row per (apartment, location) pair on success", async () => {
+    selectApartments([{ id: 1, address: "Apt St 1" }]);
+    listLocationsMock.mockResolvedValue(sampleLocations);
+    calcDistanceMock.mockResolvedValue({ bikeMinutes: 12, transitMinutes: 25 });
+    const onConflict = insertReturnsOk();
+
+    const res = await POST();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      totalApartments: 1,
+      totalLocations: 1,
+      updated: 1,
+      failed: 0,
+      skipped: 0,
+    });
+    expect(calcDistanceMock).toHaveBeenCalledWith("Basel SBB", "Apt St 1");
+    expect(onConflict).toHaveBeenCalledTimes(1);
+  });
+
+  it("counts apartments without an address as skipped (location count × them)", async () => {
+    selectApartments([
+      { id: 1, address: null },
+      { id: 2, address: "ok" },
+    ]);
+    listLocationsMock.mockResolvedValue(sampleLocations);
+    calcDistanceMock.mockResolvedValue({ bikeMinutes: 9, transitMinutes: 18 });
+    insertReturnsOk();
+
+    const res = await POST();
+    const body = await res.json();
+    expect(body.skipped).toBe(1); // one apartment without address × 1 location
+    expect(body.updated).toBe(1);
+    expect(body.failed).toBe(0);
+  });
+
+  it("counts (null, null) distance results as failed without writing", async () => {
+    selectApartments([{ id: 1, address: "x" }]);
+    listLocationsMock.mockResolvedValue(sampleLocations);
+    calcDistanceMock.mockResolvedValue({
+      bikeMinutes: null,
+      transitMinutes: null,
+    });
+    const onConflict = insertReturnsOk();
+
+    const res = await POST();
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    expect(body.updated).toBe(0);
+    expect(onConflict).not.toHaveBeenCalled();
+  });
+
+  it("counts thrown errors per pair as failed and continues", async () => {
+    selectApartments([
+      { id: 1, address: "a" },
+      { id: 2, address: "b" },
+    ]);
+    listLocationsMock.mockResolvedValue(sampleLocations);
+    calcDistanceMock
+      .mockRejectedValueOnce(new Error("rate limit"))
+      .mockResolvedValueOnce({ bikeMinutes: 5, transitMinutes: 10 });
+    insertReturnsOk();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const res = await POST();
+    const body = await res.json();
+    expect(body.failed).toBe(1);
+    expect(body.updated).toBe(1);
+    expect(errSpy).toHaveBeenCalled();
+  });
+
+  it("returns 500 when the apartments query throws", async () => {
+    selectMock.mockImplementationOnce(() => {
+      throw new Error("db down");
+    });
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const res = await POST();
+    expect(res.status).toBe(500);
+    expect(errSpy).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
The 4 routes that gained `isAuthenticated()` guards in #153 had only 401 tests (no body tests), so each sat at <20 % line coverage. This PR adds focused per-route test files that bring all four to 100 % lines, with strong branch coverage.

## Coverage delta — per route
| Route | Lines before | Lines after | Branches after |
|---|---|---|---|
| `check-listings` | 13.33 % | **100 %** | **87.5 %** |
| `apartments/[id]/reprocess` | 5.88 % | **100 %** | **90 %** |
| `geocode/backfill` | 6.06 % | **100 %** | **91.7 %** |
| `settings/recompute-distances` | 8.33 % | **100 %** | **90 %** |

## Repo-wide
| Metric | Before | After |
|---|---|---|
| Statements | 81.47 % | **87.39 %** |
| Branches | 76.45 % | **80.07 %** |
| Functions | 85.77 % | **88.26 %** |
| Lines | 82.50 % | **88.85 %** |

Branches finally over 80 % too — the floor was 75 %.

## What's covered
- **`check-listings`** — mixed gone/not-gone results, null-gone (indeterminate) skipped, throw → 500, empty-input fast path.
- **`recompute-distances`** — per-pair upsert success, address-less apartments counted as skipped, (null, null) distance counted as failed, thrown errors per pair counted + continue, 500 on db throw.
- **`geocode/backfill`** — pending apartments + locations both processed, failures collected with Google/ORS reasons, whitespace addresses filtered, worker throws don't halt the run, 500 on db throw.
- **`reprocess`** (most complex) — 404 missing, 400 no-PDF, 500 storage read fail, classified parse-pdf error propagated with status, all-fields-edited short circuit, partial merge respecting `userEditedFields`, address-change triggers re-geocode + delete + distance rebuild, geocode failure non-fatal, distance failure per location non-fatal, malformed JSON in `userEditedFields` treated as empty, outer 500.

## Test plan
- [x] `npx vitest run` — **475/475** (was 450 + 25 new).
- [x] `npx vitest run --coverage` — exit 0; all four files at 100 % lines.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)