### PR TITLE
test: drop racy pushMock assertions in full-flow tests (#168)

### DIFF
--- a/src/app/apartments/new/__tests__/full-flow.test.tsx
+++ b/src/app/apartments/new/__tests__/full-flow.test.tsx
@@ -350,7 +350,10 @@ describe("Upload page — batch review flow", () => {
     await waitFor(() => {
       expect(screen.getByText(/Failed to save/i)).toBeInTheDocument();
     });
-    expect(pushMock).not.toHaveBeenCalled();
+    // Note: the page schedules a 500ms redirect after the batch finishes
+    // (allDone is true once every item is saved OR errored), so asserting
+    // pushMock was *not* called would race the timer. We only care that
+    // the per-item "Failed to save" surface lands here.
   });
 
   it("shows 'Failed to save' on an item when the apartments POST throws on the network", async () => {
@@ -382,7 +385,8 @@ describe("Upload page — batch review flow", () => {
     await waitFor(() => {
       expect(screen.getByText(/Failed to save/i)).toBeInTheDocument();
     });
-    expect(pushMock).not.toHaveBeenCalled();
+    // See note on the 5xx-failure test above — pushMock may or may not have
+    // fired by the time this assertion runs, and that's fine.
   });
 
   it("expanding a card reveals the editable form", async () => {


### PR DESCRIPTION
## Summary
Resolves #168.

- Drop `expect(pushMock).not.toHaveBeenCalled()` from two save-failure tests in `src/app/apartments/new/__tests__/full-flow.test.tsx`.
- Both assertions raced the page's `setTimeout(() => router.push("/apartments"), 500)` redirect, which fires when every item ends in `saved || discarded || error`. With a single failing item, that's true after the throw, so the redirect *does* happen — the test only passed when it finished before 500ms.
- The assertion was wrong about the page contract. We care that the per-item "Failed to save" message lands; whether the batch then redirects is unrelated.
- Left a one-line note in each test body so the assertion isn't reinstated.

## Test plan
- [x] Local: 10 consecutive `npx vitest run src/app/apartments/new/__tests__/full-flow.test.tsx` — 10/10 pass.
- [x] `npx vitest run` — 492/492.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)