### PR TITLE
fix(security): defense-in-depth auth on /api/apartments (#170)

### DIFF
--- a/src/app/api/__tests__/apartments.test.ts
+++ b/src/app/api/__tests__/apartments.test.ts
@@ -101,6 +101,12 @@ afterEach(() => {
 });
 
 describe("GET /api/apartments", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockIsAuthenticated.mockResolvedValueOnce(false);
+    const res = await GET();
+    expect(res.status).toBe(401);
+  });
+
   it("returns list of apartments with myRating=null when no user cookie", async () => {
     const apartments = [
       { id: 1, name: "Apt 1", avgOverall: "4.5" },
@@ -180,6 +186,16 @@ describe("GET /api/apartments", () => {
 });
 
 describe("POST /api/apartments", () => {
+  it("returns 401 when not authenticated", async () => {
+    mockIsAuthenticated.mockResolvedValueOnce(false);
+    const req = new Request("http://localhost/api/apartments", {
+      method: "POST",
+      body: JSON.stringify({ name: "x" }),
+    });
+    const res = await POST(req);
+    expect(res.status).toBe(401);
+  });
+
   it("creates a new apartment", async () => {
     const newApt = {
       name: "New Place",

--- a/src/app/api/apartments/route.ts
+++ b/src/app/api/apartments/route.ts
@@ -6,7 +6,7 @@ import {
   ratings,
 } from "@/lib/db/schema";
 import { desc, avg, eq } from "drizzle-orm";
-import { getDisplayName } from "@/lib/auth";
+import { getDisplayName, isAuthenticated, unauthorized } from "@/lib/auth";
 import {
   buildShortCode,
   computeShortCodeParts,
@@ -28,6 +28,7 @@ function isUniqueConstraintError(err: unknown): boolean {
 
 export async function GET() {
   try {
+    if (!(await isAuthenticated())) return unauthorized();
     const allApartments = await db
       .select({
         id: apartments.id,
@@ -108,6 +109,7 @@ export async function GET() {
 
 export async function POST(request: Request) {
   try {
+    if (!(await isAuthenticated())) return unauthorized();
     const body = await request.json();
 
     const availableFrom: string | null =


### PR DESCRIPTION
## Summary
Resolves #170.

- Add `if (!(await isAuthenticated())) return unauthorized();` to **GET** and **POST** in `src/app/api/apartments/route.ts`, matching the pattern from `/api/apartments/[id]` (#128) and the 10 routes covered by #153.
- The POST path triggers paid Google APIs (geocode + per-location distance backfill) — this gate limits blast radius if the proxy matcher is ever misconfigured.
- Added 401 tests for GET and POST in `src/app/api/__tests__/apartments.test.ts`.

Skipped the second route the audit mentioned (`/api/apartments/[id]/ratings/route.ts`) — it already 401s via `getDisplayName() === null`, which is equivalent identity gating.

## Test plan
- [x] `npx vitest run src/app/api/__tests__/apartments.test.ts` — 17/17 (was 15 + 2 new 401 tests).
- [x] `npx vitest run` — full suite green.
- [x] `npm run build` — clean.
- [x] `npm run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)