### PR TITLE
docs: surface coverage.exclude entries in AGENTS.md (#171)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - Tests live in co-located `__tests__/` directories next to the source.
 - `npm test` runs once; `npm run test:watch` watches.
 - **Coverage thresholds are enforced in CI** via `vitest.config.ts`: lines ≥ 80, statements ≥ 80, functions ≥ 78, branches ≥ 75. New code without tests will fail the build.
+- Two paths are excluded from the coverage count: `src/components/ui/**` (shadcn primitives — vendored, re-emitted by the CLI) and `src/lib/db/schema.ts` (Drizzle table declarations, no executable logic). Don't write tests targeting those files.
 
 ## Auth
 - Shared-password + display-name model (no real accounts). See `src/lib/auth.ts` and `src/app/api/auth/`.


### PR DESCRIPTION
## Summary
Resolves #171.

- AGENTS.md "Tests" section now mentions the two `coverage.exclude` paths:
  - `src/components/ui/**` (shadcn primitives — vendored, re-emitted by the CLI, per #152)
  - `src/lib/db/schema.ts` (Drizzle table declarations, no executable logic, per #155)
- One-line addition. Helps agents avoid writing tests targeting files where coverage isn't measured.

(Skipped the libsql caret bump — `^0.17.2` already lets `npm update` resolve 0.17.3+ in practice.)

## Test plan
- [x] Docs-only change; no tests.
- [x] Numbers cross-checked against `vitest.config.ts:14-22`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)