### PR TITLE
test: lift coverage on the four big page components (#164)

### DIFF
--- a/src/app/apartments/[id]/__tests__/error-states.test.tsx
+++ b/src/app/apartments/[id]/__tests__/error-states.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const push = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ id: "42" }),
+  useRouter: () => ({ push, refresh: vi.fn() }),
+}));
+
+import ApartmentDetailPage from "../page";
+
+const APT = {
+  id: 42,
+  name: "Sonnenweg 3",
+  address: "Sonnenweg 3, 8001 Zurich",
+  sizeM2: 60,
+  numRooms: 2.5,
+  numBathrooms: 1,
+  numBalconies: 1,
+  hasWashingMachine: null,
+  rentChf: 2200,
+  pdfUrl: null,
+  listingUrl: null,
+  summary: null,
+  availableFrom: null,
+  ratings: [],
+};
+
+beforeEach(() => {
+  push.mockReset();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Apartment detail — loading and error states", () => {
+  it("renders the loading placeholder while the fetch is pending", () => {
+    // Never-resolving fetch → component stays in loading state.
+    vi.spyOn(global, "fetch").mockImplementation(
+      () => new Promise(() => {})
+    );
+    render(<ApartmentDetailPage />);
+    expect(screen.getByText(/Loading\.\.\./i)).toBeInTheDocument();
+  });
+
+  it("renders ErrorDisplay when initial GET fails and there's no apartment", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/api/apartments/42")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          headers: new Headers({ "content-type": "application/json" }),
+          json: () => Promise.resolve({ error: "boom" }),
+          text: () => Promise.resolve('{"error":"boom"}'),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }) as typeof fetch);
+
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load apartment/i)).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces an error when delete fails on the server", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(((
+      input: RequestInfo,
+      init?: RequestInit
+    ) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = init?.method ?? "GET";
+      if (url === "/api/apartments" && method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        } as Response);
+      }
+      if (url.endsWith("/api/apartments/42") && method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(APT),
+        } as Response);
+      }
+      if (url === "/api/locations" && method === "GET") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        } as Response);
+      }
+      if (url.endsWith("/api/apartments/42") && method === "DELETE") {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          headers: new Headers({ "content-type": "application/json" }),
+          json: () => Promise.resolve({ error: "boom" }),
+          text: () => Promise.resolve('{"error":"boom"}'),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response);
+    }) as typeof fetch);
+    vi.stubGlobal("confirm", vi.fn().mockReturnValue(true));
+
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Delete$/ }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't delete apartment/i)
+      ).toBeInTheDocument();
+    });
+    expect(push).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts delete when the user cancels confirm()", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url.endsWith("/api/apartments/42")) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(APT),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }) as typeof fetch);
+    vi.stubGlobal("confirm", vi.fn().mockReturnValue(false));
+
+    const user = userEvent.setup();
+    render(<ApartmentDetailPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Sonnenweg 3")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /^Delete$/ }));
+    // No DELETE was issued (only the initial GETs).
+    const deleteCalls = vi
+      .mocked(global.fetch)
+      .mock.calls.filter((c) => {
+        const init = c[1] as RequestInit | undefined;
+        return init?.method === "DELETE";
+      });
+    expect(deleteCalls.length).toBe(0);
+    vi.unstubAllGlobals();
+  });
+});

--- a/src/app/apartments/new/__tests__/full-flow.test.tsx
+++ b/src/app/apartments/new/__tests__/full-flow.test.tsx
@@ -353,6 +353,38 @@ describe("Upload page — batch review flow", () => {
     expect(pushMock).not.toHaveBeenCalled();
   });
 
+  it("shows 'Failed to save' on an item when the apartments POST throws on the network", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(global, "fetch").mockImplementation(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === "string" ? input : input.toString();
+        if (url.includes("/api/parse-pdf/upload-token")) {
+          return probeResponse(false);
+        }
+        if (url === "/api/parse-pdf" && init?.method === "POST") {
+          return parseSuccess("net.pdf");
+        }
+        if (url === "/api/apartments" && init?.method === "POST") {
+          throw new TypeError("Failed to fetch");
+        }
+        throw new Error(`Unexpected fetch: ${url}`);
+      }
+    );
+    render(<UploadPage />);
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement;
+    await user.upload(input, makePdfFile("net.pdf"));
+    await waitFor(() => {
+      expect(screen.getByText("Parsed net.pdf")).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Save apartment/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to save/i)).toBeInTheDocument();
+    });
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
   it("expanding a card reveals the editable form", async () => {
     const user = userEvent.setup();
     mockTwoSuccesses();
@@ -378,6 +410,14 @@ describe("Upload page — batch review flow", () => {
     });
   });
 });
+
+// NOTE on branch coverage:
+// new/page.tsx sits at ~67% branches. The remaining gaps are not reachable
+// through normal UI flows — e.g. the `if (toSave.length === 0)` guard inside
+// handleSaveAll only fires if items state changes between the Save button
+// rendering and being clicked, and the `processingRef.current` early-exit
+// fires only on a (currently never-triggered) cancel handler. They're kept
+// as defensive code, not as testable branches.
 
 describe("Upload page — Save all guard", () => {
   it('shows "No apartments to save" when nothing is saveable', async () => {

--- a/src/app/compare/__tests__/error-states.test.tsx
+++ b/src/app/compare/__tests__/error-states.test.tsx
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}));
+
+import ComparePage from "../page";
+
+const APT = {
+  id: 1,
+  name: "Apt A",
+  address: null,
+  sizeM2: 50,
+  numRooms: 2,
+  numBathrooms: 1,
+  numBalconies: 1,
+  hasWashingMachine: null,
+  rentChf: 2000,
+  distances: [],
+  pdfUrl: null,
+  listingUrl: null,
+  shortCode: "A-2-W-100",
+  createdAt: "2026-01-01T00:00:00Z",
+  ratings: [],
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe("Compare page — load + error states", () => {
+  it("shows 'Loading comparison...' while the initial fetch is pending", () => {
+    vi.spyOn(global, "fetch").mockImplementation(() => new Promise(() => {}));
+    render(<ComparePage />);
+    expect(screen.getByText(/Loading comparison/i)).toBeInTheDocument();
+  });
+
+  it("renders ErrorDisplay when initial GET /api/apartments fails", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url === "/api/apartments") {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          headers: new Headers({ "content-type": "application/json" }),
+          json: () => Promise.resolve({ error: "boom" }),
+          text: () => Promise.resolve('{"error":"boom"}'),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }) as typeof fetch);
+
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't load comparison data/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders ErrorDisplay when a per-apartment GET fails", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url === "/api/apartments") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 1 }]),
+        } as Response);
+      }
+      if (url === "/api/locations") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        } as Response);
+      }
+      if (url.endsWith("/api/apartments/1")) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          statusText: "Server Error",
+          headers: new Headers({ "content-type": "application/json" }),
+          json: () => Promise.resolve({ error: "boom" }),
+          text: () => Promise.resolve('{"error":"boom"}'),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response);
+    }) as typeof fetch);
+
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't load comparison data/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders ErrorDisplay when fetch throws (network failure)", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(() => {
+      throw new TypeError("Failed to fetch");
+    });
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't load comparison data/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("renders the empty state when no apartments are returned", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url === "/api/apartments") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+      } as Response);
+    }) as typeof fetch);
+
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(
+        screen.getByText(/No apartments to compare yet/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows the 'Show all (N hidden)' button after hiding a column", async () => {
+    vi.spyOn(global, "fetch").mockImplementation(((input: RequestInfo) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      if (url === "/api/apartments") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([{ id: 1 }, { id: 2 }]),
+        } as Response);
+      }
+      if (url === "/api/locations") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve([]),
+        } as Response);
+      }
+      const m = url.match(/\/api\/apartments\/(\d+)$/);
+      if (m) {
+        const id = Number(m[1]);
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({ ...APT, id, name: `Apt ${id}` }),
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      } as Response);
+    }) as typeof fetch);
+
+    const user = userEvent.setup();
+    render(<ComparePage />);
+    await waitFor(() => {
+      expect(screen.getByText("Apt 1")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /Hide Apt 2/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Show all \(1 hidden\)/i })
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Apt 2")).not.toBeInTheDocument();
+
+    // Clicking it brings the column back.
+    await user.click(
+      screen.getByRole("button", { name: /Show all \(1 hidden\)/i })
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Apt 2")).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/settings/__tests__/settings-page.test.tsx
+++ b/src/app/settings/__tests__/settings-page.test.tsx
@@ -48,6 +48,33 @@ beforeEach(() => {
       locations = [...locations, created];
       return jsonRes(created, true, 201);
     }
+    if (/^\/api\/locations\/\d+$/.test(url) && method === "PUT") {
+      const id = Number(url.split("/").pop());
+      const body = JSON.parse(init!.body as string);
+      locations = locations.map((l) =>
+        l.id === id ? { ...l, ...body } : l
+      );
+      return jsonRes(locations.find((l) => l.id === id)!);
+    }
+    if (
+      /^\/api\/locations\/\d+\/move$/.test(url) &&
+      method === "POST"
+    ) {
+      const id = Number(url.split("/")[3]);
+      const body = JSON.parse(init!.body as string);
+      const idx = locations.findIndex((l) => l.id === id);
+      const swapWith =
+        body.direction === "up" ? locations[idx - 1] : locations[idx + 1];
+      if (swapWith) {
+        const reordered = [...locations];
+        reordered[idx] = swapWith;
+        reordered[
+          body.direction === "up" ? idx - 1 : idx + 1
+        ] = locations[idx];
+        locations = reordered;
+      }
+      return jsonRes({ success: true });
+    }
     if (
       /^\/api\/locations\/\d+$/.test(url) &&
       method === "DELETE"
@@ -133,6 +160,117 @@ describe("SettingsPage", () => {
     await waitFor(() => {
       expect(
         screen.getByText(/Recomputed 6 pairs across 3 apartments/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("edit flow: opens, changes label, saves, reflects new label", async () => {
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await waitFor(() => screen.getByText("Train Station"));
+
+    await user.click(
+      screen.getByRole("button", { name: /Edit Train Station/i })
+    );
+
+    const labelInput = screen.getByLabelText(/^Label$/i) as HTMLInputElement;
+    await user.clear(labelInput);
+    await user.type(labelInput, "Renamed");
+
+    await user.click(screen.getByRole("button", { name: /^Save$/ }));
+    await waitFor(() => {
+      expect(screen.getByText("Renamed")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Train Station")).not.toBeInTheDocument();
+  });
+
+  it("move up reorders locations", async () => {
+    locations = [
+      { id: 1, label: "First", icon: "Train", address: "A", sortOrder: 0 },
+      { id: 2, label: "Second", icon: "Train", address: "B", sortOrder: 1 },
+    ];
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await waitFor(() => screen.getByText("First"));
+
+    await user.click(screen.getByRole("button", { name: /Move Second up/i }));
+    await waitFor(() => {
+      const labels = Array.from(
+        document.querySelectorAll('[class*="font-medium"]')
+      )
+        .map((el) => el.textContent?.trim())
+        .filter((s) => s === "First" || s === "Second");
+      expect(labels[0]).toBe("Second");
+      expect(labels[1]).toBe("First");
+    });
+  });
+
+  it("move down reorders locations", async () => {
+    locations = [
+      { id: 1, label: "First", icon: "Train", address: "A", sortOrder: 0 },
+      { id: 2, label: "Second", icon: "Train", address: "B", sortOrder: 1 },
+    ];
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await waitFor(() => screen.getByText("First"));
+
+    await user.click(screen.getByRole("button", { name: /Move First down/i }));
+    await waitFor(() => {
+      const movePosts = fetchMock.mock.calls.filter(
+        (c: unknown[]) => String(c[0]).includes("/move")
+      );
+      expect(movePosts.length).toBe(1);
+    });
+  });
+
+  it("shows an error when locations fail to load", async () => {
+    fetchMock.mockImplementationOnce(async () =>
+      jsonRes({ error: "boom" }, false, 500)
+    );
+    render(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/Couldn't load locations/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error when recompute fails on the server", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "/api/locations" && method === "GET") return jsonRes(locations);
+      if (url === "/api/settings/recompute-distances") {
+        return jsonRes({ error: "rate limit" }, false, 503);
+      }
+      return jsonRes({}, false, 500);
+    });
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await waitFor(() => screen.getByText("Train Station"));
+    await user.click(screen.getByRole("button", { name: /Recompute all/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't recompute distances/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows an error when recompute throws on the network", async () => {
+    fetchMock.mockImplementation(async (input: RequestInfo, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : (input as Request).url;
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "/api/locations" && method === "GET") return jsonRes(locations);
+      if (url === "/api/settings/recompute-distances") {
+        throw new TypeError("Failed to fetch");
+      }
+      return jsonRes({}, false, 500);
+    });
+    const user = userEvent.setup();
+    render(<SettingsPage />);
+    await waitFor(() => screen.getByText("Train Station"));
+    await user.click(screen.getByRole("button", { name: /Recompute all/i }));
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Couldn't recompute distances/i)
       ).toBeInTheDocument();
     });
   });


### PR DESCRIPTION
## Summary
Bring all four large page components to (or near) the issue's per-file targets (≥ 80 % lines, ≥ 70 % branches), with one annotated exception.

## Per-file coverage delta

| File | Lines before | Lines after | Branches before | Branches after |
|---|---|---|---|---|
| `settings/page.tsx` | 67.96 % | **82.52 %** | 61.42 % | **80.00 %** |
| `apartments/[id]/page.tsx` | 71.61 % | **83.91 %** | 69.23 % | **75.64 %** |
| `compare/page.tsx` | 77.55 % | **100 %** | 70 % | **90 %** |
| `apartments/page.tsx` | 82.43 % | 82.43 % | 74.50 % | 74.50 % |
| `apartments/new/page.tsx` | 86.71 % | **87.50 %** | 67.24 % | 67.24 % † |

† Annotated in `full-flow.test.tsx` — the remaining branches are defensive guards not reachable through UI (`handleSaveAll` empty-to-save branch, `processingRef` early exit). Per the issue: "Reach ≥ 80 % lines and ≥ 70 % branches, OR annotate any deliberate gap."

## Repo-wide delta
| Metric | Before | After |
|---|---|---|
| Statements | 87.39 % | **89.47 %** |
| Branches | 80.07 % | **81.81 %** |
| Functions | 88.26 % | **89.84 %** |
| Lines | 88.85 % | **91.08 %** |

## What's new
- **`settings-page.test.tsx`** (+5): edit flow, move up, move down, load error, recompute server-error, recompute network-error.
- **`apartments/[id]/__tests__/error-states.test.tsx`** (new, 4): loading placeholder, initial-load 5xx, delete 5xx, delete cancelled by `confirm()`.
- **`compare/__tests__/error-states.test.tsx`** (new, 6): loading state, list-fetch fail, per-detail fail, network throw, empty state, hide+`Show all` toggle.
- **`apartments/new/__tests__/full-flow.test.tsx`** (+1): network-throw on `/api/apartments` POST during batch save-all.

## Test plan
- [x] `npx vitest run` — **492/492** (was 475 + 17 new).
- [x] `npx vitest run --coverage` — exit 0; thresholds met.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)